### PR TITLE
add docker-compose for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,37 +8,59 @@ The Unity Engine Game Client for the Dawnseekers game.
 
 ### Dependecies
 
-You a local EVM node with ds-contracts and the backend api services.
+You need a local EVM node with ds-contracts and the api services.
 
-We use docker to provision these all together and there are two paths:
+We use [Docker](https://docs.docker.com/get-docker/) to provision these all together and there are two paths:
 
-* Easy mode (most recent build)
-* Hard mode (build locally from sources)
+* Easy mode (fetches latest build)
+* Hard mode (builds images locally)
 
-#### Provisioning backend services (Easy mode)
+### Provisioning backend services (Easy mode)
 
 To provision a local instance of the chain, and backend services based on the
 most recent builds using docker:
 
 ```
-docker-compose --profile=nightly up
+docker-compose up
 ```
 
-#### Provisioning backend services (Hard mode)
+### Provisioning backend services (Hard mode)
 
-To provision all the services built from your local sources, you must have the
-following repositories cloned as siblings next to each other:
+To provision with services built from your local sources, you will
+need to have the following repositories cloned as siblings next to
+each other:
 
 * [ds-unity](https://github.com/playmint/ds-unity)
 * [ds-contracts](https://github.com/playmint/ds-contracts)
 * [cog-services](https://github.com/playmint/cog-services)
 
-You can then use the `dev` profile to provision with docker:
+You can then tell compose to rebuild from source by including the
+relevent configurations and to override the defaults and addding the
+`--build` flag.
+
+For example to provision with changes from your local ds-contracts
+include the `ds-contracts/docker-compose.yml` as an override:
 
 ```
-docker-compose --profile=dev up --abort-on-container-exit --build
+docker compose \
+	-f ../ds-contracts/docker-compose.yml \
+	up --build
 ```
 
-Recommend using `--abort-on-container-exit` and `--build` to ensure things
-start (and fail) in an expected way.
+to also use a local build of cog-services add that override too:
+
+```
+docker compose \
+	-f ../cog-services/docker-compose.yml \
+	-f ../ds-contracts/docker-compose.yml \
+	up --build
+```
+
+Tips:
+
+Use `--abort-on-container-exit` to make it crash and burn on error
+rather than get stuck in a restart loop.
+
+Use `docker compose down -v` to destroy the built images if you want a
+clean slate for the next `up`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,29 +2,15 @@ version: '3'
 
 services:
 
-  ###############################################################################
-  #                                                                             #
-  # nightly profile                                                             #
-  #                                                                             #
-  # run via:                                                                    #
-  #                                                                             #
-  #     > docker-compose --profile=nightly up --pull=always                     #
-  #                                                                             #
-  # this provisions a local chain and api backend from the most recent build.   #
-  #                                                                             #
-  # useful for: artists, developing just the unity client, testing latest build #
-  #                                                                             #
-
-  ds-contracts-nightly:
-    profiles: ["nightly"]
+  contracts:
     image: ghcr.io/playmint/ds-contracts:latest
     pull_policy: always
     restart: always
     platform: linux/amd64
     ports:
       - 3045:8545
-  cog-services-nightly:
-    profiles: ["nightly"]
+
+  cog-services:
     image: ghcr.io/playmint/cog-services:latest
     pull_policy: always
     restart: always
@@ -34,82 +20,18 @@ services:
     - -c
     - |
       echo "waiting"
-      /wait-for -it ds-contracts-nightly:8545 -t 300
+      /wait-for -it contracts:8545 -t 300
       echo "starting"
       exec /ds-node
     environment:
       CHAIN_ID: "1337"
       SEQUENCER_PRIVATE_KEY: "095a37ef5b5d87db7fe50551725cb64804c8c554868d3d729c0dd17f0e664c87"
-      SEQUENCER_PROVIDER_URL_HTTP: "http://ds-contracts-nightly:8545"
-      SEQUENCER_PROVIDER_URL_WS: "ws://ds-contracts-nightly:8545"
+      SEQUENCER_PROVIDER_URL_HTTP: "http://contracts:8545"
+      SEQUENCER_PROVIDER_URL_WS: "ws://contracts:8545"
       INDEXER_WATCH_PENDING: "false"
-      INDEXER_PROVIDER_URL_HTTP: "http://ds-contracts-nightly:8545"
-      INDEXER_PROVIDER_URL_WS: "ws://ds-contracts-nightly:8545"
+      INDEXER_PROVIDER_URL_HTTP: "http://contracts:8545"
+      INDEXER_PROVIDER_URL_WS: "ws://contracts:8545"
     ports:
       - 3080:8080
     depends_on:
-      - ds-contracts-nightly
-  #                                                                              #
-  #                                                                              #
-  ################################################################################
-
-
-
-
-
-
-  ################################################################################
-  #                                                                              #
-  # dev profile                                                                  #
-  #                                                                              #
-  # run via:                                                                     #
-  #                                                                              #
-  #     > docker-compose --profile=dev up --abort-on-container-exit --build      #
-  #                                                                              #
-  # this provisions a local chain and api backend FROM SOURCE.                   #
-  #                                                                              #
-  # you must have the ds-uinity, ds-contracts, and cog-services repositories     #
-  # checked out as sibling directories next to each other and checked out at the #
-  # versions you want to provision.                                              #
-  #                                                                              #
-
-  ds-contracts-dev:
-    profiles: ["dev"]
-    restart: always
-    platform: linux/amd64
-    build:
-      context: ../ds-contracts
-    ports:
-      - 3045:8545
-
-  cog-services-dev:
-    profiles: ["dev"]
-    restart: always
-    build:
-      context: ../cog-services
-    entrypoint:
-    - /bin/ash
-    - -eu
-    - -c
-    - |
-      echo "waiting"
-      /wait-for -it ds-contracts-dev:8545 -t 300
-      echo "starting"
-      exec /ds-node
-    environment:
-      CHAIN_ID: "1337"
-      SEQUENCER_PRIVATE_KEY: "095a37ef5b5d87db7fe50551725cb64804c8c554868d3d729c0dd17f0e664c87"
-      SEQUENCER_PROVIDER_URL_HTTP: "http://ds-contracts-dev:8545"
-      SEQUENCER_PROVIDER_URL_WS: "ws://ds-contracts-dev:8545"
-      INDEXER_WATCH_PENDING: "false"
-      INDEXER_PROVIDER_URL_HTTP: "http://ds-contracts-dev:8545"
-      INDEXER_PROVIDER_URL_WS: "ws://ds-contracts-dev:8545"
-    ports:
-      - 3080:8080
-    depends_on:
-      - ds-contracts-dev
-  #                                                                              #
-  #                                                                              #
-  ################################################################################
-
-
+      - contracts


### PR DESCRIPTION
## What

Adds docker-compose.yml for provisiong the backend services and some notes in the README about it.

There are two options for spinning up the backend bits:

* Option 1: Provision from latest build (aka: Artist Mode).... does not require having all the repos checked out
* Option 2: Provision by building locally (aka: Dev Mode) ... works like before, builds the backend images locally, requires you have all the repositories checked out and at the commits you want to build
