### PR TITLE
Setting anchor to fullscreen so we don't need to rely on hack

### DIFF
--- a/frontend/src/components/views/unity-plugin/index.tsx
+++ b/frontend/src/components/views/unity-plugin/index.tsx
@@ -33,7 +33,8 @@ const UnityPlugin: FunctionComponent<UnityPluginProps> = (props: UnityPluginProp
 
     // -- Register plugin
     useEffect(() => {
-        registerPlugin(750, 500, Anchor.BottomRight);
+        // The size should be irrelavent but I picked a small 16:9 ratio just in case
+        registerPlugin(640, 360, Anchor.FullScreen);
     }, []);
 
     // -- Messages from shell

--- a/frontend/src/types/anchor.ts
+++ b/frontend/src/types/anchor.ts
@@ -9,5 +9,6 @@ export enum Anchor {
     CenterRight,
     BottomLeft,
     BottomCenter,
-    BottomRight
+    BottomRight,
+    FullScreen
 }


### PR DESCRIPTION
Hack in frontend looks at deployed address which means when testing locally the map plugin wasn't fullscreen