### PR TITLE
Add inventory plugin

### DIFF
--- a/core/src/client.ts
+++ b/core/src/client.ts
@@ -24,6 +24,13 @@ const ACTIONS = new ethers.Interface([
     'function SPAWN_SEEKER(bytes24 seeker)',
     'function DEV_SPAWN_SEEKER(address player, uint32 seekerID, int16 q, int16 r, int16 s)',
     'function DEV_SPAWN_TILE(uint8 kind, int16 q, int16 r, int16 s)',
+    `function TRANSFER_ITEM_SEEKER(
+            bytes24 seeker,
+            bytes24[2] calldata equipees,
+            uint8[2] calldata equipSlots,
+            uint8[2] calldata itemSlots,
+            uint64 qty
+        )`,
 ]);
 
 const gameID = 'DAWNSEEKERS';

--- a/core/src/state.ts
+++ b/core/src/state.ts
@@ -63,7 +63,7 @@ export interface ItemSlot extends Edge {
 }
 
 export interface EquipSlot extends Edge {
-    bag: Node;
+    bag: Bag;
 }
 
 export interface Bag extends Node {

--- a/frontend/src/components/organisms/tile-action/index.tsx
+++ b/frontend/src/components/organisms/tile-action/index.tsx
@@ -36,7 +36,6 @@ const PluginContent = ({
     toggleContent: ToggleContentFunc;
 }) => {
     const saferHTML = { __html: content.html ? DOMPurify.sanitize(content.html) : '' };
-    console.log(content);
 
     const submit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();

--- a/frontend/src/helpers/iterate.tsx
+++ b/frontend/src/helpers/iterate.tsx
@@ -1,0 +1,11 @@
+/** @format */
+
+import { Fragment, ReactNode } from 'react';
+
+export const Iterate = ({ component, number }: { component: ReactNode; number: number }) => {
+    const items = [];
+    for (let i = 0; i < number; i += 1) {
+        items.push(component);
+    }
+    return <Fragment>{items}</Fragment>;
+};

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic';
 
 // TODO server rendered content
 const DynamicShell = dynamic(() => import('@app/components/views/shell'), {
-    loading: () => <p>Loading...</p>,
+    loading: () => <p />,
     ssr: false
 });
 

--- a/frontend/src/plugins/inventory/bag-item/bag-item.styles.ts
+++ b/frontend/src/plugins/inventory/bag-item/bag-item.styles.ts
@@ -1,0 +1,46 @@
+/** @format */
+
+import { css } from 'styled-components';
+import { BagItemProps } from './index';
+
+type BagItemStyleProps = Partial<BagItemProps> & {
+    isPickable: boolean;
+};
+
+/**
+ * Base styles for the bag item component
+ *
+ * @param _ The bag item properties object
+ * @return Base styles for the bag item component
+ */
+const baseStyles = ({ isPickable }: BagItemStyleProps) => css`
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 4.8rem;
+    aspect-ratio: 1 / 1;
+    background: #030f25;
+    cursor: ${isPickable ? 'pointer' : 'auto'};
+
+    .icon {
+    }
+
+    .amount {
+        position: absolute;
+        bottom: 0;
+        right: 2px;
+        font-size: 1.2rem;
+        color: white;
+    }
+`;
+
+/**
+ * The bag item component styles
+ *
+ * @param props The bag item properties object
+ * @return Styles for the bag item component
+ */
+export const styles = (props: BagItemStyleProps) => css`
+    ${baseStyles(props)}
+`;

--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -1,0 +1,45 @@
+/** @format */
+
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { ComponentProps } from '@app/types/component-props';
+import { styles } from './bag-item.styles';
+import { useInventory } from '@app/plugins/inventory/inventory-provider';
+
+export interface BagItemProps extends ComponentProps {
+    name: string;
+    icon: string;
+    quantity: number;
+    ownerId: string;
+    equipIndex: number;
+    slotIndex: number;
+}
+
+const StyledBagItem = styled('div')`
+    ${styles}
+`;
+
+export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) => {
+    const { name, icon, quantity, ownerId, equipIndex, slotIndex, ...otherProps } = props;
+    const { pickUpItem, isPickedUpItemVisible } = useInventory();
+
+    const handleClick = (event: MouseEvent) => {
+        event.stopPropagation();
+        const transferInfo = {
+            id: ownerId,
+            equipIndex,
+            slotIndex
+        };
+        const item = { name, icon, quantity, transferInfo };
+        pickUpItem(item);
+    };
+
+    const isPickable = !isPickedUpItemVisible;
+
+    return (
+        <StyledBagItem {...otherProps} onClick={handleClick} isPickable={isPickable}>
+            <img src={icon} alt={name} className="icon" />
+            <span className="amount">{quantity}</span>
+        </StyledBagItem>
+    );
+};

--- a/frontend/src/plugins/inventory/bag-slot/bag-slot.styles.ts
+++ b/frontend/src/plugins/inventory/bag-slot/bag-slot.styles.ts
@@ -1,0 +1,32 @@
+/** @format */
+
+import { css } from 'styled-components';
+import { BagSlotProps } from './index';
+
+type BagSlotStyleProps = Partial<BagSlotProps> & {
+    isDroppable: boolean;
+};
+
+/**
+ * Base styles for the bag slot component
+ *
+ * @param _ The bag slot properties object
+ * @return Base styles for the bag slot component
+ */
+const baseStyles = ({ isDroppable, isDisabled }: BagSlotStyleProps) => css`
+    box-sizing: content-box;
+    width: 4.8rem;
+    height: 4.8rem;
+    background: ${isDisabled ? '#19212e' : '#030f25'};
+    border: 1px solid ${isDisabled ? '#656585' : isDroppable ? 'white' : '#6c98d4'};
+`;
+
+/**
+ * The bag slot component styles
+ *
+ * @param props The bag slot properties object
+ * @return Styles for the bag slot component
+ */
+export const styles = (props: BagSlotStyleProps) => css`
+    ${baseStyles(props)}
+`;

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -1,0 +1,46 @@
+/** @format */
+
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { ComponentProps } from '@app/types/component-props';
+import { styles } from './bag-slot.styles';
+import { BagItem } from '@app/plugins/inventory/bag-item';
+import { useInventory } from '@app/plugins/inventory/inventory-provider';
+import { ItemSlot } from '@core';
+import { getItemDetails } from '@app/plugins/inventory/helpers';
+
+export interface BagSlotProps extends ComponentProps {
+    itemSlot?: ItemSlot;
+    isDisabled?: boolean;
+    ownerId: string;
+    equipIndex: number;
+    slotIndex: number;
+}
+
+const StyledBagSlot = styled('div')`
+    ${styles}
+`;
+
+export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) => {
+    const { itemSlot, isDisabled, ownerId, equipIndex, slotIndex, ...otherProps } = props;
+    const { dropItem, isPickedUpItemVisible } = useInventory();
+
+    const item = itemSlot?.balance ? getItemDetails(itemSlot) : null;
+
+    const handleClick = () => {
+        if (!isPickedUpItemVisible) {
+            return;
+        }
+        dropItem({ id: ownerId, equipIndex, slotIndex });
+    };
+
+    // todo only slot without content
+    // todo we can add logic here to check if the slot is on the same tile etc
+    const isDroppable = isPickedUpItemVisible;
+
+    return (
+        <StyledBagSlot {...otherProps} onClick={handleClick} isDroppable={isDroppable} isDisabled={isDisabled}>
+            {item && itemSlot && <BagItem {...item} ownerId={ownerId} equipIndex={equipIndex} slotIndex={slotIndex} />}
+        </StyledBagSlot>
+    );
+};

--- a/frontend/src/plugins/inventory/bag/bag.styles.ts
+++ b/frontend/src/plugins/inventory/bag/bag.styles.ts
@@ -1,0 +1,42 @@
+/** @format */
+
+import { css } from 'styled-components';
+import { BagProps } from './index';
+
+/**
+ * Base styles for the bag component
+ *
+ * @param _ The bag properties object
+ * @return Base styles for the bag component
+ */
+const baseStyles = (_: Partial<BagProps>) => css`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+
+    > .icon {
+        width: 3.2rem;
+        height: 3.2rem;
+    }
+
+    > .slots {
+        display: flex;
+        flex-direction: row;
+        margin-left: 1.6rem;
+
+        li:not(:first-child) {
+            margin-left: 0.6rem;
+        }
+    }
+`;
+
+/**
+ * The bag component styles
+ *
+ * @param props The bag properties object
+ * @return Styles for the bag component
+ */
+export const styles = (props: Partial<BagProps>) => css`
+    ${baseStyles(props)}
+`;

--- a/frontend/src/plugins/inventory/bag/index.tsx
+++ b/frontend/src/plugins/inventory/bag/index.tsx
@@ -1,0 +1,58 @@
+/** @format */
+
+import React, { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { ComponentProps } from '@app/types/component-props';
+import { styles } from './bag.styles';
+import { BagSlot } from '@app/plugins/inventory/bag-slot';
+import { Iterate } from '@app/helpers/iterate';
+import { Bag as BagNode, ItemSlot } from '@core';
+
+export interface BagProps extends ComponentProps {
+    bag: BagNode;
+    ownerId: string;
+    equipIndex: number;
+}
+
+const StyledBag = styled('div')`
+    ${styles}
+`;
+
+export const Bag: FunctionComponent<BagProps> = (props: BagProps) => {
+    const { bag, ownerId, equipIndex, ...otherProps } = props;
+    const numBagSlots = 4;
+    const emptySlots = numBagSlots - bag.slots.length - 1;
+
+    return (
+        <StyledBag {...otherProps}>
+            <img src="/icons/bag.png" alt="" className="icon" />
+            <ul className="slots">
+                {bag.slots.map((slot: ItemSlot) => (
+                    <BagSlot
+                        key={slot.key}
+                        as="li"
+                        itemSlot={slot}
+                        ownerId={ownerId}
+                        equipIndex={equipIndex}
+                        slotIndex={slot.key}
+                    />
+                ))}
+                {bag.slots.length < numBagSlots && (
+                    <BagSlot as="li" ownerId={ownerId} equipIndex={equipIndex} slotIndex={bag.slots.length} />
+                )}
+                <Iterate
+                    component={
+                        <BagSlot
+                            as="li"
+                            isDisabled={true}
+                            ownerId={ownerId}
+                            equipIndex={equipIndex}
+                            slotIndex={bag.slots.length}
+                        />
+                    }
+                    number={emptySlots}
+                />
+            </ul>
+        </StyledBag>
+    );
+};

--- a/frontend/src/plugins/inventory/helpers.ts
+++ b/frontend/src/plugins/inventory/helpers.ts
@@ -1,0 +1,50 @@
+/** @format */
+
+import { toUtf8String } from 'ethers';
+import { ItemSlot } from '@core';
+
+export const resourceRegex = /^0x37f9b55d[0-9a-f]+$/g;
+
+export const resources = {
+    '0x37f9b55d0000000000000000000000000000000000000001': 'Wood',
+    '0x37f9b55d0000000000000000000000000000000000000002': 'Stone',
+    '0x37f9b55d0000000000000000000000000000000000000003': 'Iron'
+};
+
+export const icons = {
+    wood: '/icons/wood.png',
+    stone: '/icons/stone.png',
+    iron: '/icons/iron.png',
+    hammer: '/icons/hammer.png'
+};
+
+export const getItemName = (itemID: string): string => {
+    const last15Bytes = itemID.slice(-30, -16);
+    const asciiString = toUtf8String('0x' + last15Bytes);
+
+    return asciiString;
+};
+
+export function isResource(id: string) {
+    return id.match(resourceRegex);
+}
+
+export function getSlotName(slot: ItemSlot) {
+    return isResource(slot.item.id) ? resources[slot.item.id] : getItemName(slot.item.id);
+}
+
+export function getItemIcon(name: string) {
+    return icons[name.toLowerCase()];
+}
+
+export function getItemDetails(itemSlot: ItemSlot) {
+    const name = getSlotName(itemSlot);
+    const icon = getItemIcon(name);
+    const quantity = itemSlot.balance;
+
+    return {
+        name,
+        icon,
+        quantity
+    };
+}

--- a/frontend/src/plugins/inventory/index.tsx
+++ b/frontend/src/plugins/inventory/index.tsx
@@ -1,0 +1,34 @@
+/** @format */
+
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { ComponentProps } from '@app/types/component-props';
+import { Bag } from '@app/plugins/inventory/bag';
+import { EquipSlot } from '@core';
+
+export interface InventoryProps extends ComponentProps {
+    ownerId: string;
+    bags: EquipSlot[];
+}
+
+const StyledInventory = styled('div')`
+    > .bags {
+        > li:not(:last-child) {
+            margin-bottom: 1.6rem;
+        }
+    }
+`;
+
+export const Inventory: FunctionComponent<InventoryProps> = (props: InventoryProps) => {
+    const { bags, ownerId, ...otherProps } = props;
+
+    return (
+        <StyledInventory {...otherProps}>
+            <ul className="bags">
+                {bags.map((equipSlot: EquipSlot) => (
+                    <Bag key={equipSlot.key} bag={equipSlot.bag} equipIndex={equipSlot.key} ownerId={ownerId} as="li" />
+                ))}
+            </ul>
+        </StyledInventory>
+    );
+};

--- a/frontend/src/plugins/inventory/inventory-provider.tsx
+++ b/frontend/src/plugins/inventory/inventory-provider.tsx
@@ -1,0 +1,149 @@
+/** @format */
+
+// import { createContext, ReactNode, useContext } from 'react';
+// import { DawnseekersClient } from '@app/contexts/dawnseekers-provider';
+//
+//
+// export interface InventoryContextStore {}
+//
+// export const InventoryContext = createContext<InventoryContextStore>({} as InventoryContextStore);
+//
+// export const useInventoryContext = () => useContext(InventoryContext);
+//
+// export const InventoryProvider = ({ ds, children }: InventoryContextProviderProps) => {
+//     // we want to store the currently picked up item
+//     // we need to name, amount, and icon
+//     // we set these values in our bag item that tracks the mouse
+//     // we have a flag in state to track if we have something picked up
+//     // we need an escape handler to drop the item and reset things
+//     // we need to handle dropping the item on a different slot
+//
+//     const store: InventoryContextStore = {};
+//     return <InventoryContext.Provider value={store}>{children}</InventoryContext.Provider>;
+// };
+
+import { createContext, useContext, useState, useRef, useEffect, ReactNode } from 'react';
+import { Client as DawnseekersClient, useDawnseekersState } from '@core';
+import { styles } from '@app/plugins/inventory/bag-item/bag-item.styles';
+import styled from 'styled-components';
+
+export interface InventoryContextProviderProps {
+    ds: DawnseekersClient;
+    children?: ReactNode;
+}
+
+interface TransferInfo {
+    id: string;
+    equipIndex: number;
+    slotIndex: number;
+}
+
+interface InventoryItem {
+    name: string;
+    icon: string;
+    quantity: number;
+    transferInfo: TransferInfo;
+}
+
+interface InventoryContextStore {
+    isPickedUpItemVisible: boolean;
+    pickUpItem: (item: InventoryItem) => void;
+    dropItem: (target: TransferInfo) => void;
+}
+
+const useInventoryContext = createContext<InventoryContextStore>({} as InventoryContextStore);
+
+export const useInventory = (): InventoryContextStore => {
+    const inventoryContext = useContext(useInventoryContext);
+    if (!inventoryContext) {
+        throw new Error('useInventory must be used within an InventoryProvider');
+    }
+    return inventoryContext;
+};
+
+const StyledPickedUpItem = styled('div')`
+    ${styles};
+    pointer-events: none;
+
+    > .icon,
+    > .amount {
+        pointer-events: none;
+    }
+`;
+
+export const InventoryProvider = ({ ds, children }: InventoryContextProviderProps): JSX.Element => {
+    const { data } = useDawnseekersState(ds);
+    const [isPickedUpItemVisible, setIsPickedUpItemVisible] = useState<boolean>(false);
+    const pickedUpItemRef = useRef<InventoryItem | null>(null);
+    const pickedUpItemElementRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleMouseMove = (e: MouseEvent) => {
+            if (pickedUpItemElementRef.current) {
+                pickedUpItemElementRef.current.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
+            }
+        };
+        window.addEventListener('mousemove', handleMouseMove);
+        return () => {
+            window.removeEventListener('mousemove', handleMouseMove);
+        };
+    }, []);
+
+    const pickUpItem = (item: InventoryItem): void => {
+        pickedUpItemRef.current = item;
+        setIsPickedUpItemVisible(true);
+    };
+
+    const dropItem = (target: TransferInfo): void => {
+        if (!pickedUpItemRef.current) {
+            console.error('Cannot drop an item, you are not holding an item');
+            return;
+        }
+        transferItem(pickedUpItemRef.current?.transferInfo, target, pickedUpItemRef.current?.quantity);
+        pickedUpItemRef.current = null;
+        setIsPickedUpItemVisible(false);
+    };
+
+    const transferItem = (from: TransferInfo, to: TransferInfo, quantity: number) => {
+        const selectedSeeker = data?.ui.selection.seeker;
+
+        if (!selectedSeeker) {
+            console.error('Cannot transfer item, no selected seeker');
+            return;
+        }
+
+        ds.dispatch(
+            'TRANSFER_ITEM_SEEKER',
+            selectedSeeker.id,
+            [from.id, to.id],
+            [from.equipIndex, to.equipIndex],
+            [from.slotIndex, to.slotIndex],
+            quantity
+        ).then((result) => console.log('Transfer:', result));
+    };
+
+    const inventoryContextValue: InventoryContextStore = { isPickedUpItemVisible, pickUpItem, dropItem };
+
+    return (
+        <useInventoryContext.Provider value={inventoryContextValue}>
+            {children}
+            {isPickedUpItemVisible && pickedUpItemRef.current && (
+                <div
+                    ref={pickedUpItemElementRef}
+                    style={{
+                        position: 'absolute',
+                        top: '0',
+                        left: '0',
+                        transform: 'translate(-50%, -50%)',
+                        pointerEvents: 'none'
+                    }}
+                >
+                    <StyledPickedUpItem isPickable={false}>
+                        <img src={pickedUpItemRef.current.icon} alt={pickedUpItemRef.current.name} className="icon" />
+                        <span className="amount">{pickedUpItemRef.current.quantity}</span>
+                    </StyledPickedUpItem>
+                </div>
+            )}
+        </useInventoryContext.Provider>
+    );
+};

--- a/frontend/src/plugins/inventory/seeker-inventory.tsx
+++ b/frontend/src/plugins/inventory/seeker-inventory.tsx
@@ -1,0 +1,27 @@
+/** @format */
+
+import React, { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { ComponentProps } from '@app/types/component-props';
+import { Seeker } from '@core';
+import { Inventory } from '@app/plugins/inventory/index';
+
+export interface SeekerInventoryProps extends ComponentProps {
+    seeker: Seeker;
+}
+
+const StyledSeekerInventory = styled('div')``;
+
+export const SeekerInventory: FunctionComponent<SeekerInventoryProps> = (props: SeekerInventoryProps) => {
+    const { seeker, ...otherProps } = props;
+
+    return (
+        <StyledSeekerInventory {...otherProps}>
+            {seeker.bags.length > 0 ? (
+                <Inventory bags={seeker.bags} ownerId={seeker.id} />
+            ) : (
+                <span>The selected seeker has no bags</span>
+            )}
+        </StyledSeekerInventory>
+    );
+};

--- a/frontend/src/plugins/inventory/tile-inventory.tsx
+++ b/frontend/src/plugins/inventory/tile-inventory.tsx
@@ -1,0 +1,33 @@
+/** @format */
+
+import React, { FunctionComponent } from 'react';
+import { ComponentProps } from '@app/types/component-props';
+import { Tile } from '@core';
+import { Inventory } from '@app/plugins/inventory/index';
+import styled from 'styled-components';
+
+export interface TileInventoryProps extends ComponentProps {
+    title: string;
+    tile: Tile;
+}
+
+const StyledTileInventory = styled('div')`
+    > h3 {
+        margin-bottom: 1.6rem;
+    }
+`;
+
+export const TileInventory: FunctionComponent<TileInventoryProps> = (props: TileInventoryProps) => {
+    const { title, tile, ...otherProps } = props;
+
+    return (
+        <StyledTileInventory {...otherProps}>
+            {title && <h3>{title}</h3>}
+            {tile.bags.length > 0 ? (
+                <Inventory bags={tile.bags} ownerId={tile.id} />
+            ) : (
+                <span>there are no bags on this tile</span>
+            )}
+        </StyledTileInventory>
+    );
+};

--- a/frontend/src/styles/global.styles.ts
+++ b/frontend/src/styles/global.styles.ts
@@ -36,8 +36,12 @@ export const GlobalStyles = createGlobalStyle`
         monospace;
     }
     
-    h3 {
+    h1, h2, h3, h4 {
         text-transform: uppercase;
+    }
+    
+    
+    h3 {
         margin-bottom: 2rem;
     }
     
@@ -108,7 +112,6 @@ export const GlobalStyles = createGlobalStyle`
         left: 0;
         bottom: 0;
         width: 30rem;
-        min-height: 25rem;
         background: #143063;
         color: #fff;
     }


### PR DESCRIPTION
Inventory plugin for seekers and tiles

Click to pick up a stack and then click to drop in one of the empty slots

![image](https://user-images.githubusercontent.com/4235606/225380103-a54490a3-3b23-445f-bee8-810c39c93097.png)

Note: There seems to be an issue with the seeker bags where it is duplicated.