### PR TITLE
Only allow the player to interact with bags on their current tile

### DIFF
--- a/frontend/src/plugins/inventory/bag-item/bag-item.styles.ts
+++ b/frontend/src/plugins/inventory/bag-item/bag-item.styles.ts
@@ -13,15 +13,15 @@ type BagItemStyleProps = Partial<BagItemProps> & {
  * @param _ The bag item properties object
  * @return Base styles for the bag item component
  */
-const baseStyles = ({ isPickable }: BagItemStyleProps) => css`
+const baseStyles = ({ isPickable, isInteractable }: BagItemStyleProps) => css`
     position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
     width: 4.8rem;
     aspect-ratio: 1 / 1;
-    background: #030f25;
-    cursor: ${isPickable ? 'pointer' : 'auto'};
+    background: ${!isInteractable ? '#19212e' : '#030f25'};
+    cursor: ${isPickable && !isInteractable ? 'pointer' : 'auto'};
 
     .icon {
     }

--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -13,6 +13,7 @@ export interface BagItemProps extends ComponentProps {
     ownerId: string;
     equipIndex: number;
     slotIndex: number;
+    isInteractable: boolean;
 }
 
 const StyledBagItem = styled('div')`
@@ -20,10 +21,13 @@ const StyledBagItem = styled('div')`
 `;
 
 export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) => {
-    const { name, icon, quantity, ownerId, equipIndex, slotIndex, ...otherProps } = props;
+    const { name, icon, quantity, ownerId, equipIndex, slotIndex, isInteractable, ...otherProps } = props;
     const { pickUpItem, isPickedUpItemVisible } = useInventory();
 
     const handleClick = (event: MouseEvent) => {
+        if (!isInteractable) {
+            return;
+        }
         event.stopPropagation();
         const transferInfo = {
             id: ownerId,
@@ -37,7 +41,7 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
     const isPickable = !isPickedUpItemVisible;
 
     return (
-        <StyledBagItem {...otherProps} onClick={handleClick} isPickable={isPickable}>
+        <StyledBagItem {...otherProps} onClick={handleClick} isPickable={isPickable} isInteractable={isInteractable}>
             <img src={icon} alt={name} className="icon" />
             <span className="amount">{quantity}</span>
         </StyledBagItem>

--- a/frontend/src/plugins/inventory/bag-slot/bag-slot.styles.ts
+++ b/frontend/src/plugins/inventory/bag-slot/bag-slot.styles.ts
@@ -13,12 +13,12 @@ type BagSlotStyleProps = Partial<BagSlotProps> & {
  * @param _ The bag slot properties object
  * @return Base styles for the bag slot component
  */
-const baseStyles = ({ isDroppable, isDisabled }: BagSlotStyleProps) => css`
+const baseStyles = ({ isDroppable, isDisabled, isInteractable }: BagSlotStyleProps) => css`
     box-sizing: content-box;
     width: 4.8rem;
     height: 4.8rem;
-    background: ${isDisabled ? '#19212e' : '#030f25'};
-    border: 1px solid ${isDisabled ? '#656585' : isDroppable ? 'white' : '#6c98d4'};
+    background: ${isDisabled || !isInteractable ? '#19212e' : '#030f25'};
+    border: 1px solid ${isDisabled || !isInteractable ? '#656585' : isDroppable ? 'white' : '#6c98d4'};
 `;
 
 /**

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -15,6 +15,7 @@ export interface BagSlotProps extends ComponentProps {
     ownerId: string;
     equipIndex: number;
     slotIndex: number;
+    isInteractable: boolean;
 }
 
 const StyledBagSlot = styled('div')`
@@ -22,25 +23,37 @@ const StyledBagSlot = styled('div')`
 `;
 
 export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) => {
-    const { itemSlot, isDisabled, ownerId, equipIndex, slotIndex, ...otherProps } = props;
+    const { itemSlot, isDisabled, ownerId, equipIndex, slotIndex, isInteractable, ...otherProps } = props;
     const { dropItem, isPickedUpItemVisible } = useInventory();
 
     const item = itemSlot?.balance ? getItemDetails(itemSlot) : null;
 
     const handleClick = () => {
-        if (!isPickedUpItemVisible) {
+        if (!isPickedUpItemVisible || !isInteractable) {
             return;
         }
         dropItem({ id: ownerId, equipIndex, slotIndex });
     };
 
-    // todo only slot without content
-    // todo we can add logic here to check if the slot is on the same tile etc
-    const isDroppable = isPickedUpItemVisible;
+    const isDroppable = isPickedUpItemVisible && !item;
 
     return (
-        <StyledBagSlot {...otherProps} onClick={handleClick} isDroppable={isDroppable} isDisabled={isDisabled}>
-            {item && itemSlot && <BagItem {...item} ownerId={ownerId} equipIndex={equipIndex} slotIndex={slotIndex} />}
+        <StyledBagSlot
+            {...otherProps}
+            onClick={handleClick}
+            isDroppable={isDroppable}
+            isDisabled={isDisabled}
+            isInteractable={isInteractable}
+        >
+            {item && itemSlot && (
+                <BagItem
+                    {...item}
+                    ownerId={ownerId}
+                    equipIndex={equipIndex}
+                    slotIndex={slotIndex}
+                    isInteractable={isInteractable}
+                />
+            )}
         </StyledBagSlot>
     );
 };

--- a/frontend/src/plugins/inventory/bag/index.tsx
+++ b/frontend/src/plugins/inventory/bag/index.tsx
@@ -12,6 +12,7 @@ export interface BagProps extends ComponentProps {
     bag: BagNode;
     ownerId: string;
     equipIndex: number;
+    isInteractable: boolean;
 }
 
 const StyledBag = styled('div')`
@@ -19,7 +20,7 @@ const StyledBag = styled('div')`
 `;
 
 export const Bag: FunctionComponent<BagProps> = (props: BagProps) => {
-    const { bag, ownerId, equipIndex, ...otherProps } = props;
+    const { bag, ownerId, equipIndex, isInteractable, ...otherProps } = props;
     const numBagSlots = 4;
     const emptySlots = numBagSlots - bag.slots.length - 1;
 
@@ -35,10 +36,17 @@ export const Bag: FunctionComponent<BagProps> = (props: BagProps) => {
                         ownerId={ownerId}
                         equipIndex={equipIndex}
                         slotIndex={slot.key}
+                        isInteractable={isInteractable}
                     />
                 ))}
                 {bag.slots.length < numBagSlots && (
-                    <BagSlot as="li" ownerId={ownerId} equipIndex={equipIndex} slotIndex={bag.slots.length} />
+                    <BagSlot
+                        as="li"
+                        ownerId={ownerId}
+                        equipIndex={equipIndex}
+                        slotIndex={bag.slots.length}
+                        isInteractable={isInteractable}
+                    />
                 )}
                 <Iterate
                     component={
@@ -48,6 +56,7 @@ export const Bag: FunctionComponent<BagProps> = (props: BagProps) => {
                             ownerId={ownerId}
                             equipIndex={equipIndex}
                             slotIndex={bag.slots.length}
+                            isInteractable={isInteractable}
                         />
                     }
                     number={emptySlots}

--- a/frontend/src/plugins/inventory/index.tsx
+++ b/frontend/src/plugins/inventory/index.tsx
@@ -9,6 +9,7 @@ import { EquipSlot } from '@core';
 export interface InventoryProps extends ComponentProps {
     ownerId: string;
     bags: EquipSlot[];
+    isInteractable: boolean;
 }
 
 const StyledInventory = styled('div')`
@@ -20,13 +21,20 @@ const StyledInventory = styled('div')`
 `;
 
 export const Inventory: FunctionComponent<InventoryProps> = (props: InventoryProps) => {
-    const { bags, ownerId, ...otherProps } = props;
+    const { bags, ownerId, isInteractable, ...otherProps } = props;
 
     return (
         <StyledInventory {...otherProps}>
             <ul className="bags">
                 {bags.map((equipSlot: EquipSlot) => (
-                    <Bag key={equipSlot.key} bag={equipSlot.bag} equipIndex={equipSlot.key} ownerId={ownerId} as="li" />
+                    <Bag
+                        key={equipSlot.key}
+                        bag={equipSlot.bag}
+                        equipIndex={equipSlot.key}
+                        ownerId={ownerId}
+                        isInteractable={isInteractable}
+                        as="li"
+                    />
                 ))}
             </ul>
         </StyledInventory>

--- a/frontend/src/plugins/inventory/inventory-provider.tsx
+++ b/frontend/src/plugins/inventory/inventory-provider.tsx
@@ -23,7 +23,7 @@
 // };
 
 import { createContext, useContext, useState, useRef, useEffect, ReactNode } from 'react';
-import { Client as DawnseekersClient, useDawnseekersState } from '@core';
+import { Client as DawnseekersClient, Tile, useDawnseekersState } from '@core';
 import { styles } from '@app/plugins/inventory/bag-item/bag-item.styles';
 import styled from 'styled-components';
 
@@ -49,6 +49,7 @@ interface InventoryContextStore {
     isPickedUpItemVisible: boolean;
     pickUpItem: (item: InventoryItem) => void;
     dropItem: (target: TransferInfo) => void;
+    isSeekerAtLocation: (tile: Tile) => boolean;
 }
 
 const useInventoryContext = createContext<InventoryContextStore>({} as InventoryContextStore);
@@ -89,6 +90,15 @@ export const InventoryProvider = ({ ds, children }: InventoryContextProviderProp
         };
     }, []);
 
+    /**
+     * check if the selected seeker is on the selected tile
+     * @returns true if the seeker is on the selected tile
+     */
+    const isSeekerAtLocation = (tile: Tile) => {
+        const selectedSeeker = data?.ui.selection.seeker;
+        return tile.seekers.some((s) => s.id === selectedSeeker?.id);
+    };
+
     const pickUpItem = (item: InventoryItem): void => {
         pickedUpItemRef.current = item;
         setIsPickedUpItemVisible(true);
@@ -99,6 +109,7 @@ export const InventoryProvider = ({ ds, children }: InventoryContextProviderProp
             console.error('Cannot drop an item, you are not holding an item');
             return;
         }
+
         transferItem(pickedUpItemRef.current?.transferInfo, target, pickedUpItemRef.current?.quantity);
         pickedUpItemRef.current = null;
         setIsPickedUpItemVisible(false);
@@ -122,7 +133,12 @@ export const InventoryProvider = ({ ds, children }: InventoryContextProviderProp
         ).then((result) => console.log('Transfer:', result));
     };
 
-    const inventoryContextValue: InventoryContextStore = { isPickedUpItemVisible, pickUpItem, dropItem };
+    const inventoryContextValue: InventoryContextStore = {
+        isPickedUpItemVisible,
+        pickUpItem,
+        dropItem,
+        isSeekerAtLocation
+    };
 
     return (
         <useInventoryContext.Provider value={inventoryContextValue}>

--- a/frontend/src/plugins/inventory/seeker-inventory.tsx
+++ b/frontend/src/plugins/inventory/seeker-inventory.tsx
@@ -18,7 +18,7 @@ export const SeekerInventory: FunctionComponent<SeekerInventoryProps> = (props: 
     return (
         <StyledSeekerInventory {...otherProps}>
             {seeker.bags.length > 0 ? (
-                <Inventory bags={seeker.bags} ownerId={seeker.id} />
+                <Inventory bags={seeker.bags} ownerId={seeker.id} isInteractable={true} />
             ) : (
                 <span>The selected seeker has no bags</span>
             )}

--- a/frontend/src/plugins/inventory/tile-inventory.tsx
+++ b/frontend/src/plugins/inventory/tile-inventory.tsx
@@ -5,6 +5,7 @@ import { ComponentProps } from '@app/types/component-props';
 import { Tile } from '@core';
 import { Inventory } from '@app/plugins/inventory/index';
 import styled from 'styled-components';
+import { useInventory } from '@app/plugins/inventory/inventory-provider';
 
 export interface TileInventoryProps extends ComponentProps {
     title: string;
@@ -19,12 +20,13 @@ const StyledTileInventory = styled('div')`
 
 export const TileInventory: FunctionComponent<TileInventoryProps> = (props: TileInventoryProps) => {
     const { title, tile, ...otherProps } = props;
+    const { isSeekerAtLocation } = useInventory();
 
     return (
         <StyledTileInventory {...otherProps}>
             {title && <h3>{title}</h3>}
             {tile.bags.length > 0 ? (
-                <Inventory bags={tile.bags} ownerId={tile.id} />
+                <Inventory bags={tile.bags} ownerId={tile.id} isInteractable={isSeekerAtLocation(tile)} />
             ) : (
                 <span>there are no bags on this tile</span>
             )}


### PR DESCRIPTION
Only allow the player to interact with bags on their current tile

Show disabled state for bags on other tile and don't allow user to pick up items
![image](https://user-images.githubusercontent.com/4235606/225901895-7eae573e-6e16-4e51-aab5-06b54f69b5e0.png)

Do not highlight empty bag slots for bags on other tiles when dropping items
![image](https://user-images.githubusercontent.com/4235606/225902400-d6fa4255-c0f8-4acd-b3bb-f197ab30b441.png)

Show interactable state for bags on the current seeker tile
![image](https://user-images.githubusercontent.com/4235606/225902014-f9e3354b-f185-431b-ba6c-c4b75d5a1448.png)
