### PR TITLE
Move intent

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
@@ -33,12 +33,8 @@ public class TileHelper
         };
     }
 
-    internal static string GetTileID(Vector3Int key)
+    internal static string GetTileID(Vector3Int tilePosCube)
     {
-        // TODO: Calculate the ID using TileNode.GetKey(0, q,r,s);
-        var tile = PluginController.Instance.WorldState.Game.Tiles.FirstOrDefault(
-            tile => GetTilePosCube(tile) == key
-        );
-        return tile.Id;
+        return Cog.NodeKinds.TileNode.GetKey(0, tilePosCube.x, tilePosCube.y, tilePosCube.z);
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
@@ -32,4 +32,13 @@ public class TileHelper
             tile + new Vector3Int(1, 0, -1)
         };
     }
+
+    internal static string GetTileID(Vector3Int key)
+    {
+        // TODO: Calculate the ID using TileNode.GetKey(0, q,r,s);
+        var tile = PluginController.Instance.WorldState.Game.Tiles.FirstOrDefault(
+            tile => GetTilePosCube(tile) == key
+        );
+        return tile.Id;
+    }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent.cs
@@ -1,0 +1,7 @@
+public class Intent
+{
+    public const string NONE = "";
+    public const string MOVE = "move";
+    public const string SCOUT = "scout";
+    public const string CONSTRUCT = "construct";
+}

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent.cs.meta
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86f96412b61c642e1b7d745ff280a6e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
@@ -97,7 +97,10 @@ public class MapInteractionManager : MonoBehaviour
         }
 
         // Select the tile (Possible don't send this out if the player is moving)
-        Cog.PluginController.Instance.SendSelectTileMsg(new List<string>() { tile.Id });
+        if (PluginController.Instance.WorldState.UI.Selection.Intent == Intent.NONE)
+        {
+            Cog.PluginController.Instance.SendSelectTileMsg(new List<string>() { tile.Id });
+        }
     }
 
     void MapClicked2()

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
@@ -96,7 +96,7 @@ public class MapInteractionManager : MonoBehaviour
             EventTileLeftClick(cellPosCube);
         }
 
-        // Select the tile (Possible don't send this out if the player is moving)
+        // Select the tile
         if (PluginController.Instance.WorldState.UI.Selection.Intent == Intent.NONE)
         {
             Cog.PluginController.Instance.SendSelectTileMsg(new List<string>() { tile.Id });
@@ -154,7 +154,6 @@ public class MapInteractionManager : MonoBehaviour
             CurrentSelectedCell = GridExtensions.CubeToGrid(cellPosCube);
             clickedPlayerCell = SeekerManager.Instance.IsPlayerAtPosition(cellPosCube);
 
-            //if (!IsTileSelected || CurrentSelectedCell != gridCoords)
             selectedMarker1.position = MapManager.instance.grid.CellToWorld(CurrentSelectedCell);
 
             selectedMarker1.gameObject.SetActive(true);

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
@@ -67,7 +67,10 @@ public class MapInteractionManager : MonoBehaviour
         }
 
         // Tile mouseover cursor
-        if (SeekerManager.Instance.Seeker != null)
+        if (
+            SeekerManager.Instance.Seeker != null
+            && PluginController.Instance.WorldState.Game != null
+        )
             cursor.gameObject.SetActive(
                 IsDiscoveredTile(GridExtensions.GridToCube(CurrentMouseCell))
                     || TileHelper

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapManager.cs
@@ -62,7 +62,7 @@ public class MapManager : MonoBehaviour
         return _tilemap.GetTile(GridExtensions.CubeToGrid(position)) != null;
     }
 
-    void RenderState(Cog.State state)
+    private void OnStateUpdated(Cog.State state)
     {
         // Debug.Log("MapManager::RenderState()");
         IconManager.instance.ResetSeekerPositionCounts();
@@ -155,10 +155,5 @@ public class MapManager : MonoBehaviour
             );
         }
         IconManager.instance.CheckSeekerRemoved(state.Game.Seekers.ToList());
-    }
-
-    private void OnStateUpdated(Cog.State state)
-    {
-        RenderState(Cog.PluginController.Instance.WorldState);
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapManager.cs
@@ -27,8 +27,6 @@ public class MapManager : MonoBehaviour
     [SerializeField]
     private Tile[] _tileTypes;
 
-    private bool _hasStateUpdated;
-
     private void Awake()
     {
         instance = this;
@@ -40,17 +38,6 @@ public class MapManager : MonoBehaviour
         if (Cog.PluginController.Instance.WorldState != null)
         {
             OnStateUpdated(Cog.PluginController.Instance.WorldState);
-        }
-    }
-
-    private void Update()
-    {
-        // As state events occur on a separate thread, the tilemap cannot be updated as a side effect
-        // of the event therefore the event will set a flag and then visual state update happens as part of the main thread
-        if (_hasStateUpdated)
-        {
-            RenderState(Cog.PluginController.Instance.WorldState);
-            _hasStateUpdated = false;
         }
     }
 
@@ -77,7 +64,7 @@ public class MapManager : MonoBehaviour
 
     void RenderState(Cog.State state)
     {
-        Debug.Log("MapManager::RenderState()");
+        // Debug.Log("MapManager::RenderState()");
         IconManager.instance.ResetSeekerPositionCounts();
         MapManager.instance.ClearMap();
         foreach (var tile in state.Game.Tiles)
@@ -172,6 +159,6 @@ public class MapManager : MonoBehaviour
 
     private void OnStateUpdated(Cog.State state)
     {
-        _hasStateUpdated = true;
+        RenderState(Cog.PluginController.Instance.WorldState);
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/SeekerManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/SeekerManager.cs
@@ -38,7 +38,7 @@ public class SeekerManager : MonoBehaviour
             (state.UI.Selection.Player != null && state.UI.Selection.Player.Seekers.Count > 0)
                 ? state.UI.Selection.Player.Seekers.ToList()[0]
                 : null;
-        if (playerSeeker != Seeker)
+        if (playerSeeker != null && (Seeker == null || Seeker.Id != playerSeeker.Id))
         {
             var seekersToRemove = new List<Cog.Seeker>();
             if (Seeker != null)
@@ -49,12 +49,8 @@ public class SeekerManager : MonoBehaviour
 
             Seeker = playerSeeker;
 
-            if (playerSeeker != null)
-            {
-                // Remove 'other seeker' icon so it gets replaced with the player icon
-                seekersToRemove.Add(playerSeeker);
-                Debug.Log("SeekerManager: Seeker found. ID: " + Seeker.Id);
-            }
+            // Remove 'other seeker' icon so it gets replaced with the player icon
+            seekersToRemove.Add(playerSeeker);
 
             IconManager.instance.RemoveSeekers(seekersToRemove);
         }

--- a/DawnSeekersUnity/Assets/Map/Scripts/SeekerManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/SeekerManager.cs
@@ -34,25 +34,35 @@ public class SeekerManager : MonoBehaviour
     // TODO: Still assuming only one seeker
     private void OnStateUpdated(State state)
     {
+        var seekersToRemove = new List<Cog.Seeker>();
+
         var playerSeeker =
             (state.UI.Selection.Player != null && state.UI.Selection.Player.Seekers.Count > 0)
                 ? state.UI.Selection.Player.Seekers.ToList()[0]
                 : null;
-        if (playerSeeker != null && (Seeker == null || Seeker.Id != playerSeeker.Id))
+        if (playerSeeker != null)
         {
-            var seekersToRemove = new List<Cog.Seeker>();
-            if (Seeker != null)
+            if (Seeker != null && Seeker.Id != playerSeeker.Id)
             {
-                // If we've switched accounts then remove player icon
+                // If we've switched accounts then remove the previous player seeker as well as
+                // the icon for the current seeker which would have been a grey 'other' seeker
                 seekersToRemove.Add(Seeker);
+                seekersToRemove.Add(playerSeeker);
+            }
+            else if (Seeker == null)
+            {
+                // If we weren't logged in prior then remove the grey 'other' seeker which will become our red seeker
+                seekersToRemove.Add(playerSeeker);
             }
 
             Seeker = playerSeeker;
-
-            // Remove 'other seeker' icon so it gets replaced with the player icon
-            seekersToRemove.Add(playerSeeker);
-
-            IconManager.instance.RemoveSeekers(seekersToRemove);
         }
+        else if (Seeker != null)
+        {
+            // Signed out so remove the player seeker icon
+            seekersToRemove.Add(Seeker);
+        }
+
+        IconManager.instance.RemoveSeekers(seekersToRemove);
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/SeekerMovementManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/SeekerMovementManager.cs
@@ -54,6 +54,12 @@ public class SeekerMovementManager : MonoBehaviour
 
     private void Update()
     {
+        if (
+            PluginController.Instance.WorldState == null
+            || PluginController.Instance.WorldState.Game == null
+        )
+            return;
+
         if (isMoving && _path.Count > 0)
         {
             Vector3Int cubeMousePos = GridExtensions.GridToCube(

--- a/DawnSeekersUnity/Assets/Map/Scripts/SeekerMovementManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/SeekerMovementManager.cs
@@ -322,6 +322,7 @@ public class SeekerMovementManager : MonoBehaviour
             if (_travelMarkers.ContainsKey(cellPosCube))
             {
                 _travelMarkers[cellPosCube].HideLine();
+                _travelMarkers.Remove(cellPosCube);
             }
         }
     }

--- a/DawnSeekersUnity/Assets/Map/Scripts/SeekerMovementManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/SeekerMovementManager.cs
@@ -297,6 +297,31 @@ public class SeekerMovementManager : MonoBehaviour
         }
     }
 
+    /*
+     * Used as a way to hack round our inability to wait for a state update when adding the final tile
+     */
+    private void DirectAddCellToPathHack(Vector3Int cellCubePos)
+    {
+        bool validPosition =
+            _path.Count == 0
+            || TileHelper.GetTileNeighbours(_path[_path.Count - 1]).Contains(cellCubePos);
+        if (!_path.Any(p => p == cellCubePos) && validPosition)
+        {
+            // Add marker
+            if (!_travelMarkers.ContainsKey(cellCubePos))
+            {
+                var prevTilePosCube = _path[_path.Count - 1];
+
+                var travelMarker = Instantiate(travelMarkerPrefab)
+                    .GetComponent<TravelMarkerController>();
+                travelMarker.ShowTravelMarkers(prevTilePosCube, cellCubePos);
+                _travelMarkers.Add(cellCubePos, travelMarker);
+            }
+
+            _path.Add(cellCubePos);
+        }
+    }
+
     private void RemoveCellFromPath(Vector3Int cellCubePos)
     {
         var tileIDs = _path
@@ -322,7 +347,7 @@ public class SeekerMovementManager : MonoBehaviour
     private void ClosePath(Vector3Int cellCubePos)
     {
         // AddCellToPath(cellCubePos); // TODO: This only works when we are able to wait for this to update the state
-
+        DirectAddCellToPathHack(cellCubePos); // HACK: Because of above :-/
         StartCoroutine(TracePathCR());
 
         // Select the last tile in the path and take out of move intent

--- a/DawnSeekersUnity/Assets/Map/Scripts/SeekerMovementManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/SeekerMovementManager.cs
@@ -144,6 +144,9 @@ public class SeekerMovementManager : MonoBehaviour
 
     private List<Vector3Int> UpdatePath(List<Vector3Int> oldPath, List<Tile> newPathTiles)
     {
+        if (oldPath.Count == newPathTiles.Count)
+            return oldPath;
+
         var newPath = new List<Vector3Int>();
 
         // Remove highlights for tiles that are no longer in the list
@@ -161,8 +164,8 @@ public class SeekerMovementManager : MonoBehaviour
                 // Hide line.
                 if (_travelMarkers.ContainsKey(cellPosCube))
                 {
-                    _travelMarkers[cellPosCube].HideLine();
-                    // TODO: Destroy?
+                    _travelMarkers[cellPosCube].HideLine(); // Destroys the GameObject
+                    _travelMarkers.Remove(cellPosCube);
                 }
             }
         }
@@ -286,13 +289,13 @@ public class SeekerMovementManager : MonoBehaviour
 
     private void RemoveCellFromPath(Vector3Int cellCubePos)
     {
-        var pathCount = _path.Count;
-
-        _path.Remove(_path.FirstOrDefault(p => p == cellCubePos));
-        var tileIDs = _path.Select(cellPosCube => TileHelper.GetTileID(cellPosCube)).ToList();
+        var tileIDs = _path
+            .Where(p => p != cellCubePos)
+            .Select(cellPosCube => TileHelper.GetTileID(cellPosCube))
+            .ToList();
 
         // If we click elsewhere on the map and don't alter the path then don't make a state update
-        if (pathCount != _path.Count)
+        if (tileIDs.Count != _path.Count)
         {
             // Removing the last tile takes stops the move intention
             var intention = tileIDs.Count > 0 ? INTENTION_MOVE : 0;

--- a/DawnSeekersUnity/Assets/Map/Scripts/TravelMarkerController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/TravelMarkerController.cs
@@ -58,7 +58,7 @@ public class TravelMarkerController : MonoBehaviour
 
     public void HideLine()
     {
-        //line.HideLine();
+        line.HideLine();
         Destroy(gameObject);
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/UI/ActionMenuButtonController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/UI/ActionMenuButtonController.cs
@@ -1,11 +1,13 @@
 using System.Collections;
 using System.Collections.Generic;
+using Cog;
 using UnityEngine;
 
 public class ActionMenuButtonController : MonoBehaviour
 {
     public void ButtonClicked()
     {
-        SeekerMovementManager.instance.ActivateMovementMode();
+        // SeekerMovementManager.instance.ActivateMovementMode();
+        PluginController.Instance.SendSetIntentionMsg(1, new List<string>());
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/UI/ActionMenuButtonController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/UI/ActionMenuButtonController.cs
@@ -7,7 +7,6 @@ public class ActionMenuButtonController : MonoBehaviour
 {
     public void ButtonClicked()
     {
-        // SeekerMovementManager.instance.ActivateMovementMode();
-        PluginController.Instance.SendSetIntentionMsg(1, new List<string>());
+        PluginController.Instance.SendSetIntentMsg(Intent.MOVE);
     }
 }

--- a/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/PluginController.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/PluginController.cs
@@ -185,7 +185,7 @@ namespace Cog
             {
                 var line = _nodeJSProcess.StandardOutput.ReadLine();
                 
-                if (line[0] == '{')
+                if (line.Length > 0 && line[0] == '{')
                 {
                     try 
                     {
@@ -272,6 +272,7 @@ namespace Cog
                 tileIDs = tileIDs
             };
             var json = JsonConvert.SerializeObject(msg);
+            Debug.Log(json);
             SendMessage(json);
         }
 

--- a/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/PluginController.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/PluginController.cs
@@ -269,13 +269,6 @@ namespace Cog
             SendMessage(json);
         }
 
-        public void SendCancelIntentionMsg()
-        {
-            var msg = new GenericMessage { msg = "cancelIntent" };
-            var json = JsonConvert.SerializeObject(msg);
-            SendMessage(json);
-        }
-
         public void SendDeselectAllTilesMsg()
         {
             SendSelectTileMsg(new List<string>());

--- a/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/PluginController.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/PluginController.cs
@@ -272,7 +272,6 @@ namespace Cog
                 tileIDs = tileIDs
             };
             var json = JsonConvert.SerializeObject(msg);
-            Debug.Log(json);
             SendMessage(json);
         }
 

--- a/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/PluginController.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/PluginController.cs
@@ -18,11 +18,10 @@ namespace Cog
         public List<string> tileIDs;
     }
 
-    struct SetIntentionMessage
+    struct SetIntentMessage
     {
         public string msg;
-        public int intention; // The code gen doesn't deal with enums well so not typed
-        public List<string> tileIDs;
+        public string intent;
     }
 
     struct DispatchMessage
@@ -263,21 +262,16 @@ namespace Cog
             SendMessage(json);
         }
 
-        public void SendSetIntentionMsg(int intention, List<string> tileIDs)
+        public void SendSetIntentMsg(string intent)
         {
-            var msg = new SetIntentionMessage
-            {
-                msg = "setIntention",
-                intention = intention,
-                tileIDs = tileIDs
-            };
+            var msg = new SetIntentMessage { msg = "setIntent", intent = intent };
             var json = JsonConvert.SerializeObject(msg);
             SendMessage(json);
         }
 
         public void SendCancelIntentionMsg()
         {
-            var msg = new GenericMessage { msg = "cancelIntention" };
+            var msg = new GenericMessage { msg = "cancelIntent" };
             var json = JsonConvert.SerializeObject(msg);
             SendMessage(json);
         }

--- a/DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs
@@ -137,28 +137,6 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Intention
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"0")]
-        _0 = 0,
-
-
-        [System.Runtime.Serialization.EnumMember(Value = @"1")]
-        _1 = 1,
-
-
-        [System.Runtime.Serialization.EnumMember(Value = @"2")]
-        _2 = 2,
-
-
-        [System.Runtime.Serialization.EnumMember(Value = @"3")]
-        _3 = 3,
-
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class ItemSlot
     {
         [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -423,11 +401,8 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class SelectionState
     {
-        [Newtonsoft.Json.JsonProperty("intentTiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.ICollection<Tile> IntentTiles { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("intention", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public double Intention { get; set; }
+        [Newtonsoft.Json.JsonProperty("intent", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Intent { get; set; }
 
         [Newtonsoft.Json.JsonProperty("player", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Player Player { get; set; }

--- a/DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs
@@ -10,6 +10,28 @@ namespace Cog
     #pragma warning disable // Disable all warnings
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Bag
+    {
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<ItemSlot> Slots { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public enum BiomeKind
     {
 
@@ -71,7 +93,7 @@ namespace Cog
     public partial class EquipSlot
     {
         [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public Node Bag { get; set; }
+        public Bag Bag { get; set; }
 
         [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Key { get; set; }
@@ -100,6 +122,53 @@ namespace Cog
 
         [Newtonsoft.Json.JsonProperty("tiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Tile> Tiles { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public enum Intention
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"0")]
+        _0 = 0,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"1")]
+        _1 = 1,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"2")]
+        _2 = 2,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"3")]
+        _3 = 3,
+
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class ItemSlot
+    {
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Node Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
 
 
 
@@ -204,23 +273,8 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PluginState
     {
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Id { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("seekerActionButton", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string SeekerActionButton { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("seekerActionDetails", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string SeekerActionDetails { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("showTileActionDetails", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool ShowTileActionDetails { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("tileActionButton", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string TileActionButton { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("tileActionDetails", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string TileActionDetails { get; set; }
+        [Newtonsoft.Json.JsonProperty("components", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<PluginStateComponent> Components { get; set; }
 
 
 
@@ -232,6 +286,103 @@ namespace Cog
             get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
             set { _additionalProperties = value; }
         }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class PluginStateButton
+    {
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class PluginStateComponent
+    {
+        [Newtonsoft.Json.JsonProperty("content", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<PluginStateComponentContent> Content { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("summary", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Summary { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("title", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Title { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Type { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class PluginStateComponentContent
+    {
+        [Newtonsoft.Json.JsonProperty("buttons", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<PluginStateButton> Buttons { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("html", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Html { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("submit", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public object Submit { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public PluginStateComponentContentType Type { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public enum PluginStateComponentContentType
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"dialog")]
+        Dialog = 0,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"inline")]
+        Inline = 1,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"popout")]
+        Popout = 2,
+
 
     }
 
@@ -272,6 +423,12 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class SelectionState
     {
+        [Newtonsoft.Json.JsonProperty("intentTiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Tile> IntentTiles { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("intention", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Intention { get; set; }
+
         [Newtonsoft.Json.JsonProperty("player", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Player Player { get; set; }
 
@@ -311,6 +468,9 @@ namespace Cog
 
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("seekers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Seeker> Seekers { get; set; }
 
 
 

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -76,12 +76,6 @@ class DawnSeekersBridge implements Observer<State> {
                             });
                             break;
                         }
-                        case "cancelIntent": {
-                            ds.cancelIntent().catch((e) => {
-                                console.error(e);
-                            });
-                            break;
-                        }
                     }
                 };
 

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -3,10 +3,11 @@ import {
     State,
     PluginTrust,
     PluginType,
-} from '../../core/dist/src/index';
-import { ethers } from 'ethers';
+    Intention,
+} from "../../core/dist/src/index";
+import { ethers } from "ethers";
 import { Observer } from "zen-observable-ts";
-import 'cross-fetch/polyfill';
+import "cross-fetch/polyfill";
 
 interface Message {
     msg: string;
@@ -21,6 +22,11 @@ interface SelectTileMessage extends Message {
     tileIDs: string[];
 }
 
+interface SetIntentionMessage extends Message {
+    intention: Intention;
+    tileIDs: string[];
+}
+
 class DawnSeekersBridge implements Observer<State> {
     private _ds: DawnseekersClient;
 
@@ -31,7 +37,7 @@ class DawnSeekersBridge implements Observer<State> {
             signer: async () => {
                 const key = new ethers.SigningKey(privKey);
                 return new ethers.BaseWallet(key);
-            }
+            },
         });
 
         this._ds.subscribe(this);
@@ -49,6 +55,17 @@ class DawnSeekersBridge implements Observer<State> {
                 if (msgObj.msg === "selectTiles") {
                     const { tileIDs } = msgObj as SelectTileMessage;
                     this._ds.selectTiles(tileIDs);
+                }
+
+                if (msgObj.msg === "setIntention") {
+                    const setIntentionMessage = msgObj as SetIntentionMessage;
+                    this._ds.setIntention(
+                        setIntentionMessage.intention,
+                        setIntentionMessage.tileIDs
+                    );
+                }
+                if (msgObj.msg === "cancelIntention") {
+                    this._ds.cancelIntention();
                 }
             } catch (e) {
                 console.log(e);

--- a/core/src/client.ts
+++ b/core/src/client.ts
@@ -331,12 +331,6 @@ export class Client {
         return this.publish();
     }
 
-    async cancelIntent() {
-        this.selection.tileIDs = [];
-        this.selection.intent = Intent.NONE;
-        return this.publish();
-    }
-
     async setIntent(intent: string) {
         this.selection.intent = intent;
         return this.publish();

--- a/frontend/src/components/organisms/unity-map/index.tsx
+++ b/frontend/src/components/organisms/unity-map/index.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { ComponentProps } from '@app/types/component-props';
 import { styles } from './unity-map.styles';
-import { Client as DawnseekersClient, State } from '@core';
+import { Client as DawnseekersClient, Intention, State } from '@core';
 import { Unity, useUnityContext } from 'react-unity-webgl';
 
 export interface UnityMapProps extends ComponentProps {
@@ -22,6 +22,10 @@ interface DispatchMessage extends Message {
 }
 
 interface SelectTileMessage extends Message {
+    tileIDs: string[];
+}
+interface SetIntentionMessage extends Message {
+    intention: Intention;
     tileIDs: string[];
 }
 
@@ -105,6 +109,19 @@ export const UnityMap: FunctionComponent<UnityMapProps> = (props: UnityMapProps)
                 case 'selectTiles': {
                     const selectTileMsg = msg as SelectTileMessage;
                     ds.selectTiles(selectTileMsg.tileIDs).catch((e) => {
+                        console.error(e);
+                    });
+                    break;
+                }
+                case 'setIntention': {
+                    const setIntentionMessage = msg as SetIntentionMessage;
+                    ds.setIntention(setIntentionMessage.intention, setIntentionMessage.tileIDs).catch((e) => {
+                        console.error(e);
+                    });
+                    break;
+                }
+                case 'cancelIntention': {
+                    ds.cancelIntention().catch((e) => {
                         console.error(e);
                     });
                     break;

--- a/frontend/src/components/organisms/unity-map/index.tsx
+++ b/frontend/src/components/organisms/unity-map/index.tsx
@@ -127,12 +127,6 @@ export const UnityMap: FunctionComponent<UnityMapProps> = (props: UnityMapProps)
                     });
                     break;
                 }
-                case 'cancelIntent': {
-                    ds.cancelIntent().catch((e) => {
-                        console.error(e);
-                    });
-                    break;
-                }
             }
         };
 


### PR DESCRIPTION
# What

Clicking the move button on a seeker will set the intent on the game state to `move` by calling `setIntent` on the `core-client`. The map reads this intent on the next state update which puts the map into a `isMoving` context. When in the `isMoving` context, tiles selected for the movement path are appended to the `selectedTiles` array in the game state. Unlike before, Unity does not highlight tiles as a direct side effect of clicking on the tile but instead highlights tiles according to the state that is handled in in the `OnStateUpdated` listener.

- The core-client state object now has a string field for intent which is interpreted by the UI
- At any time `cancelIntention()` can be called set the intention back to `NONE` and the intentTileIDs to an empty array

# Why

The map component held all the state related to movement paths which meant that any external plugins couldn't see that state. Also future plugins should be able to specify a path and the map display it

# Other bits

- The switch which handles the messags within the bridge and in the Unity organism have been made the same. At some point I would like to make that into a class that can be shared between the two modules so I don't have to keep two things up to date. At least they work the same now and can be copied and pasted at least
- I updated `StateSchema.cs` by rebasing `state-schema-codegen` onto this branch, running the codegen, stashing, switching back to this branch and committing. I think the `state-schema-codegen` tool could be merged into main without any danger 
- Map manager no longer checks a `stateUpdated` flag in the update but instead reacts directly to the `EventStateUpdated` event that comes from the `PluginManager`
  - It was there because the event from the PluginManager used to come from another thread but now the mechanism of sending the event in the main thread is handled by the `PluginManager` so no need to accommodate for that in any of the classes that subscribe to this event 

# Known issues
- Right clicking on the final tile to close the path employs a hack to add the final tile directly to the `_path` array within the `SeekeMovementManager` instead of adding it to `selectedTiles` and waiting for the state to be updated. Closing the path clears the player's selection anyway so right now not a problem.
- The execution of movement is still happening via the co-routine instead of submitted as a MOVE_MULTI action. 
- The `intent` field perhaps should be hoised up a level in the state object as it doesn't belong in the selected object
