### PR TITLE
make compose: like make dev, but uses docker-compose

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -1,9 +1,6 @@
 const concurrently = require('concurrently');
-const chokidar = require('chokidar');
 const path = require('path');
 const { execSync } = require("child_process");
-const { JsonRpcProvider } = require('ethers/providers');
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 // ------------------------------------------------------------------
 // this is a startup script for running a local build of dawnseekers

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ map:
 dev: all
 	$(NODE) .devstartup.js
 
+compose: frontend/public/ds-unity/Build/ds-unity.wasm
+	docker compose up --build
+
 contracts/out/Actions.sol/Actions.json:
 	(cd contracts && forge build)
 
@@ -65,5 +68,5 @@ clean:
 	$(MAKE) -C contracts/lib/cog/services clean
 
 
-.PHONY: all clean dev map
+.PHONY: all clean dev map compose
 .SILENT: contracts/lib/cog/services/bin/ds-node frontend/public/ds-unity/Build/ds-unity.wasm

--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ If you only need a local copy of the game built (without development helpers
 like hot reloading etc), then the easist way is to provision using
 Docker Compose.
 
-To build and start the client and supporting services run:
+You need to build the unity map project first:
+
+```
+make map
+```
+
+Then to build and start the client and supporting services run:
 
 ```
 docker compose up --build

--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /contracts
 
 COPY lib ./lib
 COPY src ./src
+COPY script ./script
 COPY test ./test
 COPY remappings.txt ./
 COPY foundry.toml ./

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -3,10 +3,8 @@
 set -eu
 set -o pipefail
 
-# this is a entrypoint for a dockerized hardhat evm node
-# it starts the hardhat node, runs our deployment scripts
-# builds the required deployment confgiuration
-# it is used for local development
+# this file is used by the docker-compose setup
+# as a way of getting a chain with the contracts deployed
 
 _term() {
   echo "Terminated by user!"
@@ -22,16 +20,14 @@ rm -f deployments/*
 # must match the value for the target hardhat networks
 ACCOUNT_MNEMONIC="thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens"
 
-# set blocktime - sometimes it is useful to simulate slower mining
-: ${MINER_BLOCKTIME:=0}
-
 echo "+-------------------+"
 echo "| starting evm node |"
 echo "+-------------------+"
 anvil \
 	--host 0.0.0.0 \
 	-m "${ACCOUNT_MNEMONIC}" \
-	-b 5 \
+    --code-size-limit 9999999999999 \
+    --gas-limit 9999999999999999 \
 	&
 
 # wait for node to start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,17 @@ services:
   contracts:
     build:
       context: ./contracts
-    # restart: always
     ports:
       - 8545:8545
+    environment:
+      DEPLOYER_PRIVATE_KEY: "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8"
 
   frontend:
     build:
-      context: ./frontend
-    # restart: always
+      context: .
+      dockerfile: ./frontend/Dockerfile
     ports:
-      - 3000:3000
+      - 3000:80
 
   cog:
     build:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,45 +5,24 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+RUN apk add --update python3 make g++\
+   && rm -rf /var/cache/apk/*
+COPY package*.json ./
+COPY frontend/package*.json ./frontend/
+COPY core/package*.json ./core/
 RUN npm ci
 
-# Rebuild the source code only when needed
+# build static site
 FROM node:16-alpine AS builder
+ENV NEXT_TELEMETRY_DISABLED 1
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+COPY package*.json ./
+COPY frontend ./frontend
+COPY core ./core
+RUN npm run export -w frontend
 
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-ENV NEXT_TELEMETRY_DISABLED 1
+# output image
+FROM caddy:2.6.4
+COPY --from=builder /app/frontend/out /usr/share/caddy
 
-# If using npm comment out above and use below instead
-RUN npm run build
-
-# Production image, copy all the files and run next
-FROM node:16-alpine AS runner
-WORKDIR /app
-
-ENV NODE_ENV production
-# Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED 1
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
-COPY --from=builder /app/public ./public
-
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-USER nextjs
-
-EXPOSE 3000
-
-ENV PORT 3000
-
-CMD ["node", "server.js"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "plugin-demo",
+  "name": "frontend",
   "type": "module",
   "version": "0.1.0",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,7 +876,6 @@
       "dev": true
     },
     "frontend": {
-      "name": "plugin-demo",
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.7.3",
@@ -9150,6 +9149,10 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/frontend": {
+      "resolved": "frontend",
+      "link": true
+    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -12472,10 +12475,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/plugin-demo": {
-      "resolved": "frontend",
-      "link": true
     },
     "node_modules/polished": {
       "version": "4.2.2",
@@ -21506,6 +21505,49 @@
         }
       }
     },
+    "frontend": {
+      "version": "file:frontend",
+      "requires": {
+        "@apollo/client": "^3.7.3",
+        "@chakra-ui/react": "^2.4.9",
+        "@dawnseekers/core": "file:core",
+        "@dnd-kit/core": "^6.0.7",
+        "@dnd-kit/utilities": "^3.2.1",
+        "@types/dompurify": "^2.4.0",
+        "@types/node": "16.11.7",
+        "@types/react": "18.0.9",
+        "@types/styled-components": "5.1.25",
+        "@types/uuid": "^9.0.1",
+        "@typescript-eslint/eslint-plugin": "5.27.0",
+        "@web3-react/core": "^6.1.9",
+        "@web3-react/injected-connector": "^6.0.7",
+        "@web3-react/network-connector": "^6.2.9",
+        "bootstrap-icons": "^1.10.3",
+        "change-case": "4.1.2",
+        "dompurify": "^3.0.1",
+        "eslint": "8.16.0",
+        "eslint-config-next": "12.1.6",
+        "eslint-config-prettier": "8.5.0",
+        "eslint-plugin-prettier": "4.0.0",
+        "ethers": "^6.0.8",
+        "framer-motion": "^9.0.1",
+        "hygen": "6.2.3",
+        "next": "13.2.4",
+        "polished": "4.2.2",
+        "prettier": "2.6.2",
+        "quickjs-emscripten": "^0.22.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-unity-webgl": "^9.4.0",
+        "styled-components": "5.3.5",
+        "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "@dawnseekers/core": {
+          "version": "file:frontend/core"
+        }
+      }
+    },
     "fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -23934,49 +23976,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "dev": true
-    },
-    "plugin-demo": {
-      "version": "file:frontend",
-      "requires": {
-        "@apollo/client": "^3.7.3",
-        "@chakra-ui/react": "^2.4.9",
-        "@dawnseekers/core": "file:core",
-        "@dnd-kit/core": "^6.0.7",
-        "@dnd-kit/utilities": "^3.2.1",
-        "@types/dompurify": "^2.4.0",
-        "@types/node": "16.11.7",
-        "@types/react": "18.0.9",
-        "@types/styled-components": "5.1.25",
-        "@types/uuid": "^9.0.1",
-        "@typescript-eslint/eslint-plugin": "5.27.0",
-        "@web3-react/core": "^6.1.9",
-        "@web3-react/injected-connector": "^6.0.7",
-        "@web3-react/network-connector": "^6.2.9",
-        "bootstrap-icons": "^1.10.3",
-        "change-case": "4.1.2",
-        "dompurify": "^3.0.1",
-        "eslint": "8.16.0",
-        "eslint-config-next": "12.1.6",
-        "eslint-config-prettier": "8.5.0",
-        "eslint-plugin-prettier": "4.0.0",
-        "ethers": "^6.0.8",
-        "framer-motion": "^9.0.1",
-        "hygen": "6.2.3",
-        "next": "13.2.4",
-        "polished": "4.2.2",
-        "prettier": "2.6.2",
-        "quickjs-emscripten": "^0.22.0",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "react-unity-webgl": "^9.4.0",
-        "styled-components": "5.3.5",
-        "uuid": "^9.0.0"
-      },
-      "dependencies": {
-        "@dawnseekers/core": {
-          "version": "file:frontend/core"
-        }
-      }
     },
     "polished": {
       "version": "4.2.2",


### PR DESCRIPTION
## what

* fixes "docker compose up" to build and run the services in docker (except the map - that still needs a manual build right now because arm64)
* adds a `make compose` that is like `make dev` but runs the services with docker
* fixes up the frontend docker build so that it builds again + switch to serving with caddy as serving with node is slow and serving with nginx is broken on arm64

## Why

So that people who just want to run the game locally don't need so much of the build toolchain 