### PR TITLE
core: fix duplicate tiles bug

### DIFF
--- a/core/src/world.ts
+++ b/core/src/world.ts
@@ -52,14 +52,15 @@ function addUnscoutedTiles(tiles: WorldTileFragment[]): WorldTileFragment[] {
 }
 
 function getUnscoutedTile(tiles: WorldTileFragment[], q: number, r: number, s: number): WorldTileFragment | null {
-    const t = tiles.find(({ coords }) => coords[1] === q && coords[2] === r && coords[3] === s);
+    const coords = [0, q, r, s].map((n) => ethers.toBeHex(ethers.toTwos(n, 16)));
+    const id = CompoundKeyEncoder.encodeInt16(NodeSelectors.Tile, 0, q, r, s);
+    const t = tiles.find((t) => t.id === id);
     if (t) {
         return null;
     }
-    const keys = [0, q, r, s].map((n) => ethers.toBeHex(ethers.toTwos(n, 16)));
     return {
-        id: CompoundKeyEncoder.encodeInt16(NodeSelectors.Tile, 0, q, r, s),
-        coords: keys,
+        id,
+        coords,
         bagCount: 0,
         biome: BiomeKind.UNDISCOVERED,
         seekers: [],


### PR DESCRIPTION
the bit that adds the "unscouted" tiles into the world data was incorrectly comparing numbers vs 0-prefix-strings, which resulted in generated "unscouted" tiles for all existing tiles too, and polluting the data.

this was something that got missed in porting and unfortunely wasn't something the typechecker was able to spot for some reason