### PR TITLE
Fix to query so the next location is used and fix to icon states

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/IconManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/IconManager.cs
@@ -134,7 +134,7 @@ public class IconManager : MonoBehaviour
             seekerPositionCounts[cell.cubicCoords]++;
     }
 
-    public void RemoveSeekers(List<Cog.Seeker> seekers)
+    public void RemoveSeekers(List<Cog.Seekers> seekers)
     {
         var filteredDictionary = spawnedSeekerIcons
             .Where(pair => seekers.Any(s => s.Id == pair.Key))

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapManager.cs
@@ -101,9 +101,9 @@ public class MapManager : MonoBehaviour
                         );
                     }
                 }
-                // Do I need to call this?
-                // IconManager.instance.CheckSeekerRemoved(state.Game.Seekers.ToList());
             }
+            // TODO: Call this again after we have refactored the map data to include the seeker list
+            // IconManager.instance.CheckSeekerRemoved(state.Game.Seekers.ToList());
         }
         var playerSeekerTilePos = new List<Vector3Int>();
     }

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -61,7 +61,7 @@ fragment WorldTile on Node {
     building: node(match: { kinds: "Building", via: { rel: "Location", dir: IN } }) {
         ...WorldBuilding
     }
-    seekers: nodes(match: { kinds: "Seeker", via: { rel: "Location", dir: IN, key: 0 } }) {
+    seekers: nodes(match: { kinds: "Seeker", via: { rel: "Location", dir: IN, key: 1 } }) {
         ...WorldSeeker
     }
 }


### PR DESCRIPTION
In all the excitement I hadn't committed the fix to the query so the map seekers are shown at the `nextLocation`

- Updated query to use location[1] which is next instead of [0] which is previous location
- Fixed map icons so switching accounts lights up your seeker and turns the seeker of the account that was signed in black
  - Feels a little messy with the `SeekerManager` doing this but it at least behaves less broken which I think is important

![image](https://user-images.githubusercontent.com/51167118/228223229-9c9d477c-56cc-4484-9e93-22945987801d.png)
![image](https://user-images.githubusercontent.com/51167118/228223585-0f2d5553-232b-4a68-90f8-aff1e9c83d1b.png)
