### PR TITLE
Drop single inventory items with right click

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -2,7 +2,7 @@
 
 import type { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
-import { Fragment } from 'react';
+import { Fragment, useEffect } from 'react';
 import Head from 'next/head';
 import { GlobalStyles } from '@app/styles/global.styles';
 import { ModalProvider } from '@app/contexts/modal-provider';
@@ -18,6 +18,17 @@ const initialConfig = {
 const defaultPlugins = [scout];
 
 const App = ({ Component, pageProps }: AppProps) => {
+    useEffect(() => {
+        const handleContextMenu = (e: MouseEvent) => {
+            e.preventDefault();
+        };
+        document.addEventListener('contextmenu', handleContextMenu);
+
+        return () => {
+            document.removeEventListener('contextmenu', handleContextMenu);
+        };
+    }, []);
+
     return (
         <Fragment>
             <Head>

--- a/frontend/src/plugins/inventory/bag-item/bag-item.styles.ts
+++ b/frontend/src/plugins/inventory/bag-item/bag-item.styles.ts
@@ -1,6 +1,6 @@
 /** @format */
 
-import { css } from 'styled-components';
+import { css, keyframes } from 'styled-components';
 import { BagItemProps } from './index';
 
 type BagItemStyleProps = Partial<BagItemProps> & {
@@ -33,6 +33,26 @@ const baseStyles = ({ isPickable, isInteractable }: BagItemStyleProps) => css`
         font-size: 1.2rem;
         color: white;
     }
+
+    .spinner {
+        display: block;
+        width: 1rem;
+        height: 1rem;
+        position: absolute;
+        top: 2px;
+        right: 2px;
+        border: 1px solid white;
+        border-left-color: transparent;
+        border-radius: 0.5rem;
+        animation-name: ${spinAnimation};
+        animation-duration: 0.5s;
+        animation-iteration-count: infinite;
+        animation-timing-function: linear;
+    }
+`;
+
+const spinAnimation = keyframes`
+    100% { transform:rotate(360deg); }
 `;
 
 /**

--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -24,15 +24,25 @@ const StyledBagItem = styled('div')`
 `;
 
 export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) => {
-    const { name, icon, quantity, ownerId, equipIndex, slotIndex, itemId, itemKind, isPending, isInteractable, ...otherProps } =
-        props;
+    const {
+        name,
+        icon,
+        quantity,
+        ownerId,
+        equipIndex,
+        slotIndex,
+        itemId,
+        itemKind,
+        isPending,
+        isInteractable,
+        ...otherProps
+    } = props;
     const { pickUpItem, isPickedUpItemVisible } = useInventory();
 
-    const handleClick = (event: MouseEvent) => {
+    const handleClick = () => {
         if (!isInteractable) {
             return;
         }
-        event.stopPropagation();
         const transferInfo = {
             id: ownerId,
             equipIndex,

--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -16,6 +16,7 @@ export interface BagItemProps extends ComponentProps {
     itemId: string;
     itemKind: string;
     isInteractable: boolean;
+    isPending: boolean;
 }
 
 const StyledBagItem = styled('div')`
@@ -23,7 +24,7 @@ const StyledBagItem = styled('div')`
 `;
 
 export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) => {
-    const { name, icon, quantity, ownerId, equipIndex, slotIndex, itemId, itemKind, isInteractable, ...otherProps } =
+    const { name, icon, quantity, ownerId, equipIndex, slotIndex, itemId, itemKind, isPending, isInteractable, ...otherProps } =
         props;
     const { pickUpItem, isPickedUpItemVisible } = useInventory();
 
@@ -48,6 +49,7 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
 
     return (
         <StyledBagItem {...otherProps} onClick={handleClick} isPickable={isPickable} isInteractable={isInteractable}>
+            {isPending && <span className="spinner" />}
             <img src={icon} alt={name} className="icon" />
             <span className="amount">{quantity}</span>
         </StyledBagItem>

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -25,7 +25,7 @@ const StyledBagSlot = styled('div')`
 
 export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) => {
     const { itemSlot, isDisabled, ownerId, equipIndex, slotIndex, isInteractable, isPending, ...otherProps } = props;
-    const { dropItem, isPickedUpItemVisible, pickedUpItem } = useInventory();
+    const { dropStack, dropSingle, isPickedUpItemVisible, pickedUpItem } = useInventory();
 
     const item = itemSlot?.balance ? getItemDetails(itemSlot) : null;
 
@@ -33,18 +33,34 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
         console.log(isPending, itemSlot, item);
     }
 
-    const handleClick = () => {
+    const handleLeftClick = () => {
         if (!isPickedUpItemVisible || !isInteractable || !pickedUpItem) {
             return;
         }
-        dropItem({
-            id: ownerId,
-            equipIndex,
-            slotIndex,
-            newBalance: pickedUpItem.quantity,
-            itemId: pickedUpItem.transferInfo.itemId,
-            itemKind: pickedUpItem.transferInfo.itemKind
-        });
+
+        dropStack(
+            {
+                id: ownerId,
+                equipIndex,
+                slotIndex
+            },
+            itemSlot?.balance || 0
+        );
+    };
+
+    const handleRightClick = () => {
+        if (!isPickedUpItemVisible || !isInteractable || !pickedUpItem) {
+            return;
+        }
+
+        dropSingle(
+            {
+                id: ownerId,
+                equipIndex,
+                slotIndex
+            },
+            itemSlot?.balance || 0
+        );
     };
 
     const isDroppable = isPickedUpItemVisible && !item;
@@ -52,7 +68,8 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
     return (
         <StyledBagSlot
             {...otherProps}
-            onClick={handleClick}
+            onClick={handleLeftClick}
+            onContextMenu={handleRightClick}
             isDroppable={isDroppable}
             isDisabled={isDisabled}
             isInteractable={isInteractable}

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -24,10 +24,14 @@ const StyledBagSlot = styled('div')`
 `;
 
 export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) => {
-    const { itemSlot, isDisabled, ownerId, equipIndex, slotIndex, isInteractable, ...otherProps } = props;
+    const { itemSlot, isDisabled, ownerId, equipIndex, slotIndex, isInteractable, isPending, ...otherProps } = props;
     const { dropItem, isPickedUpItemVisible, pickedUpItem } = useInventory();
 
     const item = itemSlot?.balance ? getItemDetails(itemSlot) : null;
+
+    if (isPending) {
+        console.log(isPending, itemSlot, item);
+    }
 
     const handleClick = () => {
         if (!isPickedUpItemVisible || !isInteractable || !pickedUpItem) {
@@ -37,7 +41,7 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
             id: ownerId,
             equipIndex,
             slotIndex,
-            newBalance: pickedUpItem.transferInfo.newBalance,
+            newBalance: pickedUpItem.quantity,
             itemId: pickedUpItem.transferInfo.itemId,
             itemKind: pickedUpItem.transferInfo.itemKind
         });
@@ -60,6 +64,7 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
                     equipIndex={equipIndex}
                     slotIndex={slotIndex}
                     isInteractable={isInteractable}
+                    isPending={isPending}
                 />
             )}
         </StyledBagSlot>

--- a/frontend/src/plugins/inventory/bag/index.tsx
+++ b/frontend/src/plugins/inventory/bag/index.tsx
@@ -48,6 +48,7 @@ export const Bag: FunctionComponent<BagProps> = (props: BagProps) => {
             // we want to check if the slot has a pending from if so we update the balance
             const from = pending.map(([from, _]) => from).find((from) => from.slotIndex === index);
             if (from) {
+                console.log('From balance', from.newBalance);
                 if (slot.itemSlot) {
                     slot.itemSlot.balance = from.newBalance;
                 } else {
@@ -62,12 +63,14 @@ export const Bag: FunctionComponent<BagProps> = (props: BagProps) => {
                 }
                 slot.isPending = true;
                 slot.isDisabled = false;
+                slot.isInteractable = false;
             }
 
             // we want to check if the slot has a pending to if so we
             // update the balance and add the item id
             const to = pending.map(([_, to]) => to).find((to) => to.slotIndex === index);
             if (to) {
+                console.log('to', to);
                 if (slot.itemSlot) {
                     slot.itemSlot.balance = to.newBalance;
                 } else {

--- a/frontend/src/plugins/inventory/use-click-outside.ts
+++ b/frontend/src/plugins/inventory/use-click-outside.ts
@@ -1,0 +1,49 @@
+/** @format */
+import { RefObject, useEffect, useRef } from 'react';
+
+export const useClickOutside = (handler: (event: any) => void) => {
+    const refsArray = useRef<RefObject<HTMLElement>[]>([]);
+    const callback = useRef<(event: MouseEvent | TouchEvent) => void>(() => {});
+
+    callback.current = handler;
+
+    function isClickInside(refs: RefObject<HTMLElement>[], event: any): boolean {
+        return refs.some((ref: RefObject<HTMLElement>) => {
+            return !ref.current || ref.current.contains(event.target);
+        });
+    }
+
+    function addRef(ref: RefObject<HTMLElement>) {
+        refsArray.current.push(ref);
+    }
+
+    function removeRef(ref: RefObject<HTMLElement>) {
+        const index = refsArray.current.indexOf(ref);
+        if (index > -1) {
+            refsArray.current.splice(index, 1);
+        }
+    }
+
+    useEffect(() => {
+        const listener = (event: MouseEvent | TouchEvent) => {
+            // Do nothing if clicking ref's element or descendent elements
+            if (isClickInside(refsArray.current, event)) {
+                return;
+            }
+            callback.current(event);
+        };
+
+        document.addEventListener('mousedown', listener);
+        document.addEventListener('touchstart', listener);
+
+        return () => {
+            document.removeEventListener('mousedown', listener);
+            document.removeEventListener('touchstart', listener);
+        };
+    }, []);
+
+    return {
+        addRef,
+        removeRef
+    };
+};

--- a/frontend/src/styles/global.styles.ts
+++ b/frontend/src/styles/global.styles.ts
@@ -29,6 +29,7 @@ export const GlobalStyles = createGlobalStyle`
         -moz-osx-font-smoothing: grayscale;
         background: #335c90;
         font-size: 1.6rem;
+        overflow: hidden;
     }
 
     code {


### PR DESCRIPTION
- Drop single items with right click
- Show a pending animation on pending to slots
- Disable interaction on pending from slots
- Stop items in player hand from triggering scroll bars
- Clicking outside of a bag causes items in hand to reset

Still to come
Batching up transfers when the user clicks to drop a single item quickly

Note: I have captured context menu (right click) events at the top of the app. Use f12 to open dev tools instead of inspect