### PR TITLE
Stop infinite render loop

### DIFF
--- a/frontend/src/plugins/inventory/bag/index.tsx
+++ b/frontend/src/plugins/inventory/bag/index.tsx
@@ -87,7 +87,7 @@ export const Bag: FunctionComponent<BagProps> = (props: BagProps) => {
     useEffect(() => {
         addBagRef(slotsRef);
         return () => removeBagRef(slotsRef);
-    });
+    }, [addBagRef, removeBagRef]);
 
     return (
         <StyledBag {...otherProps}>

--- a/frontend/src/plugins/inventory/inventory-provider.tsx
+++ b/frontend/src/plugins/inventory/inventory-provider.tsx
@@ -94,7 +94,8 @@ export const InventoryProvider = ({ children }: InventoryContextProviderProps): 
                 return !transferCompleted;
             })
         );
-    }, [player, selectedTiles, world?.block, pendingTransfers]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [player, selectedTiles, world?.block]);
 
     /**
      * check if the selected seeker is on the selected tile


### PR DESCRIPTION
No more infinite loops.
- Remove pending transfer depenedency from effect that updates the dependency
- Disable  react-hooks/exhaustive-deps linting for the effect
- Also add deps array to add remove bag ref effect