### PR TITLE
chore: getting frontend build ready for deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.dockerignore
+.git
+/frontend/Dockerfile
+/frontend/node_modules
+/frontend/npm-debug.log
+/frontend/.next
+/frontend/out
+/frontend/dist
+/DawnSeekersUnity/
+/bridge/
+/state-schema-gen/
+/node_modules/
+/core/node_modules/
+/core/dist/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,6 +133,7 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v3
       with:
+        context: .
         file: frontend/Dockerfile
         push: true
         tags: ${{ steps.docker_tagging.outputs.docker_tags }}
@@ -144,6 +145,8 @@ jobs:
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            NEXT_PUBLIC_DEFAULT_COG_WS_ENDPOINT=wss://frontend-ds-${{ inputs.DEPLOYMENT_ENVIRONMENT }}.dev.playmint.com/query
+            NEXT_PUBLIC_DEFAULT_COG_HTTP_ENDPOINT=https://services-ds-${{ inputs.DEPLOYMENT_ENVIRONMENT }}.dev.playmint.com/query
 
   contracts:
     name: Contracts

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,7 +1,0 @@
-Dockerfile
-.dockerignore
-node_modules
-npm-debug.log
-README.md
-.next
-.git

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,11 +22,15 @@ RUN forge build
 
 # build static site
 FROM node:16-alpine AS builder
+ARG NEXT_PUBLIC_DEFAULT_COG_WS_ENDPOINT="ws://localhost:8080/query"
+ARG NEXT_PUBLIC_DEFAULT_COG_HTTP_ENDPOINT="http://localhost:8080/query"
 ENV NEXT_TELEMETRY_DISABLED 1
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY package*.json ./
 COPY frontend ./frontend
+# explicitly copy the ds-unity folder so build explodes if missing
+COPY frontend/public/ds-unity ./frontend/public/ds-unity
 COPY core ./core
 COPY contracts/lib/cog/services/schema/*.graphqls ./contracts/lib/cog/services/schema/
 COPY --from=contracts /contracts/out/Actions.sol/Actions.json ./contracts/out/Actions.sol/Actions.json

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -11,8 +11,8 @@ import scout from '../plugins/scout';
 import { InventoryProvider } from '@app/plugins/inventory/inventory-provider';
 
 const initialConfig = {
-    wsEndpoint: 'ws://localhost:8080/query',
-    httpEndpoint: 'http://localhost:8080/query'
+    wsEndpoint: process.env.NEXT_PUBLIC_DEFAULT_COG_WS_ENDPOINT || 'ws://localhost:8080/query',
+    httpEndpoint: process.env.NEXT_PUBLIC_DEFAULT_COG_HTTP_ENDPOINT || 'http://localhost:8080/query'
 };
 
 const defaultPlugins = [scout];


### PR DESCRIPTION

* adds some config to allow picking endpoint at build time (not ideal - runtime would be better - but a start)
* fixup some of the docker build context so it includes the wasm map and ignores ~2GB of context