### PR TITLE
Fixed cursor being visible at all times before seeker spawns

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -2634,7 +2634,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!212 &1333271655
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
@@ -72,18 +72,22 @@ public class MapInteractionManager : MonoBehaviour
             MapClicked2();
         }
 
+        bool TileNeighbourValid = false;
+        if (SeekerManager.Instance.Seeker != null)
+            TileNeighbourValid = TileHelper
+                .GetTileNeighbours(
+                    TileHelper.GetTilePosCube(SeekerManager.Instance.Seeker.NextLocation)
+                )
+                .Contains(GridExtensions.GridToCube(CurrentMouseCell));
+
         // Tile mouseover cursor
         if (
-            SeekerManager.Instance.Seeker != null
+            GameStateMediator.Instance.gameState != null
             && GameStateMediator.Instance.gameState.World != null
         )
             cursor.gameObject.SetActive(
                 TileHelper.IsDiscoveredTile(GridExtensions.GridToCube(CurrentMouseCell))
-                    || TileHelper
-                        .GetTileNeighbours(
-                            TileHelper.GetTilePosCube(SeekerManager.Instance.Seeker.NextLocation)
-                        )
-                        .Contains(GridExtensions.GridToCube(CurrentMouseCell))
+                    || TileNeighbourValid
             );
     }
 


### PR DESCRIPTION
Very small PR that fixes a bug where the cursor would be visible at all times before a seeker spawned in, as well as being visible at the start of the game regardless.