### PR TITLE
Construction intent implementation

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Prefabs/Intents.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/Intents.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6406227089287717616}
-  - component: {fileID: 7830148173117367100}
+  - component: {fileID: 5830282379756671830}
   m_Layer: 0
   m_Name: Intents
   m_TagString: Untagged
@@ -35,7 +35,7 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7830148173117367100
+--- !u!114 &5830282379756671830
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -44,7 +44,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6406227089287717617}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cbc32405fb37643ccb01dab4f7b10f15, type: 3}
+  m_Script: {fileID: 11500000, guid: 25bf05bcc30e1411a8a11924abe4778c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &6406227089827611954
@@ -56,6 +56,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6406227089827611953}
+  - component: {fileID: 8967175068638033150}
   m_Layer: 0
   m_Name: ConstructIntent
   m_TagString: Untagged
@@ -78,6 +79,22 @@ Transform:
   m_Father: {fileID: 6406227089287717616}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8967175068638033150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6406227089827611954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbc32405fb37643ccb01dab4f7b10f15, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _validHighlightPrefab: {fileID: 9133061235819889254, guid: 7f40037dbe60e4a0d8b02da7ed0b821d,
+    type: 3}
+  _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: b7c618a848ab743e6a4d96eceec155b2,
+    type: 3}
 --- !u!1 &6406227090609630104
 GameObject:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
@@ -77,6 +77,17 @@ public class TileHelper
         return tile.BagCount > 0;
     }
 
+    public static bool HasBuilding(Vector3Int tilePosCube)
+    {
+        var tile = GetTileByPos(tilePosCube);
+        return tile != null && HasBuilding(tile);
+    }
+
+    public static bool HasBuilding(Tiles2 tile)
+    {
+        return tile.Building != null;
+    }
+
     public static Vector3Int[] GetTileNeighbours(Vector3Int tile)
     {
         return new Vector3Int[6]

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ConstructIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ConstructIntent.cs
@@ -5,17 +5,184 @@ using UnityEngine;
 using System.Linq;
 using Cog;
 
-public class ConstructIntent : MonoBehaviour
+public class ConstructIntent : IntentHandler
 {
     public static ConstructIntent instance;
+    private bool _isActiveIntent;
+    private Vector3Int _seekerPos;
+    private Vector3Int[] _validTilePositions;
+
+    // TODO: put in base class
+    private Dictionary<Vector3Int, GameObject> _spawnedValidHighlights;
+    private Dictionary<Vector3Int, GameObject> _spawnedSelectedHighlights;
+
+    [SerializeField]
+    private GameObject _validHighlightPrefab,
+        _selectedHighlightPrefab;
+
+    ConstructIntent()
+    {
+        Intent = IntentKind.CONSTRUCT;
+    }
 
     private void Awake()
     {
         instance = this;
+        _validTilePositions = Array.Empty<Vector3Int>();
+        _spawnedValidHighlights = new Dictionary<Vector3Int, GameObject>();
+        _spawnedSelectedHighlights = new Dictionary<Vector3Int, GameObject>();
     }
 
-    private bool isValidConstructionTile()
+    protected void Start()
     {
-        return true;
+        GameStateMediator.Instance.EventStateUpdated += OnStateUpdated;
+        MapInteractionManager.instance.EventTileLeftClick += OnTileLeftClick;
+        MapInteractionManager.instance.EventTileRightClick += OnTileRightClick;
+    }
+
+    private void OnDestroy()
+    {
+        GameStateMediator.Instance.EventStateUpdated -= OnStateUpdated;
+        MapInteractionManager.instance.EventTileLeftClick -= OnTileLeftClick;
+        MapInteractionManager.instance.EventTileRightClick -= OnTileRightClick;
+    }
+
+    private void OnStateUpdated(GameState state)
+    {
+        if (state.Selected.Intent == Intent)
+        {
+            _isActiveIntent = true;
+            _seekerPos = TileHelper.GetTilePosCube(state.Selected.Seeker.NextLocation);
+            _validTilePositions = GetValidTilePositions(state);
+
+            var selection = GetSelectedTilePositions(state);
+            HighlightSelectedTiles(selection);
+
+            // Highlight the valid tiles that haven't been selected
+            HighlightValidTiles(
+                _validTilePositions
+                    .Where(cellPosCube => !_spawnedSelectedHighlights.ContainsKey(cellPosCube))
+                    .ToArray()
+            );
+        }
+        else
+        {
+            _isActiveIntent = false;
+            RemoveAllHighlights();
+        }
+    }
+
+    private void OnTileLeftClick(Vector3Int cellPosCube)
+    {
+        if (!_isActiveIntent)
+            return;
+
+        if (_spawnedSelectedHighlights.ContainsKey(cellPosCube))
+        {
+            // Deselect tile (This is always going to yield an empty list but keeping it here for posterity)
+            var tileIDs = _spawnedSelectedHighlights
+                .Where(kvp => kvp.Key != cellPosCube)
+                .Select(kvp => TileHelper.GetTileID(kvp.Key))
+                .ToList();
+
+            GameStateMediator.Instance.SendSelectTileMsg(tileIDs);
+        }
+        else if (_validTilePositions.Contains(cellPosCube))
+        {
+            // set the selection to just the clicked tile i.e. doesn't add to selection like scout or move does
+            GameStateMediator.Instance.SendSelectTileMsg(
+                new List<string>() { TileHelper.GetTileID(cellPosCube) }
+            );
+        }
+    }
+
+    private void OnTileRightClick(Vector3Int cellPosCube)
+    {
+        if (!_isActiveIntent)
+            return;
+    }
+
+    private Vector3Int[] GetValidTilePositions(GameState state)
+    {
+        var neighbourTiles = TileHelper.GetTileNeighbours(_seekerPos);
+        return neighbourTiles
+            .Where(cellPosCube =>
+            {
+                return TileHelper.IsDiscoveredTile(cellPosCube)
+                    && !TileHelper.HasBuilding(cellPosCube);
+            })
+            .ToArray();
+    }
+
+    // -- Tile Highlighting
+
+    private void HighlightValidTiles(Vector3Int[] tilePositions)
+    {
+        HighlightTiles(tilePositions, _validHighlightPrefab, _spawnedValidHighlights);
+    }
+
+    private void HighlightSelectedTiles(Vector3Int[] tilePositions)
+    {
+        // Filter selection to only contain valid tiles
+        var validTilePositions = tilePositions
+            .Where(cellPosCube => _validTilePositions.Contains(cellPosCube))
+            .ToArray();
+
+        if (validTilePositions.Length > 0)
+        {
+            // We only care about the first valid tile
+            HighlightTiles(
+                new Vector3Int[1] { validTilePositions[0] },
+                _selectedHighlightPrefab,
+                _spawnedSelectedHighlights
+            );
+        }
+    }
+
+    private void RemoveAllHighlights()
+    {
+        foreach (var kvp in _spawnedSelectedHighlights)
+        {
+            Destroy(kvp.Value);
+        }
+        foreach (var kvp in _spawnedValidHighlights)
+        {
+            Destroy(kvp.Value);
+        }
+
+        _spawnedSelectedHighlights.Clear();
+        _spawnedValidHighlights.Clear();
+    }
+
+    // TODO: Move to base class or put into a seperate class all intents can use
+    private void HighlightTiles(
+        Vector3Int[] tilePositions,
+        GameObject highlightPrefab,
+        Dictionary<Vector3Int, GameObject> spawnedHighlights
+    )
+    {
+        // Destroy tiles that are no longer on the list
+        var oldHighlights = spawnedHighlights
+            .Where(kvp => !tilePositions.Contains(kvp.Key))
+            .ToArray();
+
+        foreach (var kvp in oldHighlights)
+        {
+            Destroy(kvp.Value);
+            spawnedHighlights.Remove(kvp.Key);
+        }
+
+        // Highlight tiles on the list that haven't been highlighted
+        foreach (Vector3Int cellPosCube in tilePositions)
+        {
+            if (!spawnedHighlights.ContainsKey(cellPosCube))
+            {
+                GameObject highlight = Instantiate(highlightPrefab);
+                highlight.transform.position = MapManager.instance.grid.CellToWorld(
+                    GridExtensions.CubeToGrid(cellPosCube)
+                );
+                spawnedHighlights.Add(cellPosCube, highlight);
+            }
+        }
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/IntentHandler.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/IntentHandler.cs
@@ -1,6 +1,13 @@
+using Cog;
 using UnityEngine;
+using System.Linq;
 
 public class IntentHandler : MonoBehaviour
 {
     public string Intent { get; protected set; }
+
+    protected Vector3Int[] GetSelectedTilePositions(GameState state)
+    {
+        return state.Selected.Tiles.Select(tile => TileHelper.GetTilePosCube(tile)).ToArray();
+    }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/IntentManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/IntentManager.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using System.Linq;
+
+public class IntentManager : MonoBehaviour
+{
+    public static IntentManager Instance;
+
+    private IntentHandler[] _intentHandlers;
+
+    protected void Awake()
+    {
+        Instance = this;
+        _intentHandlers = GetComponentsInChildren<IntentHandler>();
+    }
+
+    public bool IsHandledIntent(string intent)
+    {
+        return _intentHandlers.FirstOrDefault(intentHandler => intentHandler.Intent == intent)
+            != null;
+    }
+}

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/IntentManager.cs.meta
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/IntentManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25bf05bcc30e1411a8a11924abe4778c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
@@ -15,6 +15,7 @@ public class ScoutIntent : IntentHandler
     private GameObject _validHighlightPrefab,
         _selectedHighlightPrefab;
 
+    // TODO: put in base class
     private Dictionary<Vector3Int, GameObject> _spawnedValidHighlights;
     private Dictionary<Vector3Int, GameObject> _spawnedSelectedHighlights;
 
@@ -84,7 +85,6 @@ public class ScoutIntent : IntentHandler
             return;
 
         // Should clicking the seeker tile set the intent to NONE?
-        // Either way we don't want to deselect the seeker tile otherwise we lose the action menu!
         if (cellPosCube == _seekerPos)
             return;
 
@@ -137,15 +137,8 @@ public class ScoutIntent : IntentHandler
             GameStateMediator.Instance.ScoutTile(cellPosCube);
         }
 
-        // Reset the selection to just the seeker
-        GameStateMediator.Instance.SendSelectTileMsg(
-            new List<string>() { TileHelper.GetTileID(_seekerPos) }
-        );
-    }
-
-    private Vector3Int[] GetSelectedTilePositions(GameState state)
-    {
-        return state.Selected.Tiles.Select(tile => TileHelper.GetTilePosCube(tile)).ToArray();
+        // Clear the selection
+        GameStateMediator.Instance.SendDeselectAllTilesMsg();
     }
 
     protected void Update()
@@ -197,15 +190,13 @@ public class ScoutIntent : IntentHandler
     {
         // Filter selection to only contain valid scout tiles
         var validTilePositions = tilePositions
-            .Where(
-                cellPosCube =>
-                    _validTilePositions.Contains(cellPosCube) || cellPosCube == _seekerPos
-            )
+            .Where(cellPosCube => _validTilePositions.Contains(cellPosCube))
             .ToArray();
 
         HighlightTiles(validTilePositions, _selectedHighlightPrefab, _spawnedSelectedHighlights);
     }
 
+    // TODO: Move to base class or put into a seperate class all intents can use
     private void HighlightTiles(
         Vector3Int[] tilePositions,
         GameObject highlightPrefab,

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapInteractionManager.cs
@@ -25,12 +25,9 @@ public class MapInteractionManager : MonoBehaviour
     [SerializeField]
     private GameObject _intentContainerGO;
 
-    private IntentHandler[] IntentHandlers;
-
     private void Awake()
     {
         instance = this;
-        IntentHandlers = _intentContainerGO.GetComponentsInChildren<IntentHandler>();
     }
 
     private void Start()
@@ -105,16 +102,14 @@ public class MapInteractionManager : MonoBehaviour
         }
 
         // Do generic selection of tile if we aren't in any of our handled intents
-        if (!IsHandledIntent(GameStateMediator.Instance.gameState.Selected.Intent))
+        if (
+            !IntentManager.Instance.IsHandledIntent(
+                GameStateMediator.Instance.gameState.Selected.Intent
+            )
+        )
         {
             Cog.GameStateMediator.Instance.SendSelectTileMsg(new List<string>() { tile.Id });
         }
-    }
-
-    private bool IsHandledIntent(string intent)
-    {
-        return IntentHandlers.FirstOrDefault(intentHandler => intentHandler.Intent == intent)
-            != null;
     }
 
     void MapClicked2()

--- a/DawnSeekersUnity/Assets/Map/Scripts/MapManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/MapManager.cs
@@ -80,7 +80,7 @@ public class MapManager : MonoBehaviour
             else
                 IconManager.instance.CheckIconRemoved(cell);
 
-            if (tile.Building != null)
+            if (TileHelper.HasBuilding(tile))
                 IconManager.instance.CreateBuildingIcon(cell);
 
             MapManager.instance.AddTile(cell);

--- a/DawnSeekersUnity/Assets/Map/Scripts/UI/ActionMenuController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/UI/ActionMenuController.cs
@@ -23,29 +23,36 @@ public class ActionMenuController : MonoBehaviour
 
     private void OnStateUpdated(GameState state)
     {
-        if (state.Selected.Tiles != null && state.Selected.Tiles.Count > 0)
+        if (ShouldShowMenu(state))
         {
-            var tile = state.Selected.Tiles.ToList()[0];
-            var cellPosCube = TileHelper.GetTilePosCube(tile);
-            bool isPlayerAtPosition = SeekerManager.Instance.IsPlayerAtPosition(cellPosCube);
-            if (isPlayerAtPosition)
-            {
-                gameObject.SetActive(true);
-                transform.position = MapManager.instance.grid.CellToWorld(
-                    GridExtensions.CubeToGrid(cellPosCube)
-                );
+            var seekerPos = TileHelper.GetTilePosCube(state.Selected.Seeker.NextLocation);
+            gameObject.SetActive(true);
+            transform.position = MapManager.instance.grid.CellToWorld(
+                GridExtensions.CubeToGrid(seekerPos)
+            );
 
-                UpdateButtonStates(state);
-            }
-            else
-            {
-                gameObject.SetActive(false);
-            }
+            UpdateButtonStates(state);
         }
         else
         {
             gameObject.SetActive(false);
         }
+    }
+
+    private bool ShouldShowMenu(GameState state)
+    {
+        if (IntentManager.Instance.IsHandledIntent(state.Selected.Intent))
+        {
+            return true;
+        }
+        else if (state.Selected.Tiles != null && state.Selected.Tiles.Count > 0)
+        {
+            var tile = state.Selected.Tiles.ToList()[0];
+            var cellPosCube = TileHelper.GetTilePosCube(tile);
+            return SeekerManager.Instance.IsPlayerAtPosition(cellPosCube);
+        }
+
+        return false;
     }
 
     private void UpdateButtonStates(GameState state)


### PR DESCRIPTION
# What

Implementation of construction intent along with some tweaks to not have the action menu rely on the seeker tile having to be the first in the selection

- Construction intent allows the player to select only 1 tile adjacent to the seeker if it doesn't have a building on it
- Removed quirk where the `ActionMenu` required the first tile in a selection to be the seeker tile
  - If we are in any of the handled intents then the action menu will be shown
- Removed the first tile being the seeker quirk from the `ScoutIntent`

## Known issues

There's a double of code across Move, Scout and Construct intent handlers. We could put some of that stuff either in the base `IntentHandler` class or make some kind of generic selection manager which handles this stuff so not each intent is handling what's highlighted. One for another day...