### PR TITLE
Adjust mesh on action icon bg to be rectangular

### DIFF
--- a/DawnSeekersUnity/Assets/Map/2D_Assets/UI/Icon_BG.png.meta
+++ b/DawnSeekersUnity/Assets/Map/2D_Assets/UI/Icon_BG.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 2
   spriteExtrude: 1
-  spriteMeshType: 1
+  spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 256

--- a/DawnSeekersUnity/Assets/Map/2D_Assets/UI/constructIcon.png.meta
+++ b/DawnSeekersUnity/Assets/Map/2D_Assets/UI/constructIcon.png.meta
@@ -36,9 +36,9 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
-    wrapW: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50

--- a/DawnSeekersUnity/Assets/Map/2D_Assets/UI/moveIcon.png.meta
+++ b/DawnSeekersUnity/Assets/Map/2D_Assets/UI/moveIcon.png.meta
@@ -36,9 +36,9 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
-    wrapW: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50

--- a/DawnSeekersUnity/Assets/Map/2D_Assets/UI/scoutIcon.png.meta
+++ b/DawnSeekersUnity/Assets/Map/2D_Assets/UI/scoutIcon.png.meta
@@ -36,9 +36,9 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
-    wrapW: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50


### PR DESCRIPTION
# What

Fixed the problem where we could see parts of other textures in the transparent area of the icon background sprite

Closes #64 

## Before
<img width="321" alt="image" src="https://user-images.githubusercontent.com/51167118/228862841-e2d7f7f2-a7ce-40c6-b126-1ec557c67f2d.png">

## Fixed
<img width="313" alt="image" src="https://user-images.githubusercontent.com/51167118/228869410-a310d332-67d4-4589-88d3-701fc1fd3902.png">


- Adjusted `Icon_BG` mesh to be full rectangle instead of tight to fix the problem where we were seeing parts of other textures from the texture atlas
- Adjusted wrap mode on icons to clamp so we don't see sub pixel wrapping artifacts