### PR TITLE
Extend to debounce time on the COG subscription to mitigate inventory…

### DIFF
--- a/core/src/cog.ts
+++ b/core/src/cog.ts
@@ -183,7 +183,7 @@ export function configureClient({
                 return res.data.events;
             }),
             filter((data): data is AnyGameSubscription['events'] => !!data),
-            debounce(() => 250), // chill out
+            debounce(() => 2500), // chill out
             tap(() => console.log('NEW DATA ARRIVED!!!!!!!!!')),
             share,
         );


### PR DESCRIPTION
… pending states getting removed too early

## What?
Increase the debounce time of the Cog subscription

## Why?
The inventory pending states for transfers are getting in a muddle when we receive partial data back from the indexer, for example:
![image](https://user-images.githubusercontent.com/4235606/229785930-95a72f5c-f8ac-4bcd-8bf4-389b9db4043c.png)
We have an additional balance of 99 in slot 2 after transferring 1 item to slot 3. Subsequent transfers to slots 0 and 1 have updated those slots but not yet slot 2. This causes the pending states to be removed from all slots and slot 2 is interactable even though the balance there is already gone and should be shown as pending.

Currently the pending transfer logic is not looking at the from slots to determine if it is complete and will be raised as a separate issue