### PR TITLE
disable pointer-events on logs

### DIFF
--- a/frontend/src/components/organisms/logs/logs.styles.ts
+++ b/frontend/src/components/organisms/logs/logs.styles.ts
@@ -15,6 +15,7 @@ const baseStyles = (_: Partial<LogsProps>) => css`
         top: 55px;
         left 0px;
         width: 30vw;
+        pointer-events: none;
         > .log {
             display: block;
             font-family: courier;


### PR DESCRIPTION
allow interacting with map through the logs overlay

resolves #66 