### PR TITLE
Check for world state before attempting to get tile count

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/UI/LoadingOverlay.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/UI/LoadingOverlay.cs
@@ -22,7 +22,7 @@ public class LoadingOverlay : MonoBehaviour
 
     private void OnStateUpdated(GameState state)
     {
-        if (_hidden)
+        if (_hidden || state.World == null || state.World.Tiles == null)
             return;
 
         //foreach (var seeker in state.Game.Seekers)


### PR DESCRIPTION
Fix for the 8cce5c-ba1d-47c4-bedb-3e9c109446f0:3 MethodAccessException: Attempt to access method 'System.Collections.Generic.ICollection<Cog.Tiles2>.get_Count' on type '' failed. error.