### PR TITLE
Add a dev build to maker file and clean up unity build script

### DIFF
--- a/DawnSeekersUnity/Assets/Scripts/Editor/BuildScript.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Editor/BuildScript.cs
@@ -8,36 +8,6 @@ using System.Collections.Generic;
 
 public class BuildScript
 {
-    //WebGL Build
-    [MenuItem("Playmint/Build/Prod/WebGL")]
-    static void WebGLBuild()
-    {
-        var scenes = GetScenesFromBuildSettings();
-        WebGLThreadDisable();
-        EditorUserBuildSettings.il2CppCodeGeneration = Il2CppCodeGeneration.OptimizeSize;
-        BuildPipeline.BuildPlayer(
-            scenes,
-            "Builds/Prod/Web/DawnSeekers",
-            BuildTarget.WebGL,
-            BuildOptions.None
-        );
-    }
-
-    //Debug WebGL Build
-    [MenuItem("Playmint/Build/Debug/WebGL")]
-    static void WebGLBuildDebug()
-    {
-        var scenes = GetScenesFromBuildSettings();
-        WebGLThreadDisable();
-        EditorUserBuildSettings.il2CppCodeGeneration = Il2CppCodeGeneration.OptimizeSize;
-        BuildPipeline.BuildPlayer(
-            scenes,
-            "Builds/Debug/Web/DawnSeekers",
-            BuildTarget.WebGL,
-            BuildOptions.Development
-        );
-    }
-
     //Github actions build
     [MenuItem("Playmint/Build/Pipeline Test")]
     static void GitHubBuild()
@@ -51,6 +21,20 @@ public class BuildScript
             "../frontend/public/ds-unity",
             BuildTarget.WebGL,
             BuildOptions.None
+        );
+    }
+
+    static void DevBuild()
+    {
+        var scenes = GetScenesFromBuildSettings();
+        //MoveJson();
+        PlayerSettings.WebGL.threadsSupport = false;
+        EditorUserBuildSettings.il2CppCodeGeneration = Il2CppCodeGeneration.OptimizeSize;
+        BuildPipeline.BuildPlayer(
+            scenes,
+            "../frontend/public/ds-unity",
+            BuildTarget.WebGL,
+            BuildOptions.Development
         );
     }
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ all: node_modules contracts/lib/cog/services/bin/ds-node contracts/out/Actions.s
 map:
 	$(UNITY_EDITOR) -batchmode -quit -projectPath ./DawnSeekersUnity -executeMethod BuildScript.GitHubBuild -buildTarget WebGL -logFile - 
 
+debugmap:
+	$(UNITY_EDITOR) -batchmode -quit -projectPath ./DawnSeekersUnity -executeMethod BuildScript.DevBuild -buildTarget WebGL -logFile - 
+
 dev: all
 	$(NODE) .devstartup.js
 

--- a/Makefile
+++ b/Makefile
@@ -71,5 +71,5 @@ clean:
 	$(MAKE) -C contracts/lib/cog/services clean
 
 
-.PHONY: all clean dev map compose
+.PHONY: all clean dev map compose debugmap
 .SILENT: contracts/lib/cog/services/bin/ds-node frontend/public/ds-unity/Build/ds-unity.wasm


### PR DESCRIPTION
### What?
I have added another maker command that calls a unity build script function to make a build but with development mode turned on

### Why?
Unity debug output by default is pretty rubbish so this should help finding and squashing bugs

### How?
I have copied the make map command and make it call a new unity build script function called DevBuild. In DevBuild, the unity options parameter is set to "Development" instead of "None". This does a few things but I have mainly done it for more verbose logging.

### So what?
If you do a make clean, a make debugmap and then a make dev, you will get a build with big verbose logging enabled