### PR TITLE
Require wood for constructing buildings

### DIFF
--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -131,7 +131,7 @@ contract BuildingRule is Rule {
         uint8 resourceFromEquipSlot = 0;
         uint8 resourceFromItemSlot = 0;
         // burn resources from given slot
-        // [!] for now we are hard coding a fee of "100 of any resource"
+        // [!] for now we are hard coding a fee of "100 wood"
         _payConstructionFee(state, ctx, buildingInstance, resourceFromEquipSlot, resourceFromItemSlot);
         // set type of building
         state.setBuildingKind(buildingInstance, buildingKind);
@@ -154,7 +154,7 @@ contract BuildingRule is Rule {
         _requireCanUseBag(state, bag, Node.Player(ctx.sender));
         // check we meet the building requirements
         (bytes24 resource, uint64 balance) = state.getItemSlot(bag, resourceFromItemSlot);
-        if (balance < BUILDING_COST) {
+        if (balance < BUILDING_COST || resource != Node.Resource(ResourceKind.WOOD)) {
             revert BuildingResourceRequirementsNotMet();
         }
         balance -= BUILDING_COST;

--- a/frontend/src/plugins/building/index.tsx
+++ b/frontend/src/plugins/building/index.tsx
@@ -218,7 +218,7 @@ const ConstructAvailable: FunctionComponent<ConstructAvailableProps> = ({ tile, 
                                 key: 0,
                                 balance: 100,
                                 item: {
-                                    id: resourceIds.unknown,
+                                    id: resourceIds.wood,
                                     kind: 'Resource'
                                 }
                             }}


### PR DESCRIPTION
## What is here
- Constrain construction resource to wood instead of using any resource in the build contract
- Validate the correct resource type and amount in the client
- Show wood icon in the building bag as a placeholder

## What is missing?
Pending states are still missing so whilst a transfer is in progress it is currently possible to drop too many resources on the bag (because the balance check is using the last known on chain balance and not the pending one).