### PR TITLE
Tile coord display

### DIFF
--- a/frontend/public/empty-tile.png
+++ b/frontend/public/empty-tile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c648a0172d1c3f306131f6456e5de7e7f835e37e3accf38b35cd8337271125bc
+size 29284

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -8,6 +8,7 @@ import { Building } from '@app/plugins/building';
 import { SeekerInventory } from '@app/plugins/inventory/seeker-inventory';
 import { TileInventory } from '@app/plugins/inventory/tile-inventory';
 import { SeekerList } from '@app/plugins/seeker-list';
+import { TileCoords } from '@app/plugins/tile-coords';
 import { ComponentProps } from '@app/types/component-props';
 import { CompoundKeyEncoder, NodeSelectors, usePlayer, usePluginState, useSelection } from '@dawnseekers/core';
 import { Fragment, FunctionComponent, useCallback } from 'react';
@@ -112,6 +113,9 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
                     </div>
 
                     <div className="tile-actions">
+                        {selectedTiles && selectedTiles.length > 0 && (
+                            <TileCoords className="action" selectedTiles={selectedTiles} />
+                        )}
                         <Building className="action" />
                         {tileSeekers.length > 0 && <SeekerList seekers={tileSeekers} className="action" />}
                         {selectedTile && <TileInventory className="action" tile={selectedTile} title="Bags" />}

--- a/frontend/src/plugins/tile-coords/index.tsx
+++ b/frontend/src/plugins/tile-coords/index.tsx
@@ -1,0 +1,38 @@
+/** @format */
+
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+import { ComponentProps } from '@app/types/component-props';
+import { styles } from './tile-coords.styles';
+import { ethers } from 'ethers';
+import { SelectedTileFragment } from '@app/../../core/dist/core';
+
+export interface TileCoordsProps extends ComponentProps {
+    selectedTiles: SelectedTileFragment[];
+}
+
+const StyledTileCoords = styled('div')`
+    ${styles}
+`;
+
+export const TileCoords: FunctionComponent<TileCoordsProps> = (props: TileCoordsProps) => {
+    const { selectedTiles, ...otherProps } = props;
+    const lastTile = selectedTiles[selectedTiles.length - 1];
+    const [_, q, r, s] = lastTile.coords.map((elm) => ethers.fromTwos(elm, 16));
+
+    return (
+        <StyledTileCoords {...otherProps}>
+            <h3>Selected Tile Coordinates</h3>
+            <div className="tile-container">
+                <img src="empty-tile.png" alt="" width={80} />
+                <div className="element q">{`${q}`}</div>
+                <div className="element r">{`${r}`}</div>
+                <div className="element s">{`${s}`}</div>
+                <div className="axis q">{`Q`}</div>
+                <div className="axis r">{`R`}</div>
+                <div className="axis s">{`S`}</div>
+            </div>
+            <div>{`${q}, ${r}, ${s}`}</div>
+        </StyledTileCoords>
+    );
+};

--- a/frontend/src/plugins/tile-coords/index.tsx
+++ b/frontend/src/plugins/tile-coords/index.tsx
@@ -32,7 +32,7 @@ export const TileCoords: FunctionComponent<TileCoordsProps> = (props: TileCoords
                 <div className="axis r">{`R`}</div>
                 <div className="axis s">{`S`}</div>
             </div>
-            <div>{`${q}, ${r}, ${s}`}</div>
+            <div className="coordinates">{`Q:${q} R:${r} S:${s}`}</div>
         </StyledTileCoords>
     );
 };

--- a/frontend/src/plugins/tile-coords/index.tsx
+++ b/frontend/src/plugins/tile-coords/index.tsx
@@ -1,6 +1,6 @@
 /** @format */
 
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
 import { ComponentProps } from '@app/types/component-props';
 import { styles } from './tile-coords.styles';
@@ -19,20 +19,29 @@ export const TileCoords: FunctionComponent<TileCoordsProps> = (props: TileCoords
     const { selectedTiles, ...otherProps } = props;
     const lastTile = selectedTiles[selectedTiles.length - 1];
     const [_, q, r, s] = lastTile.coords.map((elm) => ethers.fromTwos(elm, 16));
+    const [showingIllustration, setShowingIllustration] = useState(false);
+    // const [__, qHex, rHex, sHex] = lastTile.coords;
+
+    const handleCoordinatesClick = () => {
+        setShowingIllustration(!showingIllustration);
+    };
 
     return (
         <StyledTileCoords {...otherProps}>
             <h3>Selected Tile Coordinates</h3>
-            <div className="tile-container">
-                <img src="empty-tile.png" alt="" width={80} />
-                <div className="element q">{`${q}`}</div>
-                <div className="element r">{`${r}`}</div>
-                <div className="element s">{`${s}`}</div>
-                <div className="axis q">{`Q`}</div>
-                <div className="axis r">{`R`}</div>
-                <div className="axis s">{`S`}</div>
-            </div>
-            <div className="coordinates">{`Q:${q} R:${r} S:${s}`}</div>
+            {showingIllustration && (
+                <div className="tile-container">
+                    <img src="empty-tile.png" alt="" width={80} />
+                    <div className="element q">{`${q}`}</div>
+                    <div className="element r">{`${r}`}</div>
+                    <div className="element s">{`${s}`}</div>
+                    <div className="axis q">{`Q`}</div>
+                    <div className="axis r">{`R`}</div>
+                    <div className="axis s">{`S`}</div>
+                </div>
+            )}
+            <div className="coordinates" onClick={handleCoordinatesClick}>{`${q}, ${r}, ${s}`}</div>
+            {/* <div className="coordinates">{`Q:${qHex} R:${rHex} S:${sHex}`}</div> */}
         </StyledTileCoords>
     );
 };

--- a/frontend/src/plugins/tile-coords/tile-coords.styles.ts
+++ b/frontend/src/plugins/tile-coords/tile-coords.styles.ts
@@ -33,19 +33,19 @@ const baseStyles = (_: Partial<TileCoordsProps>) => css`
     }
 
     .axis.q {
-        transform: translate(-53px, 28px);
+        transform: translate(-19px, -3px);
     }
 
     .axis.r {
-        transform: translate(50px, -18px);
+        transform: translate(22px, -21px);
     }
 
     .axis.s {
-        transform: translate(-51px, -63px);
+        transform: translate(-17px, -40px);
     }
 
     .element.q {
-        transform: translate(-53px, 28px);
+        transform: translate(-44px, 35px);
     }
 
     .element.r {
@@ -54,6 +54,10 @@ const baseStyles = (_: Partial<TileCoordsProps>) => css`
 
     .element.s {
         transform: translate(-51px, -63px);
+    }
+
+    .coordinates {
+        margin-top: 1em;
     }
 `;
 

--- a/frontend/src/plugins/tile-coords/tile-coords.styles.ts
+++ b/frontend/src/plugins/tile-coords/tile-coords.styles.ts
@@ -1,0 +1,68 @@
+/** @format */
+
+import { css } from 'styled-components';
+import { TileCoordsProps } from './index';
+
+/**
+ * Base styles for the seeker list component
+ *
+ * @param _ The seeker list properties object
+ * @return Base styles for the seeker list component
+ */
+const baseStyles = (_: Partial<TileCoordsProps>) => css`
+    /* h3 {
+        margin-bottom: 0;
+    } */
+
+    .tile-container {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .element,
+    .axis {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+    }
+
+    .axis {
+        color: #143063;
+    }
+
+    .axis.q {
+        transform: translate(-53px, 28px);
+    }
+
+    .axis.r {
+        transform: translate(50px, -18px);
+    }
+
+    .axis.s {
+        transform: translate(-51px, -63px);
+    }
+
+    .element.q {
+        transform: translate(-53px, 28px);
+    }
+
+    .element.r {
+        transform: translate(50px, -18px);
+    }
+
+    .element.s {
+        transform: translate(-51px, -63px);
+    }
+`;
+
+/**
+ * The seeker list component styles
+ *
+ * @param props The seeker list properties object
+ * @return Styles for the seeker list component
+ */
+export const styles = (props: Partial<TileCoordsProps>) => css`
+    ${baseStyles(props)}
+`;

--- a/frontend/src/plugins/tile-coords/tile-coords.styles.ts
+++ b/frontend/src/plugins/tile-coords/tile-coords.styles.ts
@@ -45,7 +45,9 @@ const baseStyles = (_: Partial<TileCoordsProps>) => css`
     }
 
     .element.q {
-        transform: translate(-44px, 35px);
+        width: 50px;
+        text-align: right;
+        transform: translate(-76px, 39px);
     }
 
     .element.r {
@@ -53,7 +55,9 @@ const baseStyles = (_: Partial<TileCoordsProps>) => css`
     }
 
     .element.s {
-        transform: translate(-51px, -63px);
+        width: 50px;
+        text-align: right;
+        transform: translate(-76px, -63px);
     }
 
     .coordinates {


### PR DESCRIPTION
# What

Added a plugin to show the select tile's coordinates

![image](https://user-images.githubusercontent.com/51167118/234334603-b8d0d250-304e-42b4-aac6-85854143e5cb.png)

Tried to make it clear what the Q,R,S axis mean but maybe made a hot mess. Open to suggestions if there is a way of making this clearer.

The coordinates show the selected tile but perhaps it should show the coords of the mouse over tile?