### PR TITLE
Hiding bags with zero balance

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
@@ -73,8 +73,15 @@ public class TileHelper
 
     public static bool HasResource(Tiles2 tile)
     {
-        // TODO: Check for balance on tile (Currently not in data)
-        return tile.BagCount > 0;
+        if (tile.BagBalances != null && tile.BagBalances.Count > 0)
+        {
+            double totalBalance = tile.BagBalances.Aggregate(
+                0,
+                (acc, balObj) => acc + balObj.Balance
+            );
+            return totalBalance > 0;
+        }
+        return false;
     }
 
     public static bool HasBuilding(Vector3Int tilePosCube)

--- a/DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs
@@ -580,6 +580,9 @@ namespace Cog
         [Newtonsoft.Json.JsonProperty("bagCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double BagCount { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("bagBalances")]
+        public System.Collections.Generic.ICollection<BagBalance> BagBalances { get; set; }
+
         [Newtonsoft.Json.JsonProperty("biome", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Biome { get; set; }
 
@@ -606,6 +609,12 @@ namespace Cog
             set { _additionalProperties = value; }
         }
 
+    }
+
+    public partial class BagBalance
+    {
+        [Newtonsoft.Json.JsonProperty("balance")]
+        public int Balance { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -60,7 +60,10 @@ fragment WorldTile on Node {
     # but this is temporary until we know what we need
     biome: value(match: { via: { rel: "Biome" } }) # 0=UNDISCOVERED, 1=DISCOVERED
     # bags equip to tiles
-    bagCount: count(match: { kinds: ["Bag"], via: { rel: "Equip" } })
+    bagCount: count(match: { kinds: "Bag", via: { rel: "Equip" } })
+    bagBalances: nodes(match: { kinds: "Bag", via: { rel: "Equip", dir: OUT } }) {
+        balance: sum(match: { kinds: "Resource", via: { rel: "Balance" } })
+    }
     building: node(match: { kinds: "Building", via: { rel: "Location", dir: IN } }) {
         ...WorldBuilding
     }

--- a/core/src/world.ts
+++ b/core/src/world.ts
@@ -62,6 +62,7 @@ function getUnscoutedTile(tiles: WorldTileFragment[], q: number, r: number, s: n
         id,
         coords,
         bagCount: 0,
+        bagBalances: [],
         biome: BiomeKind.UNDISCOVERED,
         seekers: [],
     };


### PR DESCRIPTION
# What

Bags with zero balance are no longer displayed on the map

![image](https://user-images.githubusercontent.com/51167118/234564758-6098b2c6-982d-4b3c-8b95-ac0f8395760e.png)
![image](https://user-images.githubusercontent.com/51167118/234564975-bc437453-9db1-4867-b3f2-68c53b41e896.png)

# How

Added the field `bagBalances` to the core World query which fetches an array of bag balance sums. In Unity I'm reducing this array to get the total balance for the tile. Bags are only displayed if the balance is above zero.

# Problem

I added the new field by hand to the generated `DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs`
Reason being `typescript-json-schema` still hasn't been updated to support the `satisfies` keyword. The last release of this NPM package was a month ago so I'm still expecting it to support it in the near future. Seemed easier to just insert the new field than do a big find and replace on `core`. Added to that, there was also some other problem where I had to manually allow for null values so the C# code gen stuff needs some actual time thrown at it to:

1. Integrate it properly with the build scripot
2. Define fields that can be null without having to tamper with the generated code

Fixes: #115