### PR TITLE
Intent confirm buttons in sidebar

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ConstructIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ConstructIntent.cs
@@ -102,6 +102,10 @@ public class ConstructIntent : IntentHandler
 
     private void OnTileRightClick(Vector3Int cellPosCube)
     {
+#if UNITY_EDITOR
+#elif UNITY_WEBGL
+        return;
+#endif
         if (!_isActiveIntent)
             return;
     }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/MoveIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/MoveIntent.cs
@@ -131,31 +131,6 @@ public class MoveIntent : IntentHandler
             || GameStateMediator.Instance.gameState.World == null
         )
             return;
-
-        if (isMoving && _path.Count > 0)
-        {
-            Vector3Int cubeMousePos = GridExtensions.GridToCube(
-                MapInteractionManager.CurrentMouseCell
-            );
-            if (TileHelper.IsDiscoveredTile(cubeMousePos))
-            {
-                if (
-                    !spawnedPathHighlights.ContainsKey(cubeMousePos)
-                    && TileHelper.GetTileNeighbours(_path[_path.Count - 1]).Contains(cubeMousePos)
-                )
-                {
-                    TooltipManager.instance.ShowTooltip(
-                        "Right-click to <b>Move</b>\nLeft-click to <b>Add</b>"
-                    );
-                }
-                else if (_path[_path.Count - 1] == cubeMousePos)
-                {
-                    TooltipManager.instance.ShowTooltip(
-                        "Right-click to <b>Move</b>\nLeft-click to <b>Undo</b>"
-                    );
-                }
-            }
-        }
     }
 
     private void OnTileLeftClick(Vector3Int cellCubePos)

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/MoveIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/MoveIntent.cs
@@ -153,6 +153,10 @@ public class MoveIntent : IntentHandler
 
     private void OnTileRightClick(Vector3Int cellCubePos)
     {
+#if UNITY_EDITOR
+#elif UNITY_WEBGL
+        return;
+#endif
         if (isMoving)
         {
             ClosePath(cellCubePos);

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
@@ -119,6 +119,10 @@ public class ScoutIntent : IntentHandler
      */
     private void OnTileRightClick(Vector3Int cellPosCube)
     {
+#if UNITY_EDITOR
+#elif UNITY_WEBGL
+        return;
+#endif
         if (!_isActiveIntent)
             return;
 

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
@@ -141,30 +140,7 @@ public class ScoutIntent : IntentHandler
         GameStateMediator.Instance.SendDeselectAllTilesMsg();
     }
 
-    protected void Update()
-    {
-        if (_isActiveIntent)
-        {
-            Vector3Int cubeMousePos = GridExtensions.GridToCube(
-                MapInteractionManager.CurrentMouseCell
-            );
-            if (IsValidScoutTile(cubeMousePos))
-            {
-                if (IsTileSelected(cubeMousePos))
-                {
-                    TooltipManager.instance.ShowTooltip(
-                        "Right-click to <b>Scout</b>\nLeft-click to <b>Undo</b>"
-                    );
-                }
-                else
-                {
-                    TooltipManager.instance.ShowTooltip(
-                        "Right-click to <b>Scout</b>\nLeft-click to <b>Add</b>"
-                    );
-                }
-            }
-        }
-    }
+    protected void Update() { }
 
     private void RemoveAllHighlights()
     {

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
@@ -119,6 +119,9 @@ public class ScoutIntent : IntentHandler
      */
     private void OnTileRightClick(Vector3Int cellPosCube)
     {
+        if (!_isActiveIntent)
+            return;
+
         // Right click completes the scout. We are lacking a SCOUT_MULTI atm so will just rattle off the txs sequentially
         foreach (var kvp in _spawnedSelectedHighlights)
         {

--- a/frontend/public/tile-scouting.png
+++ b/frontend/public/tile-scouting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef0e7c9ed89608b6a1dee328535ea86c2c840c2080967378fcaf9ba4bbfb5290
+size 11354

--- a/frontend/public/tile-selecting.png
+++ b/frontend/public/tile-selecting.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:907a7de26d88fa97eeaba9c092d6cddb3d8e61276d8f85f27c741de022b0d0f8
+size 10376

--- a/frontend/src/components/organisms/unity-map/index.tsx
+++ b/frontend/src/components/organisms/unity-map/index.tsx
@@ -2,7 +2,7 @@
 
 import { ComponentProps } from '@app/types/component-props';
 import { ActionName, useGameState, usePlayer, useSelection } from '@dawnseekers/core';
-import { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { Unity, useUnityContext } from 'react-unity-webgl';
 import styled from 'styled-components';
 import { styles } from './unity-map.styles';
@@ -61,7 +61,7 @@ export const UnityMap: FunctionComponent<UnityMapProps> = ({ ...otherProps }: Un
     const player = usePlayer();
     const { dispatch } = player || {};
     const game = useGameState();
-    const { selectTiles, selectIntent } = useSelection();
+    const { selectTiles, selectIntent: rawSelectIntent } = useSelection();
     const { unityProvider, sendMessage, addEventListener, removeEventListener, loadingProgression } = useUnityContext({
         loaderUrl: `/ds-unity/Build/ds-unity.loader.js`,
         dataUrl: `/ds-unity/Build/ds-unity.data`,
@@ -96,6 +96,14 @@ export const UnityMap: FunctionComponent<UnityMapProps> = ({ ...otherProps }: Un
         globalLastBlob = newMapBlob;
         globalQueue.push(newMapBlob);
     }
+
+    const selectIntent = useCallback(
+        (intent: string | undefined, tileId?: string) => {
+            selectTiles(tileId ? [tileId] : []);
+            rawSelectIntent(intent);
+        },
+        [selectTiles, rawSelectIntent]
+    );
 
     // -- Event handling
 

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -113,9 +113,6 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
                     </div>
 
                     <div className="tile-actions">
-                        {selectedTiles && selectedTiles.length > 0 && (
-                            <TileCoords className="action" selectedTiles={selectedTiles} />
-                        )}
                         <Building className="action" />
                         {tileSeekers.length > 0 && <SeekerList seekers={tileSeekers} className="action" />}
                         {selectedTile && <TileInventory className="action" tile={selectedTile} title="Bags" />}
@@ -125,6 +122,9 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
                             .map((c) => (
                                 <TileAction key={c.id} component={c} className="action" />
                             ))}
+                        {selectedTiles && selectedTiles.length > 0 && (
+                            <TileCoords className="action" selectedTiles={selectedTiles} />
+                        )}
                     </div>
                 </Fragment>
             )}

--- a/frontend/src/plugins/building/index.tsx
+++ b/frontend/src/plugins/building/index.tsx
@@ -43,7 +43,7 @@ interface MaybeNamedThing {
     } | null;
 }
 
-const ImageConstruct = () => <img src="/tile-construct.png" alt="" className="building-image" />;
+const ImageConstruct = () => <img src="/tile-construct.png" alt="" className="building-image" width="33%" />;
 const ImageAvailable = () => <img src="/tile-grass.png" alt="" className="building-image" />;
 const ImageBuilding = () => <img src="/building-with-flag.png" alt="" className="building-image" />;
 const ImageScouting = () => <img src="/tile-scouting.png" alt="" className="building-image" width="33%" />;
@@ -305,14 +305,21 @@ const Move: FunctionComponent<MoveProps> = ({ selectTiles, selectIntent, selecte
     return (
         <Fragment>
             <h3>Moving</h3>
-            <span className="sub-title">Select a tile to add to your movement path</span>
+            <span className="sub-title">Select a tile to add to path</span>
             <ImageSelecting />
-            <button className="action-button" onClick={move} disabled={!canMove} style={{ opacity: canMove ? 1 : 0.1 }}>
-                Confirm Move
-            </button>
-            <button className="link-button" onClick={clearIntent}>
-                Cancel Move
-            </button>
+            <form>
+                <button
+                    className="action-button"
+                    onClick={move}
+                    disabled={!canMove}
+                    style={{ opacity: canMove ? 1 : 0.1 }}
+                >
+                    Confirm Move
+                </button>
+                <button className="link-button" onClick={clearIntent}>
+                    Cancel Move
+                </button>
+            </form>
         </Fragment>
     );
 };
@@ -364,17 +371,19 @@ const Scout: FunctionComponent<ScoutProps> = ({ selectTiles, selectIntent, selec
             <h3>Scouting</h3>
             <span className="sub-title">{note}</span>
             <ImageScouting />
-            <button
-                className="action-button"
-                onClick={scout}
-                disabled={!canScout}
-                style={{ opacity: canScout ? 1 : 0.1 }}
-            >
-                Confirm Scout
-            </button>
-            <button className="link-button" onClick={clearIntent}>
-                Cancel
-            </button>
+            <form>
+                <button
+                    className="action-button"
+                    onClick={scout}
+                    disabled={!canScout}
+                    style={{ opacity: canScout ? 1 : 0.1 }}
+                >
+                    Confirm Scout
+                </button>
+                <button className="link-button" onClick={clearIntent}>
+                    Cancel Scout
+                </button>
+            </form>
         </Fragment>
     );
 };

--- a/frontend/src/plugins/building/index.tsx
+++ b/frontend/src/plugins/building/index.tsx
@@ -3,6 +3,7 @@ import { TileAction } from '@app/components/organisms/tile-action';
 import { ComponentProps } from '@app/types/component-props';
 import {
     BiomeKind,
+    CogAction,
     ConnectedPlayer,
     SelectedSeekerFragment,
     SelectedTileFragment,
@@ -25,6 +26,12 @@ import { getBuildingEquipSlot, getBuildingId, resourceIds } from '@app/plugins/i
 export interface BuildingProps extends ComponentProps {}
 
 const CONSTRUCT_INTENT = 'construct';
+const MOVE_INTENT = 'move';
+const SCOUT_INTENT = 'scout';
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 const StyledBuilding = styled('div')`
     ${styles}
@@ -39,6 +46,8 @@ interface MaybeNamedThing {
 const ImageConstruct = () => <img src="/tile-construct.png" alt="" className="building-image" />;
 const ImageAvailable = () => <img src="/tile-grass.png" alt="" className="building-image" />;
 const ImageBuilding = () => <img src="/building-with-flag.png" alt="" className="building-image" />;
+const ImageScouting = () => <img src="/tile-scouting.png" alt="" className="building-image" width="33%" />;
+const ImageSelecting = () => <img src="/tile-selecting.png" alt="" className="building-image" width="33%" />;
 
 const byName = (a: MaybeNamedThing, b: MaybeNamedThing) => {
     return a.name && b.name && a.name.value > b.name.value ? 1 : -1;
@@ -104,43 +113,40 @@ const TileUndiscovered: FunctionComponent<unknown> = (_props) => {
     );
 };
 
-const ConstructNoneSelected: FunctionComponent<unknown> = (_props) => {
-    return (
-        <Fragment>
-            <h3>Construct</h3>
-            <span className="sub-title">Choose a tile to construct</span>
-            <ImageConstruct />
-        </Fragment>
-    );
-};
-
-const ConstructMultiSelected: FunctionComponent<unknown> = (_props) => {
-    return (
-        <Fragment>
-            <h3>Construct</h3>
-            <span className="sub-title">Multiple tiles selected, pick a single tile to construct</span>
-            <ImageConstruct />
-        </Fragment>
-    );
-};
-
-const ConstructUndiscovered: FunctionComponent<unknown> = (_props) => {
-    return (
-        <Fragment>
-            <h3>Construct</h3>
-            <span className="sub-title">Can&apos;t construct on an undisocvered tile</span>
-            <ImageConstruct />
-        </Fragment>
-    );
-};
-
-interface ConstructAvailableProps {
-    tile: SelectedTileFragment;
+interface ConstructProps {
+    selectedTiles: SelectedTileFragment[];
     selectIntent: Selector<string | undefined>;
-    player: ConnectedPlayer;
-    seeker: SelectedSeekerFragment;
+    selectTiles: Selector<string[] | undefined>;
+    player?: ConnectedPlayer;
+    seeker?: SelectedSeekerFragment;
 }
-const ConstructAvailable: FunctionComponent<ConstructAvailableProps> = ({ tile, seeker, player, selectIntent }) => {
+const Construct: FunctionComponent<ConstructProps> = ({ selectedTiles, seeker, player, selectIntent }) => {
+    // } else if (selectedTiles.length > 1) {
+    //     return <ConstructMultiSelected />;
+    // } else {
+    //     return <ConstructNoneSelected />;
+    // }
+    // if (!seeker || !seeker.nextLocation || !player) {
+    //     return <ConstructNoSeeker />;
+    // } else if (selectedTile.biome == BiomeKind.UNDISCOVERED) {
+    //     return <ConstructUndiscovered />;
+    // } else if (selectedTile.building) {
+    //     return <ConstructOcupied />;
+    // } else if (getTileDistance(seeker.nextLocation.tile, selectedTile) !== 1) {
+    //     return <ConstructTooFarAway />;
+    const selectedTile = selectedTiles.find(() => true);
+    const selectedTileIsAdjacent =
+        selectedTile && seeker?.nextLocation?.tile
+            ? getTileDistance(selectedTile, seeker.nextLocation.tile) === 1
+            : false;
+    const constructableTile =
+        !!selectedTile?.building ||
+        !selectedTileIsAdjacent ||
+        !selectedTile ||
+        selectedTile.biome !== BiomeKind.DISCOVERED
+            ? undefined
+            : selectedTile;
+    const constructionCoords = constructableTile ? getCoords(constructableTile) : undefined;
     const { addBagRef, removeBagRef } = useInventory();
     const world = useWorld();
     const slotsRef = useRef<HTMLDivElement>(null);
@@ -160,10 +166,25 @@ const ConstructAvailable: FunctionComponent<ConstructAvailableProps> = ({ tile, 
         e.preventDefault();
         const form = new FormData(e.target as any);
         const data = Object.fromEntries(form.entries());
+        if (!player) {
+            return;
+        }
+        if (!seeker) {
+            return;
+        }
+        if (!constructableTile) {
+            return;
+        }
 
         player.dispatch({
             name: 'CONSTRUCT_BUILDING_SEEKER',
-            args: [seeker.id, data.kind, tile.coords[1], tile.coords[2], tile.coords[3]]
+            args: [
+                seeker.id,
+                data.kind,
+                constructableTile.coords[1],
+                constructableTile.coords[2],
+                constructableTile.coords[3]
+            ]
         });
         clearIntent();
     };
@@ -173,14 +194,11 @@ const ConstructAvailable: FunctionComponent<ConstructAvailableProps> = ({ tile, 
         return () => removeBagRef(slotsRef);
     }, [addBagRef, removeBagRef]);
 
-    if (!tile) {
-        return null;
-    }
-
-    const { q, r, s } = getCoords(tile);
-    const buildingId = getBuildingId(q, r, s);
+    const buildingId = constructionCoords
+        ? getBuildingId(constructionCoords.q, constructionCoords.r, constructionCoords.s)
+        : undefined;
     const equipIndex = 0; // we don't have multi bag building recipes
-    const equipSlot = getBuildingEquipSlot(world, buildingId, equipIndex);
+    const equipSlot = buildingId ? getBuildingEquipSlot(world, buildingId, equipIndex) : undefined;
     const recipe = [
         {
             key: 0,
@@ -191,15 +209,22 @@ const ConstructAvailable: FunctionComponent<ConstructAvailableProps> = ({ tile, 
             }
         }
     ];
-    const canConstruct = recipe.every((ingredient, index) => {
-        const bag = equipSlot && equipSlot.bag;
-        return bag && bag.slots[index].balance === ingredient.balance;
-    });
+    const canConstruct =
+        recipe.every((ingredient, index) => {
+            const bag = equipSlot && equipSlot.bag;
+            return bag && bag.slots[index].balance === ingredient.balance;
+        }) && selectedTiles.length > 0;
+
+    const help = selectedTile?.building
+        ? 'Can&apos;t construct on a tile that already has a building on it'
+        : constructableTile
+        ? 'Select what kind of building to construct'
+        : 'Select an adjacent tile to construct on';
 
     return (
         <Fragment>
-            <h3>Construct</h3>
-            <span className="sub-title">Select what kind of building to construct</span>
+            <h3>Constructing</h3>
+            <span className="sub-title">{help}</span>
             <ImageConstruct />
             <form onSubmit={handleConstruct}>
                 <div className="select">
@@ -211,12 +236,13 @@ const ConstructAvailable: FunctionComponent<ConstructAvailableProps> = ({ tile, 
                         ))}
                     </select>
                 </div>
-                <div ref={slotsRef} className="ingredients">
-                    <BuildingInventory buildingId={buildingId} recipe={recipe} />
-                </div>
-                {/*// todo disable the construct button if we don't have resources */}
+                {buildingId && (
+                    <div ref={slotsRef} className="ingredients">
+                        <BuildingInventory buildingId={buildingId} recipe={recipe} />
+                    </div>
+                )}
                 <button className="action-button" type="submit" disabled={!canConstruct}>
-                    Construct It!
+                    Confirm Construction
                 </button>
                 <button className="link-button" onClick={clearIntent}>
                     Cancel Construction
@@ -226,70 +252,170 @@ const ConstructAvailable: FunctionComponent<ConstructAvailableProps> = ({ tile, 
     );
 };
 
-const ConstructOcupied: FunctionComponent<unknown> = (_props) => {
+interface MoveProps {
+    selectedTiles: SelectedTileFragment[];
+    selectIntent: Selector<string | undefined>;
+    selectTiles: Selector<string[] | undefined>;
+    player?: ConnectedPlayer;
+    seeker?: SelectedSeekerFragment;
+}
+const Move: FunctionComponent<MoveProps> = ({ selectTiles, selectIntent, selectedTiles, player, seeker }) => {
+    const moveableTiles = selectedTiles
+        .filter((t) => t.biome === BiomeKind.DISCOVERED)
+        .filter((t, idx) => (idx === 0 ? t.id !== seeker?.nextLocation?.tile?.id : true)); // map include the start tile in selection, ignore it
+    const move = () => {
+        if (!player) {
+            return;
+        }
+        if (!seeker) {
+            return;
+        }
+        if (moveableTiles.length < 1) {
+            return;
+        }
+        const actions = moveableTiles.map((tile): CogAction => {
+            const [_zone, q, r, s] = tile.coords;
+            return {
+                name: 'MOVE_SEEKER',
+                args: [seeker.key, q, r, s]
+            };
+        });
+        actions.reduce(
+            (chain, action) => chain.then(() => player.dispatch(action)).then(() => sleep(5000)),
+            Promise.resolve()
+        );
+        if (selectIntent) {
+            selectIntent(undefined);
+        }
+        if (selectTiles) {
+            selectTiles([]);
+        }
+    };
+    const canMove = seeker && player && moveableTiles.length > 0;
+    const clearIntent = useCallback(
+        (e?: React.MouseEvent) => {
+            if (e) {
+                e.preventDefault();
+            }
+            selectIntent(undefined);
+            selectTiles([]);
+        },
+        [selectIntent, selectTiles]
+    );
     return (
         <Fragment>
-            <h3>Construct</h3>
-            <span className="sub-title">Can&apos;t construct on a tile that already has a building on it</span>
-            <ImageConstruct />
+            <h3>Moving</h3>
+            <span className="sub-title">Select a tile to add to your movement path</span>
+            <ImageSelecting />
+            <button className="action-button" onClick={move} disabled={!canMove} style={{ opacity: canMove ? 1 : 0.1 }}>
+                Confirm Move
+            </button>
+            <a href="#cancel" className="secondary-button" onClick={clearIntent}>
+                Cancel
+            </a>
         </Fragment>
     );
 };
-
-const ConstructNoSeeker: FunctionComponent<unknown> = (_props) => {
-    return (
-        <Fragment>
-            <h3>Construct</h3>
-            <span className="sub-title">Must have a seeker selected</span>
-            <ImageConstruct />
-        </Fragment>
+interface ScoutProps {
+    selectedTiles: SelectedTileFragment[];
+    selectIntent: Selector<string | undefined>;
+    selectTiles: Selector<string[] | undefined>;
+    player?: ConnectedPlayer;
+    seeker?: SelectedSeekerFragment;
+}
+const Scout: FunctionComponent<ScoutProps> = ({ selectTiles, selectIntent, selectedTiles, player, seeker }) => {
+    const scoutableTiles = selectedTiles.filter((t) => t.biome === BiomeKind.UNDISCOVERED);
+    const scout = () => {
+        if (!player) {
+            return;
+        }
+        if (!seeker) {
+            return;
+        }
+        const actions = scoutableTiles.map((tile): CogAction => {
+            const [_zone, q, r, s] = tile.coords;
+            return {
+                name: 'SCOUT_SEEKER',
+                args: [seeker.key, q, r, s]
+            };
+        });
+        player.dispatch(...actions);
+        if (selectIntent) {
+            selectIntent(undefined);
+        }
+        if (selectTiles) {
+            selectTiles([]);
+        }
+    };
+    const clearIntent = useCallback(
+        (e?: React.MouseEvent) => {
+            if (e) {
+                e.preventDefault();
+            }
+            selectIntent(undefined);
+            selectTiles([]);
+        },
+        [selectIntent, selectTiles]
     );
-};
-
-const ConstructTooFarAway: FunctionComponent<unknown> = (_props) => {
+    const canScout = seeker && player && scoutableTiles.length > 0;
+    const note = canScout ? 'Click scout to reveal selected tiles' : 'Select tiles you want to reveal';
     return (
         <Fragment>
-            <h3>Construct</h3>
-            <span className="sub-title">Select an adjacent tile to start construction</span>
-            <ImageConstruct />
+            <h3>Scouting</h3>
+            <span className="sub-title">{note}</span>
+            <ImageScouting />
+            <button
+                className="action-button"
+                onClick={scout}
+                disabled={!canScout}
+                style={{ opacity: canScout ? 1 : 0.1 }}
+            >
+                Confirm Scout
+            </button>
+            <a href="#cancel" className="secondary-button" onClick={clearIntent} style={{ opacity: 0.5 }}>
+                Cancel
+            </a>
         </Fragment>
     );
 };
 
 export const Building: FunctionComponent<BuildingProps> = ({ ...otherProps }) => {
-    const { selectIntent, intent, tiles, seeker } = useSelection();
+    const { selectIntent, intent, tiles, seeker, selectTiles } = useSelection();
     const player = usePlayer();
 
     const selectedTiles = tiles || [];
 
     const content = (() => {
         if (intent === CONSTRUCT_INTENT) {
-            // design says these states should be in a pop-out UI, inline until we have that UI
-            if (selectedTiles.length === 1) {
-                const selectedTile = selectedTiles[0];
-                if (!seeker || !seeker.nextLocation || !player) {
-                    return <ConstructNoSeeker />;
-                } else if (selectedTile.biome == BiomeKind.UNDISCOVERED) {
-                    return <ConstructUndiscovered />;
-                } else if (selectedTile.building) {
-                    return <ConstructOcupied />;
-                } else if (getTileDistance(seeker.nextLocation.tile, selectedTile) !== 1) {
-                    return <ConstructTooFarAway />;
-                } else {
-                    return (
-                        <ConstructAvailable
-                            selectIntent={selectIntent}
-                            tile={selectedTile}
-                            seeker={seeker}
-                            player={player}
-                        />
-                    );
-                }
-            } else if (selectedTiles.length > 1) {
-                return <ConstructMultiSelected />;
-            } else {
-                return <ConstructNoneSelected />;
-            }
+            return (
+                <Construct
+                    selectIntent={selectIntent}
+                    selectedTiles={selectedTiles}
+                    selectTiles={selectTiles}
+                    seeker={seeker}
+                    player={player}
+                />
+            );
+        } else if (intent === MOVE_INTENT) {
+            return (
+                <Move
+                    selectIntent={selectIntent}
+                    selectedTiles={selectedTiles}
+                    selectTiles={selectTiles}
+                    seeker={seeker}
+                    player={player}
+                />
+            );
+        } else if (intent === SCOUT_INTENT) {
+            return (
+                <Scout
+                    selectIntent={selectIntent}
+                    selectedTiles={selectedTiles}
+                    selectTiles={selectTiles}
+                    seeker={seeker}
+                    player={player}
+                />
+            );
         } else {
             if (selectedTiles.length === 1) {
                 const selectedTile = selectedTiles[0];

--- a/frontend/src/plugins/building/index.tsx
+++ b/frontend/src/plugins/building/index.tsx
@@ -310,9 +310,9 @@ const Move: FunctionComponent<MoveProps> = ({ selectTiles, selectIntent, selecte
             <button className="action-button" onClick={move} disabled={!canMove} style={{ opacity: canMove ? 1 : 0.1 }}>
                 Confirm Move
             </button>
-            <a href="#cancel" className="secondary-button" onClick={clearIntent}>
-                Cancel
-            </a>
+            <button className="link-button" onClick={clearIntent}>
+                Cancel Move
+            </button>
         </Fragment>
     );
 };
@@ -372,9 +372,9 @@ const Scout: FunctionComponent<ScoutProps> = ({ selectTiles, selectIntent, selec
             >
                 Confirm Scout
             </button>
-            <a href="#cancel" className="secondary-button" onClick={clearIntent} style={{ opacity: 0.5 }}>
+            <button className="link-button" onClick={clearIntent}>
                 Cancel
-            </a>
+            </button>
         </Fragment>
     );
 };


### PR DESCRIPTION
## What

* Adds the sidebar buttons for "Confirm Move", "Confirm Scout" ...consistent with "Confirm Construction"
* Buttons are visible but disabled while intent is active ... enabled when valid
* Intents/selection cleared on confirm
* Removes the tooltip about "right-clicking" since right-click is disabled 
* Fixes issue where map does move + scout at same time for some reason

## Related

resolves: #104 
resolves: #123 
resolves: #127 
resolves: #144 
closes: #145 as tooltip removed
closes: #67 as tooltip removed
