### PR TITLE
Only select tiles when not dragging

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/CameraController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/CameraController.cs
@@ -14,6 +14,10 @@ public class CameraController : MonoBehaviour
     private float prevDirection = -100;
     private Vector3 mouseDownPos;
     private Vector3 camMouseDownPos;
+    private float _dragThreshold = 0.1f;
+
+    [HideInInspector]
+    public bool hasDragged = false;
 
     void Start()
     {
@@ -32,6 +36,7 @@ public class CameraController : MonoBehaviour
         {
             mouseDownPos = Input.mousePosition;
             camMouseDownPos = transform.position;
+            hasDragged = false;
         }
         if (Input.GetMouseButton(0))
         {
@@ -46,6 +51,10 @@ public class CameraController : MonoBehaviour
                 mouseDownRay.GetPoint(mouseDownDist) - currentMouseRay.GetPoint(currentMouseDist)
             );
             transform.position = camMouseDownPos + offset;
+            if (Vector3.Distance(camMouseDownPos, camMouseDownPos + offset) > _dragThreshold)
+            {
+                hasDragged = true;
+            }
         }
     }
 

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
@@ -26,11 +26,14 @@ public class MapInteractionManager : MonoBehaviour
     [SerializeField]
     private GameObject _intentContainerGO;
 
+    private CameraController _camController;
+
     bool mapReady = false;
 
     private void Awake()
     {
         instance = this;
+        _camController = Camera.main.GetComponent<CameraController>();
     }
 
     private void Start()
@@ -64,9 +67,10 @@ public class MapInteractionManager : MonoBehaviour
         }
         if (EventSystem.current.IsPointerOverGameObject())
             return;
-        if (Input.GetMouseButtonDown(0))
+        if (Input.GetMouseButtonUp(0))
         {
-            MapClicked();
+            if (!_camController.hasDragged)
+                MapClicked();
         }
 
         if (Input.GetMouseButtonDown(1))


### PR DESCRIPTION
This PR adds a check to only pass a select event if the user hasn't dragged the camera.
As a result it also changes the interaction from an OnMouseDown to an OnMouseUp event.