### PR TITLE
hide tile selection if nothing selected

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
@@ -153,5 +153,9 @@ public class MapInteractionManager : MonoBehaviour
 
             selectedMarker1.gameObject.SetActive(true);
         }
+        else
+        {
+            selectedMarker1.gameObject.SetActive(false);
+        }
     }
 }


### PR DESCRIPTION
fixes issue where the map and shell get out of sync because map wasn't removing the selected tile state when selectTiles(undefined) or selectTiles([])