### PR TITLE
player account switching improvements

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
@@ -137,7 +137,15 @@ public class MapInteractionManager : MonoBehaviour
     private void OnStateUpdated(GameState state)
     {
         mapReady = true;
-        if (state.Selected.Tiles != null && state.Selected.Tiles.Count > 0)
+        if (
+            IntentManager.Instance.IsHandledIntent(
+                GameStateMediator.Instance.gameState.Selected.Intent
+            )
+        )
+        {
+            selectedMarker1.gameObject.SetActive(false);
+        }
+        else if (state.Selected.Tiles != null && state.Selected.Tiles.Count > 0)
         {
             var tile = state.Selected.Tiles.First();
             var cellPosCube = TileHelper.GetTilePosCube(tile);

--- a/core/src/wallet.ts
+++ b/core/src/wallet.ts
@@ -9,7 +9,7 @@ export function makeBrowserWallet(): Source<Wallet | undefined> {
     const { accounts, fetchAccounts } = newBrowserAccountSource();
     let prev: string | undefined;
     return pipe(
-        concat([fromPromise(fetchAccounts().catch(() => prev)), accounts]),
+        lazy(() => concat([fromPromise(fetchAccounts().catch(() => prev)), accounts])),
         tap((address) => (prev = address)),
         map((address) =>
             address

--- a/frontend/src/plugins/building/index.tsx
+++ b/frontend/src/plugins/building/index.tsx
@@ -310,6 +310,7 @@ const Move: FunctionComponent<MoveProps> = ({ selectTiles, selectIntent, selecte
             <form>
                 <button
                     className="action-button"
+                    type="button"
                     onClick={move}
                     disabled={!canMove}
                     style={{ opacity: canMove ? 1 : 0.1 }}
@@ -374,6 +375,7 @@ const Scout: FunctionComponent<ScoutProps> = ({ selectTiles, selectIntent, selec
             <form>
                 <button
                     className="action-button"
+                    type="button"
                     onClick={scout}
                     disabled={!canScout}
                     style={{ opacity: canScout ? 1 : 0.1 }}


### PR DESCRIPTION
## what

a few tweaks related to account switching and immediately after a new wallet connect.... 

* redraw all map seekers when account switching (fixes issue losing the red icon when switching)
* use lazy wallet source to avoid sharing promise (fixes race condition on connect/switch account)
* hide tile selection when active intent (fixes inconsistent tile highlight when picking tiles)
* use type=button to avoid form warning (fixes a console warning)

## demo

using seekers after account switch...

https://user-images.githubusercontent.com/45921/234769228-b4b7fcd9-c03e-428c-a63c-b155553e3e54.mov

showing construction working immediately after wallet connect...

https://user-images.githubusercontent.com/45921/234769570-cd3fcee0-d0f0-42a9-a0a2-d00e3a08631b.mov


## related

fixes: #130 