### PR TITLE
Rotate the map

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Addressables/EnvironmentPrefabs/HexTile/Tile.prefab
+++ b/DawnSeekersUnity/Assets/Map/Addressables/EnvironmentPrefabs/HexTile/Tile.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8808793146209390760}
-  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -32,7 +32,7 @@ Transform:
   - {fileID: 8464072377590378335}
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &-3611125150982830747
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Prefabs/GreenHighlight.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/GreenHighlight.prefab
@@ -24,14 +24,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9133061235819889254}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!212 &3319977055583762012
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapCamera.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapCamera.prefab
@@ -60,15 +60,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6518314203346260197}
-  m_LocalRotation: {x: -0.258819, y: -0, z: -0, w: 0.9659259}
-  m_LocalPosition: {x: 0, y: -4.9999995, z: -8.6602545}
+  m_LocalRotation: {x: 0.5, y: 0, z: 0, w: 0.8660254}
+  m_LocalPosition: {x: 0, y: 8.660254, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6518314205033195296}
   m_Father: {fileID: 175672473536720282}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: -30, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 60, y: 0, z: 0}
 --- !u!114 &6518314203346260196
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -183,8 +183,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6518314203603543956}
-  m_LocalRotation: {x: -0.258819, y: -0, z: -0, w: 0.9659259}
-  m_LocalPosition: {x: 0, y: -4.9999995, z: -8.6602545}
+  m_LocalRotation: {x: 0.5, y: -0, z: -0, w: 0.8660254}
+  m_LocalPosition: {x: 0, y: 8.660254, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -359,14 +359,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6518314203803930000}
-  m_LocalRotation: {x: -0.70710576, y: -0, z: -0, w: 0.7071079}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 175672473536720282}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6518314204067571691
 GameObject:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BagMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BagMapElement.prefab
@@ -15,17 +15,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -0.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BagMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BagMapElement.prefab
@@ -30,27 +30,27 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.000000005808044
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.000000014881773
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.70710677
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7071069
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 90
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f50906aea88c91441a88b2c0396f5117,
         type: 3}

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BuildingMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BuildingMapElement.prefab
@@ -30,12 +30,12 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: db038f6e69b403e498a8bd24c3235fb1,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db038f6e69b403e498a8bd24c3235fb1,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db038f6e69b403e498a8bd24c3235fb1,
         type: 3}
@@ -50,7 +50,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: db038f6e69b403e498a8bd24c3235fb1,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: db038f6e69b403e498a8bd24c3235fb1,
         type: 3}
@@ -109,27 +109,27 @@ PrefabInstance:
     - target: {fileID: 4011681257798519416, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.00000035762784
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4011681257798519416, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4011681257798519416, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 4011681257798519416, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4011681257798519416, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 4011681257798519416, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/PlayerMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/PlayerMapElement.prefab
@@ -17,6 +17,16 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 4200293388350177078, guid: 87b00e9807c374871b1cd063b867ba6e,
         type: 3}
+    - target: {fileID: 4011681257694613555, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 4011681257694613555, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4011681257798519416, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}
       propertyPath: m_RootOrder
@@ -227,27 +237,27 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: ed67c054313d2594abada4044bb38698,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ed67c054313d2594abada4044bb38698,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ed67c054313d2594abada4044bb38698,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ed67c054313d2594abada4044bb38698,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ed67c054313d2594abada4044bb38698,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: ed67c054313d2594abada4044bb38698,
         type: 3}

--- a/DawnSeekersUnity/Assets/Map/Prefabs/OrangeHighlight.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/OrangeHighlight.prefab
@@ -24,14 +24,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9133061235819889254}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!212 &3319977055583762012
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Prefabs/UI/SeekerActionMenu.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/UI/SeekerActionMenu.prefab
@@ -152,7 +152,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2476847599759415504}
-  m_LocalRotation: {x: -0.258819, y: 0, z: 0, w: 0.9659259}
+  m_LocalRotation: {x: 0.5, y: 0, z: 0, w: 0.8660254}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.005, y: 0.005, z: 0.005}
   m_ConstrainProportionsScale: 0
@@ -160,7 +160,7 @@ RectTransform:
   - {fileID: 2476847598666213357}
   m_Father: {fileID: 2476847598487868881}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -30, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 60, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}

--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -1705,14 +1705,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 834498989}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: -1.58, z: 0}
   m_LocalScale: {x: 0.95, y: 0.95, z: 0.95}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &876533704
 GameObject:
   m_ObjectHideFlags: 0
@@ -1894,7 +1894,7 @@ Grid:
   m_CellSize: {x: 0.8659766, y: 1, z: 0.01}
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 1
-  m_CellSwizzle: 0
+  m_CellSwizzle: 1
 --- !u!4 &913983448
 Transform:
   m_ObjectHideFlags: 0
@@ -1929,7 +1929,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!64 &1049267803
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -2384,14 +2384,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1333271654}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &1348261811
 GameObject:
   m_ObjectHideFlags: 0
@@ -2710,12 +2710,12 @@ PrefabInstance:
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
@@ -2730,7 +2730,7 @@ PrefabInstance:
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
@@ -2747,6 +2747,16 @@ PrefabInstance:
       propertyPath: target
       value: 
       objectReference: {fileID: 681872498}
+    - target: {fileID: 4814635802840031563, guid: e06645b593db042baa70468de29d36c6,
+        type: 3}
+      propertyPath: positionMask.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4814635802840031563, guid: e06645b593db042baa70468de29d36c6,
+        type: 3}
+      propertyPath: positionMask.z
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e06645b593db042baa70468de29d36c6, type: 3}
 --- !u!1001 &6406227089419367163
@@ -2884,6 +2894,86 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: MapCamera
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.660254
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.660254
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8660254
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13c17ec3607f94f34a8d6fc7cf4300af, type: 3}

--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -2895,86 +2895,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: MapCamera
       objectReference: {fileID: 0}
-    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 8.660254
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.8660254
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 8.660254
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.8660254
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203803930007, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13c17ec3607f94f34a8d6fc7cf4300af, type: 3}
 --- !u!1001 &7103627627158448603
@@ -3007,12 +2927,12 @@ PrefabInstance:
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}
@@ -3027,7 +2947,7 @@ PrefabInstance:
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}

--- a/DawnSeekersUnity/Assets/Map/Scenes/MockMapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MockMapScene.unity
@@ -144,37 +144,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.5
+      value: -0.35110238
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: -0.77590704
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -354,37 +354,37 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: be6d2b64e56439f40b7637907fe5bfab,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.75
+      value: -0.024670273
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: be6d2b64e56439f40b7637907fe5bfab,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.023572922
+      value: 1.4740922
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: be6d2b64e56439f40b7637907fe5bfab,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: be6d2b64e56439f40b7637907fe5bfab,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: be6d2b64e56439f40b7637907fe5bfab,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: be6d2b64e56439f40b7637907fe5bfab,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: be6d2b64e56439f40b7637907fe5bfab,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: be6d2b64e56439f40b7637907fe5bfab,
         type: 3}
@@ -467,37 +467,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.35109565
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: 2.224093
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -542,37 +542,37 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 07f42a4edcf229e4e992373c6b61f371,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.75
+      value: -0.024673551
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f42a4edcf229e4e992373c6b61f371,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.023572922
+      value: -0.025907695
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f42a4edcf229e4e992373c6b61f371,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f42a4edcf229e4e992373c6b61f371,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f42a4edcf229e4e992373c6b61f371,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f42a4edcf229e4e992373c6b61f371,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f42a4edcf229e4e992373c6b61f371,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f42a4edcf229e4e992373c6b61f371,
         type: 3}
@@ -621,37 +621,17 @@ PrefabInstance:
     - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.033735484
       objectReference: {fileID: 0}
     - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.03263654
-      objectReference: {fileID: 0}
-    - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
+      value: 0.72409236
       objectReference: {fileID: 0}
     - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
         type: 3}
@@ -685,37 +665,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.033735484
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.032636523
+      value: 0.72409236
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -810,37 +790,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.75
+      value: -0.024670273
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.023572922
+      value: 1.4740922
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -997,42 +977,42 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.7319531
+      value: -1.731953
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.35109895
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: 0.7240931
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -1077,37 +1057,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.5
+      value: -0.35110238
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: -0.77590704
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -1152,37 +1132,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.75
+      value: -0.024670273
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.023572922
+      value: 1.4740922
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -1227,37 +1207,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.5
+      value: -0.35110238
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: -0.77590704
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -1588,42 +1568,42 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.5979297
+      value: 2.5979295
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.35109895
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: 0.7240931
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -1724,14 +1704,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 834498989}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.01, z: 0}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0.428, y: -0.01, z: 0}
   m_LocalScale: {x: 0.95, y: 0.95, z: 0.95}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1001 &836393474
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1752,37 +1732,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.5
+      value: -0.35110238
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: -0.77590704
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -1832,37 +1812,17 @@ PrefabInstance:
     - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.75
+      value: 0.31287387
       objectReference: {fileID: 0}
     - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.06397462
-      objectReference: {fileID: 0}
-    - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0.27590787
       objectReference: {fileID: 0}
     - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
         type: 3}
@@ -2042,37 +2002,37 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 53f89809609981f42b57d86b7a6a254b,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.0048789084
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 53f89809609981f42b57d86b7a6a254b,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.005977869
+      value: 0.72409225
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 53f89809609981f42b57d86b7a6a254b,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 53f89809609981f42b57d86b7a6a254b,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 53f89809609981f42b57d86b7a6a254b,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 53f89809609981f42b57d86b7a6a254b,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 53f89809609981f42b57d86b7a6a254b,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 53f89809609981f42b57d86b7a6a254b,
         type: 3}
@@ -2116,37 +2076,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.75
+      value: -0.3511006
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: -0.0259071
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -2189,7 +2149,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!64 &1049267803
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -2289,37 +2249,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.75
+      value: -0.35109726
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: 1.4740931
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -2449,37 +2409,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.053000003
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.051901102
+      value: 0.7240924
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -2752,37 +2712,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.75
+      value: -0.024673551
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.023572922
+      value: -0.025907695
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -2832,37 +2792,17 @@ PrefabInstance:
     - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.197
       objectReference: {fileID: 0}
     - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.051901102
-      objectReference: {fileID: 0}
-    - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
+      value: 0.47409242
       objectReference: {fileID: 0}
     - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 8776346270060902167, guid: a2154e623a0a249b0aa3f222d4d27e10,
         type: 3}
@@ -2896,37 +2836,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.35109565
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: 2.224093
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -2976,37 +2916,17 @@ PrefabInstance:
     - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.053000003
       objectReference: {fileID: 0}
     - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.051901117
-      objectReference: {fileID: 0}
-    - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
+      value: 0.7240924
       objectReference: {fileID: 0}
     - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 8730588450062426087, guid: 3f49ef0e27bad4b61b190f7d800dfea9,
         type: 3}
@@ -3040,37 +2960,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.75
+      value: -0.024673551
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.023572922
+      value: -0.025907695
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3115,37 +3035,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.0048789084
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.005977869
+      value: 0.72409225
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3195,37 +3115,17 @@ PrefabInstance:
     - target: {fileID: 7268972726147497455, guid: d0e9e485dc776404cace2c21ae6830ca,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.75
+      value: -0.024670273
       objectReference: {fileID: 0}
     - target: {fileID: 7268972726147497455, guid: d0e9e485dc776404cace2c21ae6830ca,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.023572922
-      objectReference: {fileID: 0}
-    - target: {fileID: 7268972726147497455, guid: d0e9e485dc776404cace2c21ae6830ca,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7268972726147497455, guid: d0e9e485dc776404cace2c21ae6830ca,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7268972726147497455, guid: d0e9e485dc776404cace2c21ae6830ca,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7268972726147497455, guid: d0e9e485dc776404cace2c21ae6830ca,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 1
+      value: 1.4740922
       objectReference: {fileID: 0}
     - target: {fileID: 7268972726147497455, guid: d0e9e485dc776404cace2c21ae6830ca,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 7268972726147497455, guid: d0e9e485dc776404cace2c21ae6830ca,
         type: 3}
@@ -3259,37 +3159,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.75
+      value: 0.06287739
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.06397462
+      value: 1.4740921
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3334,37 +3234,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.35109565
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: 2.224093
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3409,37 +3309,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.053000003
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.051901102
+      value: 0.7240924
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3484,22 +3384,22 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: -0.35109565
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: 2.224093
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3514,7 +3414,7 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3559,37 +3459,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.75
+      value: 0.06287387
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.06397462
+      value: -0.025907874
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3634,37 +3534,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.75
+      value: -0.3511006
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: -0.0259071
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3709,37 +3609,37 @@ PrefabInstance:
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.75
+      value: -0.35109726
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.35000002
+      value: 1.4740931
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.0000014603138
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2265421376858709839, guid: 7983d528686114d8cb4fbc979e031ef0,
         type: 3}
@@ -3799,12 +3699,12 @@ PrefabInstance:
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
@@ -3819,7 +3719,7 @@ PrefabInstance:
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
@@ -3836,6 +3736,16 @@ PrefabInstance:
       propertyPath: target
       value: 
       objectReference: {fileID: 681872498}
+    - target: {fileID: 4814635802840031563, guid: e06645b593db042baa70468de29d36c6,
+        type: 3}
+      propertyPath: positionMask.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4814635802840031563, guid: e06645b593db042baa70468de29d36c6,
+        type: 3}
+      propertyPath: positionMask.z
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e06645b593db042baa70468de29d36c6, type: 3}
 --- !u!1001 &6518314204280695803
@@ -3937,12 +3847,12 @@ PrefabInstance:
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}
@@ -3957,7 +3867,7 @@ PrefabInstance:
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 646957063094719393, guid: 8711978a6989a44e69ebe8a5a40fa057,
         type: 3}

--- a/DawnSeekersUnity/Assets/Map/Scripts/Addressables/EnvironmentLoaderManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Addressables/EnvironmentLoaderManager.cs
@@ -70,7 +70,7 @@ public class EnvironmentLoaderManager : MonoBehaviour
     {
         Transform tile = Instantiate(_tilePrefab, tileContainer).transform;
         tile.name = "Tile_" + cellCubicCoords.ToString();
-        tile.position = new Vector3(position.x, position.y, 1);
+        tile.position = new Vector3(position.x, -1, position.z);
         return tile.GetComponent<TileController>();
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Environment/MapHeightManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Environment/MapHeightManager.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class MapHeightManager : MonoBehaviour
 {
     public static MapHeightManager instance;
-    public const float UNSCOUTED_HEIGHT = 0.35f;
+    public const float UNSCOUTED_HEIGHT = -0.35f;
 
     [SerializeField]
     float heightScale = 1;
@@ -37,7 +37,7 @@ public class MapHeightManager : MonoBehaviour
     {
         return heightOffset
             + (
-                Mathf.PerlinNoise(position.x * heightFrequency, position.y * heightFrequency)
+                Mathf.PerlinNoise(position.x * heightFrequency, position.z * heightFrequency)
                 * heightScale
             );
     }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Environment/TileController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Environment/TileController.cs
@@ -29,8 +29,8 @@ public class TileController : MonoBehaviour
         Vector3 startPos = transform.position;
         Vector3 endPos = new Vector3(
             transform.position.x,
-            transform.position.y,
-            MapHeightManager.instance.GetHeightAtPosition(transform.position)
+            MapHeightManager.instance.GetHeightAtPosition(transform.position),
+            transform.position.z
         );
         yield return new WaitForSeconds(delay);
         while (t < 1)
@@ -44,7 +44,7 @@ public class TileController : MonoBehaviour
 
     public void Appear()
     {
-        transform.position = new Vector3(transform.position.x, transform.position.y, 1);
+        transform.position = new Vector3(transform.position.x, -1, transform.position.z);
         delayCount++;
         delay += 0.05f;
         StartCoroutine(AppearCR());
@@ -53,11 +53,11 @@ public class TileController : MonoBehaviour
     IEnumerator AppearCR()
     {
         float t = 0;
-        Vector3 startPos = new Vector3(transform.position.x, transform.position.y, 1);
+        Vector3 startPos = new Vector3(transform.position.x, -1, transform.position.z);
         Vector3 endPos = new Vector3(
             transform.position.x,
-            transform.position.y,
-            MapHeightManager.UNSCOUTED_HEIGHT
+            MapHeightManager.UNSCOUTED_HEIGHT,
+            transform.position.z
         );
         yield return new WaitForSeconds(delay);
         while (t < 1)

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/CameraController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/CameraController.cs
@@ -40,7 +40,7 @@ public class CameraController : MonoBehaviour
     void Start()
     {
         mainCamera = Camera.main;
-        m_Plane = new Plane(Vector3.forward, 0);
+        m_Plane = new Plane(Vector3.up, 0);
     }
 
     void Update()
@@ -91,9 +91,9 @@ public class CameraController : MonoBehaviour
         }
 
         HandleMouseCameraDrag();
-        float speed = moveSpeed * Mathf.Abs(mainCamera.transform.position.z);
+        float speed = moveSpeed * Mathf.Abs(mainCamera.transform.position.y);
         Vector3 inputVector =
-            new Vector3(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"), 0)
+            new Vector3(Input.GetAxis("Horizontal"), 0, Input.GetAxis("Vertical"))
             * speed
             * Time.deltaTime;
         target.position += inputVector;

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/IconController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/IconController.cs
@@ -34,7 +34,7 @@ public class IconController : MonoBehaviour
     {
         transform.position =
             _iconParent.position
-            + (Vector3.forward * -iconHeightOffset)
+            + (Vector3.up * -iconHeightOffset)
             + (Vector3.right * _iconHOffset);
         transform.rotation = _camTrans.rotation;
     }

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementController.cs
@@ -18,7 +18,7 @@ public class MapElementController : MonoBehaviour
         Vector3 pos = MapManager.instance.grid.CellToWorld(GridExtensions.CubeToGrid(cell));
         float height = MapHeightManager.instance.GetHeightAtPosition(pos);
         _currentPosition = pos;
-        _currentPosition = new Vector3(_currentPosition.x, _currentPosition.y, height);
+        _currentPosition = new Vector3(_currentPosition.x, height, _currentPosition.z);
         transform.position = _currentPosition;
 
         _icon = MapElementManager.instance.CreateIcon(iconParent, iconPrefab);

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
@@ -53,6 +53,7 @@ public class MapInteractionManager : MonoBehaviour
 
         if (Physics.Raycast(ray, out hit))
         {
+            Debug.Log(hit.transform.name);
             //Get the point that is clicked
             Vector3 hitPoint = hit.point;
             Vector3Int cubePos = GridExtensions.GridToCube(
@@ -63,7 +64,7 @@ public class MapInteractionManager : MonoBehaviour
             float height = MapHeightManager.UNSCOUTED_HEIGHT;
             if (TileHelper.IsDiscoveredTile(cubePos))
                 height = MapHeightManager.instance.GetHeightAtPosition(cursorPos);
-            cursor.position = new Vector3(cursorPos.x, cursorPos.y, height);
+            cursor.position = new Vector3(cursorPos.x, height, cursorPos.z);
         }
         if (EventSystem.current.IsPointerOverGameObject())
             return;
@@ -157,7 +158,7 @@ public class MapInteractionManager : MonoBehaviour
             float height = MapHeightManager.UNSCOUTED_HEIGHT;
             if (TileHelper.IsDiscoveredTile(cellPosCube))
                 height = MapHeightManager.instance.GetHeightAtPosition(markerPos);
-            selectedMarker1.position = new Vector3(markerPos.x, markerPos.y, height);
+            selectedMarker1.position = new Vector3(markerPos.x, height, markerPos.z);
 
             selectedMarker1.gameObject.SetActive(true);
         }

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/SeekerController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/SeekerController.cs
@@ -35,7 +35,7 @@ public class SeekerController : MapElementController
         Vector3 pos = MapManager.instance.grid.CellToWorld(GridExtensions.CubeToGrid(cell));
         float height = MapHeightManager.instance.GetHeightAtPosition(pos);
         _currentPosition = pos + offset;
-        _currentPosition = new Vector3(_currentPosition.x, _currentPosition.y, height);
+        _currentPosition = new Vector3(_currentPosition.x, height, _currentPosition.z);
         transform.position = _currentPosition;
 
         // Prepare icon:
@@ -74,7 +74,7 @@ public class SeekerController : MapElementController
         );
         float height = MapHeightManager.instance.GetHeightAtPosition(serverPosition);
         serverPosition += offset;
-        serverPosition = new Vector3(serverPosition.x, serverPosition.y, height);
+        serverPosition = new Vector3(serverPosition.x, height, serverPosition.z);
         if (serverPosition != _currentPosition)
         {
             _currentPosition = serverPosition;
@@ -100,8 +100,8 @@ public class SeekerController : MapElementController
             t += Time.deltaTime;
             transform.position = Vector3.Lerp(startPos, endPos, _moveCurve.Evaluate(t));
             transform.position = Vector3.Lerp(
-                new Vector3(transform.position.x, transform.position.y, endPos.z),
-                new Vector3(transform.position.x, transform.position.y, endPos.z - 0.5f),
+                new Vector3(transform.position.x, endPos.y, transform.position.z),
+                new Vector3(transform.position.x, endPos.y + 0.5f, transform.position.z),
                 _jumpCurve.Evaluate(t)
             );
             yield return null;

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/SeekerController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/SeekerController.cs
@@ -86,7 +86,7 @@ public class SeekerController : MapElementController
     {
         Vector3 offset = Vector3.zero;
         if (isElementAtPosition > 0)
-            offset = Vector3.zero + (Vector3.down * _offsetRadius);
+            offset = Vector3.zero + (Vector3.back * _offsetRadius);
 
         return offset;
     }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ConstructIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ConstructIntent.cs
@@ -194,8 +194,8 @@ public class ConstructIntent : IntentHandler
                 );
                 highlight.transform.position = new Vector3(
                     cellPos.x,
-                    cellPos.y,
-                    MapHeightManager.instance.GetHeightAtPosition(cellPos)
+                    MapHeightManager.instance.GetHeightAtPosition(cellPos),
+                    cellPos.z
                 );
                 spawnedHighlights.Add(cellPosCube, highlight);
             }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/MoveIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/MoveIntent.cs
@@ -210,8 +210,8 @@ public class MoveIntent : IntentHandler
                 );
                 highlight.transform.position = new Vector3(
                     cellPos.x,
-                    cellPos.y,
-                    MapHeightManager.instance.GetHeightAtPosition(cellPos)
+                    MapHeightManager.instance.GetHeightAtPosition(cellPos),
+                    cellPos.z
                 );
                 spawnedPathHighlights.Add(newPosCube, highlight);
             }
@@ -278,8 +278,8 @@ public class MoveIntent : IntentHandler
                 );
                 highlight.position = new Vector3(
                     highlight.position.x,
-                    highlight.position.y,
-                    MapHeightManager.instance.GetHeightAtPosition(highlight.position)
+                    MapHeightManager.instance.GetHeightAtPosition(highlight.position),
+                    highlight.position.z
                 );
                 spawnedValidCellHighlights.Add(space, highlight.gameObject);
             }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ScoutIntent.cs
@@ -208,8 +208,8 @@ public class ScoutIntent : IntentHandler
                 );
                 highlight.transform.position = new Vector3(
                     cellPos.x,
-                    cellPos.y,
-                    MapHeightManager.UNSCOUTED_HEIGHT
+                    MapHeightManager.UNSCOUTED_HEIGHT,
+                    cellPos.z
                 );
                 spawnedHighlights.Add(cellPosCube, highlight);
             }

--- a/DawnSeekersUnity/Assets/Map/Scripts/UI/ActionMenuController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/UI/ActionMenuController.cs
@@ -32,8 +32,8 @@ public class ActionMenuController : MonoBehaviour
             );
             transform.position = new Vector3(
                 transform.position.x,
-                transform.position.y,
-                MapHeightManager.instance.GetHeightAtPosition(transform.position)
+                MapHeightManager.instance.GetHeightAtPosition(transform.position),
+                transform.position.z
             );
 
             UpdateButtonStates(state);

--- a/DawnSeekersUnity/Assets/Map/Scripts/UI/ParabolicLineController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/UI/ParabolicLineController.cs
@@ -59,7 +59,7 @@ public class ParabolicLineController : MonoBehaviour
         {
             Vector3 dir = (endPos - startPos) / _resolution;
             positions[i] = startPos + (dir * i);
-            positions[i].z -=
+            positions[i].y +=
                 _lineCurve.Evaluate((float)i / (float)_resolution)
                 * (
                     _lineHeight

--- a/DawnSeekersUnity/Assets/Map/Scripts/UI/TravelMarkerController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/UI/TravelMarkerController.cs
@@ -55,13 +55,13 @@ public class TravelMarkerController : MonoBehaviour
     {
         Vector3 startOffset = new Vector3(
             startPos.x,
-            startPos.y,
-            MapHeightManager.instance.GetHeightAtPosition(startPos)
+            MapHeightManager.instance.GetHeightAtPosition(startPos),
+            startPos.z
         );
         Vector3 endOffset = new Vector3(
             endPos.x,
-            endPos.y,
-            MapHeightManager.instance.GetHeightAtPosition(endPos)
+            MapHeightManager.instance.GetHeightAtPosition(endPos),
+            endPos.z
         );
         Vector3 worldEndPos = endPos;
         line.DrawLine(startOffset, endOffset);


### PR DESCRIPTION
In the beginning, the map was vertical, and it was good.
Then I forgot why it needed to be vertical, something to do with the tilemap system I think.
Now it no longer needs to be vertical as we've switched to 3D mode, and Lo, the map was made horizontal like a normal, sensible game.
This PR handles switching over to horizontal mode, swizzling the Vector3s in a bunch of map elements and effects.
It also updates some prefab orientations and positions.

Should make working on the scene more intuitive going forward.