### PR TITLE
Increase pixel ratio for WebGL element

### DIFF
--- a/frontend/src/components/organisms/unity-map/index.tsx
+++ b/frontend/src/components/organisms/unity-map/index.tsx
@@ -189,7 +189,7 @@ export const UnityMap: FunctionComponent<UnityMapProps> = ({ ...otherProps }: Un
                     />
                 </div>
             )}
-            <Unity unityProvider={unityProvider} />
+            <Unity unityProvider={unityProvider} devicePixelRatio={2} />
         </StyledUnityMap>
     );
 };


### PR DESCRIPTION
Unity is a bit blurry in WebGL, this PR increases the resolution.
This could negatively affect performance on lower end platforms, so worth keeping in mind when we do our performance pass.