### PR TITLE
Added adjustable AO intensity based on zoom

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapCamera.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapCamera.prefab
@@ -159,7 +159,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6518314203346260197}
   m_LocalRotation: {x: 0.38268343, y: 0, z: 0, w: 0.92387956}
-  m_LocalPosition: {x: 0, y: 4.9497476, z: -4.949748}
+  m_LocalPosition: {x: 0, y: 4.9497476, z: -4.9497476}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -282,7 +282,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6518314203603543956}
   m_LocalRotation: {x: 0.38268343, y: -0, z: -0, w: 0.92387956}
-  m_LocalPosition: {x: 0, y: 4.9497476, z: -4.949748}
+  m_LocalPosition: {x: 0, y: 4.9497476, z: -4.9497476}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -520,7 +520,7 @@ MonoBehaviour:
   maxCameraDistance: 10
   zoomDuration: 0.025
   PPVolume: {fileID: 6518314203581509767}
-  minAOIntensity: 0.75
+  minAOIntensity: 0.3
   maxAOIntensity: 3
 --- !u!1 &6518314205033195297
 GameObject:

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapCamera.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapCamera.prefab
@@ -519,6 +519,9 @@ MonoBehaviour:
   minCameraDistance: 2
   maxCameraDistance: 10
   zoomDuration: 0.025
+  PPVolume: {fileID: 6518314203581509767}
+  minAOIntensity: 0.75
+  maxAOIntensity: 3
 --- !u!1 &6518314205033195297
 GameObject:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -1091,7 +1091,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!1 &564338985
@@ -1582,8 +1582,6 @@ MonoBehaviour:
   grid: {fileID: 913983447}
   scoutColor: {r: 0.31176567, g: 0.41419315, b: 0.5849056, a: 1}
   normalColor: {r: 0.44522065, g: 0.5320815, b: 0.6509434, a: 1}
-  scoutedContainer: {fileID: 823133098}
-  unscoutedContainer: {fileID: 1269189909}
 --- !u!4 &755192403
 Transform:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/CameraController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/CameraController.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Cinemachine;
 using UnityEngine;
+using UnityEngine.Rendering.PostProcessing;
 
 public class CameraController : MonoBehaviour
 {
@@ -27,6 +28,13 @@ public class CameraController : MonoBehaviour
 
     [SerializeField]
     private float zoomDuration = 0.2f;
+
+    [SerializeField]
+    PostProcessVolume PPVolume;
+
+    [SerializeField]
+    float minAOIntensity,
+        maxAOIntensity;
 
     private Camera mainCamera;
     private Coroutine zoomCoroutine;
@@ -89,7 +97,17 @@ public class CameraController : MonoBehaviour
                 );
             }
         }
-
+        PPVolume.sharedProfile.GetSetting<AmbientOcclusion>().intensity.value = Mathf.Lerp(
+            minAOIntensity,
+            maxAOIntensity,
+            Mathf.InverseLerp(
+                minCameraDistance,
+                maxCameraDistance,
+                virtualCamera
+                    .GetCinemachineComponent<CinemachineFramingTransposer>()
+                    .m_CameraDistance
+            )
+        );
         HandleMouseCameraDrag();
         float speed = moveSpeed * Mathf.Abs(mainCamera.transform.position.y);
         Vector3 inputVector =


### PR DESCRIPTION
The Ambient Occlusion Post Processing effect seemed to get darker the closer the camera got to solid objects.
This is a problem with the method of AO we were using called Scalable Ambient Obscurance.
Multi-scale Ambient Obscurance would be a better choice, but is unavailable on WebGL as it doesn't support Compute Shaders.
So instead this PR adds a "fix" which scales the AO's intensity based on the current zoom level of the camera.
Seems to do the job, just means we need to update two intensity values instead of one.