### PR TITLE
Editor intents window

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -2551,6 +2551,175 @@ RectTransform:
   m_AnchoredPosition: {x: 15, y: 15}
   m_SizeDelta: {x: 207.7256, y: 116.9156}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &1752055061
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598487868882, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_Name
+      value: SeekerActionMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847598666213357, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2476847599759415508, guid: 6a7a5c2a730a843b4a48249413d547b6,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 50
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6a7a5c2a730a843b4a48249413d547b6, type: 3}
 --- !u!1 &1987954015
 GameObject:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -970,7 +970,7 @@ RectTransform:
   - {fileID: 359895531}
   - {fileID: 332946493}
   m_Father: {fileID: 0}
-  m_RootOrder: 14
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1630,7 +1630,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!210 &823133099
 SortingGroup:
@@ -2150,7 +2150,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 17
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1278070348
 GameObject:
@@ -2648,177 +2648,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!1001 &2476847598685358811
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289450638959245, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1814289452247057556, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868881, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598487868882, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_Name
-      value: SeekerActionMenu
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847598666213357, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847599540612602, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2476847599759415508, guid: 6a7a5c2a730a843b4a48249413d547b6,
-        type: 3}
-      propertyPath: m_SortingOrder
-      value: 100
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6a7a5c2a730a843b4a48249413d547b6, type: 3}
 --- !u!1001 &4814635801955597106
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2834,7 +2665,7 @@ PrefabInstance:
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 4814635802840031562, guid: e06645b593db042baa70468de29d36c6,
         type: 3}
@@ -2913,7 +2744,7 @@ PrefabInstance:
     - target: {fileID: 6406227089287717616, guid: 6aed245e8122049368e7ebb7195afd6e,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 6406227089287717616, guid: 6aed245e8122049368e7ebb7195afd6e,
         type: 3}
@@ -3038,6 +2869,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: MapCamera
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.949748
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.949748
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13c17ec3607f94f34a8d6fc7cf4300af, type: 3}

--- a/DawnSeekersUnity/Assets/Map/Scripts/Editor.meta
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d78e01d7b7e2a49bf8d868e1ec038149
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+using UnityEditor;
+using Cog;
+
+public class IntentsEditorWindow : EditorWindow
+{
+    [MenuItem("Playmint/Player Intents")]
+    public static void ShowWindow()
+    {
+        GetWindow<IntentsEditorWindow>("Player Intents");
+    }
+
+    private void OnGUI()
+    {
+        bool isPlaying = EditorApplication.isPlaying && !EditorApplication.isPaused;
+        bool disableButtons = !isPlaying;
+
+        EditorGUI.BeginDisabledGroup(disableButtons);
+
+        GUILayout.BeginVertical();
+        GUILayout.Space(10f);
+        GUILayout.BeginHorizontal();
+        GUILayout.Space(10f);
+
+        if (GUILayout.Button("Construct", GUILayout.Height(50f)))
+        {
+            IntentClick("construct");
+        }
+
+        GUILayout.Space(10f);
+
+        if (GUILayout.Button("Move", GUILayout.Height(50f)))
+        {
+            IntentClick("move");
+        }
+
+        GUILayout.Space(10f);
+
+        if (GUILayout.Button("Scout", GUILayout.Height(50f)))
+        {
+            IntentClick("scout");
+        }
+
+        /*
+        GUILayout.Space(10f);
+
+        if (GUILayout.Button("Use", GUILayout.Height(50f)))
+        {
+            // Do something when Button 4 is clicked
+        }*/
+
+        GUILayout.Space(10f);
+        GUILayout.EndHorizontal();
+        GUILayout.Space(10f);
+
+        if (GUILayout.Button("Confirm", GUILayout.Height(50f)))
+        {
+            MapInteractionManager.instance.MapClicked2();
+            //IntentClick("scout");
+        }
+        GUILayout.EndVertical();
+        GUILayout.Space(10f);
+
+        EditorGUI.EndDisabledGroup();
+    }
+
+    void IntentClick(string intent)
+    {
+        if (GameStateMediator.Instance.gameState.Selected.Intent == intent)
+        {
+            // Cancel intent if already in intent for this button
+            GameStateMediator.Instance.SendSetIntentMsg(IntentKind.NONE);
+        }
+        else
+        {
+            GameStateMediator.Instance.SendSetIntentMsg(intent);
+        }
+    }
+}

--- a/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs
@@ -41,13 +41,20 @@ public class IntentsEditorWindow : EditorWindow
             IntentClick("scout");
         }
 
-        /*
+        
         GUILayout.Space(10f);
 
         if (GUILayout.Button("Use", GUILayout.Height(50f)))
         {
-            // Do something when Button 4 is clicked
-        }*/
+            IntentClick("use");
+        }
+
+        GUILayout.Space(10f);
+
+        if (GUILayout.Button("Combat", GUILayout.Height(50f)))
+        {
+            //IntentClick("Kick their ass, sea bass!");
+        }
 
         GUILayout.Space(10f);
         GUILayout.EndHorizontal();

--- a/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs
@@ -41,7 +41,6 @@ public class IntentsEditorWindow : EditorWindow
             IntentClick("scout");
         }
 
-        
         GUILayout.Space(10f);
 
         if (GUILayout.Button("Use", GUILayout.Height(50f)))

--- a/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs.meta
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f99ee018612249308dcfa8b8f8b5329
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
@@ -121,7 +121,7 @@ public class MapInteractionManager : MonoBehaviour
         }
     }
 
-    void MapClicked2()
+    public void MapClicked2()
     {
         var cellPosOddR = MapManager.instance.grid.WorldToCell(cursor.position);
         var cellPosCube = GridExtensions.GridToCube(cellPosOddR);


### PR DESCRIPTION
This PR adds a window to the editor that mimics the popup intents menu, as this will soon be replaced by ui in the shell.
At the moment I've left the popup intents menu in the scene as it is currently still needed in the WebGL build, but it is no longer required to play the game in the editor.

The 'Use' and 'Combat' intents have no effect at this time either, but they're ready for when we do.