### PR TITLE
fix: output arrow should not show if no outputs

### DIFF
--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -135,9 +135,11 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, showFull
                             />
                         </div>
                     )}
-                    <div className="process">
-                        <img src="/icons/downarrow.png" alt="output" className="arrow" />
-                    </div>
+                    {outputs.length > 0 && outputBag && (
+                        <div className="process">
+                            <img src="/icons/downarrow.png" alt="output" className="arrow" />
+                        </div>
+                    )}
                     {outputs.length > 0 && outputBag && (
                         <div ref={outputsRef} className="ingredients">
                             <Bag


### PR DESCRIPTION

fixup from #218 ... the little output arrow is incorrectly showing even when there are no crafting outputs