### PR TITLE
a quick native dialog/modal with icon

### DIFF
--- a/frontend/src/components/molecules/dialog/dialog.styles.ts
+++ b/frontend/src/components/molecules/dialog/dialog.styles.ts
@@ -1,7 +1,7 @@
 /** @format */
 
 import { css } from 'styled-components';
-import { ModalProps } from './index';
+import { DialogProps } from './index';
 
 /**
  * Base styles for the modal component
@@ -9,7 +9,7 @@ import { ModalProps } from './index';
  * @param _ The modal properties object
  * @return Base styles for the modal component
  */
-const baseStyles = ({ width }: Partial<ModalProps>) => css`
+const baseStyles = ({ width }: Partial<DialogProps>) => css`
     border: 0;
     background: transparent;
     overflow: hidden;
@@ -96,11 +96,11 @@ const baseStyles = ({ width }: Partial<ModalProps>) => css`
 `;
 
 /**
- * The modal component styles
+ * component styles
  *
  * @param props The modal properties object
  * @return Styles for the modal component
  */
-export const styles = (props: Partial<ModalProps>) => css`
+export const styles = (props: Partial<DialogProps>) => css`
     ${baseStyles(props)}
 `;

--- a/frontend/src/components/molecules/dialog/dialog.styles.ts
+++ b/frontend/src/components/molecules/dialog/dialog.styles.ts
@@ -1,0 +1,106 @@
+/** @format */
+
+import { css } from 'styled-components';
+import { ModalProps } from './index';
+
+/**
+ * Base styles for the modal component
+ *
+ * @param _ The modal properties object
+ * @return Base styles for the modal component
+ */
+const baseStyles = ({ width }: Partial<ModalProps>) => css`
+    border: 0;
+    background: transparent;
+    overflow: hidden;
+    width: ${width || '40rem'};
+    ::backdrop {
+        background: rgba(15, 15, 15, 0.1);
+        backdrop-filter: blur(10px) !important;
+        pointer-events: none;
+    }
+    .content {
+        margin-top: 40px;
+        background: #143063;
+        color: #fff;
+        border: 2px solid #fff;
+        width: 100%;
+        height: 30rem;
+    }
+    .icon {
+        position: relative;
+        margin-left: calc(50% - 43px);
+        top: -5px;
+    }
+    .diamond-bg {
+        position: absolute;
+        top: -45px;
+        left: 0;
+        width: 0;
+        height: 0;
+        border: 45px solid transparent;
+        border-bottom-color: white;
+    }
+    .diamond-bg:after {
+        content: '';
+        position: absolute;
+        left: -45px;
+        top: 45px;
+        width: 0;
+        height: 0;
+        border: 45px solid transparent;
+        border-top-color: white;
+    }
+    .diamond-br-shift {
+        position: absolute;
+        left: 2px;
+        top: 2px;
+    }
+    .diamond-br {
+        position: absolute;
+        top: -43px;
+        left: 0px;
+        width: 0;
+        height: 0;
+        border: 43px solid transparent;
+        border-bottom-color: #143063;
+    }
+    .diamond-br:after {
+        content: '';
+        position: absolute;
+        left: -43px;
+        top: 43px;
+        width: 0;
+        height: 0;
+        border: 43px solid transparent;
+        border-top-color: #143063;
+    }
+    img {
+        position: absolute;
+        left: 29px;
+        top: 25px;
+        width: 32px;
+        height: 32px;
+        filter: invert(100);
+    }
+    .close {
+        position: absolute;
+        right: 4px;
+        top: 42px;
+        border-radius: 20px;
+        border: 0px solid transparent;
+        width: 3rem;
+        height: 3rem;
+        font-weight: bold;
+    }
+`;
+
+/**
+ * The modal component styles
+ *
+ * @param props The modal properties object
+ * @return Styles for the modal component
+ */
+export const styles = (props: Partial<ModalProps>) => css`
+    ${baseStyles(props)}
+`;

--- a/frontend/src/components/molecules/dialog/index.tsx
+++ b/frontend/src/components/molecules/dialog/index.tsx
@@ -1,0 +1,47 @@
+/** @format */
+
+import { ComponentProps } from '@app/types/component-props';
+import { FunctionComponent, ReactNode, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { styles } from './dialog.styles';
+
+export interface DialogProps extends ComponentProps {
+    children?: ReactNode;
+    width?: string;
+    icon?: string;
+    onClose: () => void;
+}
+
+const StyledDialog = styled('dialog')`
+    ${styles}
+`;
+
+export const Dialog: FunctionComponent<DialogProps> = ({ icon, width = '40rem', onClose, children, ...otherProps }) => {
+    const ref = useRef<HTMLDialogElement>(null);
+
+    useEffect(() => {
+        if (!ref.current?.open) {
+            ref.current?.showModal();
+        }
+    }, []);
+
+    return (
+        <StyledDialog {...otherProps} ref={ref} onCancel={onClose}>
+            {icon && (
+                <div className="icon">
+                    <div className="diamond-bg"></div>
+                    <div className="diamond-br-shift">
+                        <div className="diamond-br"></div>
+                    </div>
+                    <img src={icon} alt="icon" />
+                </div>
+            )}
+            <div className="content">
+                {children}
+                <button className="close" onClick={onClose}>
+                    x
+                </button>
+            </div>
+        </StyledDialog>
+    );
+};


### PR DESCRIPTION
#### what

a quick dialog/modal implementation with an icon and blury background.

native dialogs have decent browser support and some nice properties like correctly handling events and esc-to-cancel, and less code to maintain than using a context-based thing 🤷 

this is not being used anywhere yet so has no impact on the game, but I thought it might be useful to combat.

#### usage

just dump the Dialog component into the page anywhere and it will become a modal thing.... pass in a onClose handler to handle when the user closes via native ESC/cancel

pass in an optional icon url (expects a black svg like from our icon pack) to have a little diamond thing

```typescript
import { Dialog } from '@app/components/molecules/dialog';

const MyComponent = () => {
    const [showDialog, toggleDialog] = useState(false);

    return (
        <div>
            {showDialog && (
                <Dialog
                    onClose={() => toggleDialog(false)}
                    icon="https://playmintglobal.z16.web.core.windows.net/icons/28-58.svg"
                >
                    <div>hello this is modal content</div>
                </Dialog>
            )}
        </div>
    );
};
```

#### looks like...

![Screenshot 2023-05-24 at 10 18 38](https://github.com/playmint/ds/assets/45921/d775fb5d-d018-4e59-9b04-0e57db3939bb)


