### PR TITLE
Swap attack and defense param order in itemConfig to be correct

### DIFF
--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -57,8 +57,8 @@ contract GameDeployer is Script {
                 name: "Welcome Cocktail",
                 icon: "02-40",
                 life: 1,
-                attack: 1,
-                defense: 0,
+                defense: 1,
+                attack: 0,
                 stackable: true,
                 implementation: address(0),
                 plugin: ""

--- a/contracts/src/utils/ItemUtils.sol
+++ b/contracts/src/utils/ItemUtils.sol
@@ -11,8 +11,8 @@ struct ItemConfig {
     string name;
     string icon;
     uint256 life;
-    uint256 attack;
     uint256 defense;
+    uint256 attack;
     bool stackable;
     address implementation;
     string plugin;
@@ -38,7 +38,7 @@ library ItemUtils {
     // register is a helper to declare a new kind of item
     function register(BaseGame ds, ItemConfig memory cfg) internal returns (bytes24) {
         Dispatcher dispatcher = ds.getDispatcher();
-        uint32[3] memory outputItemAtoms = [uint32(cfg.life), uint32(cfg.attack), uint32(cfg.defense)];
+        uint32[3] memory outputItemAtoms = [uint32(cfg.life), uint32(cfg.defense), uint32(cfg.attack)];
         bytes24 itemKind = Node.Item(uint32(cfg.id), outputItemAtoms, cfg.stackable);
         dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (itemKind, cfg.name, cfg.icon)));
         if (address(cfg.implementation) != address(0)) {


### PR DESCRIPTION
Welcome drinks are now a little bit defensive rather than a little bit attacky. Should make for a safer, if less exciting, welcome party.

Will require HammerFactory to be fixed when this commit hits that repo's submodule.

resolves: #235 