### PR TITLE
show inline content without buttons

### DIFF
--- a/frontend/src/components/organisms/tile-action/index.tsx
+++ b/frontend/src/components/organisms/tile-action/index.tsx
@@ -141,7 +141,7 @@ export const TileAction: FunctionComponent<TileActionProps> = (props: TileAction
     // const popout = getVisibleContentForType('popout');
     // const dialog = getVisibleContentForType('dialog');
 
-    if (!inline || (inline && inline.buttons?.length === 0)) {
+    if (!inline) {
         return null;
     }
 


### PR DESCRIPTION
we previously had some idea that content areas can only show if a button exists.... but we aren't using it like that ... so always show the inline content if it's available

resolves: #240 