### PR TITLE
fix white-on-white select in firefox win

### DIFF
--- a/frontend/src/styles/global.styles.ts
+++ b/frontend/src/styles/global.styles.ts
@@ -65,7 +65,7 @@ export const GlobalStyles = createGlobalStyle`
         color: #143063;
         padding: 1.2rem 2rem 0.8rem;
         font-weight: 600;
-        
+
         &:disabled {
             opacity: 0.5;
         }
@@ -119,15 +119,15 @@ export const GlobalStyles = createGlobalStyle`
 
     form {
         width: 100%;
-        
+
         .select {
             position: relative;
             width: 100%;
-            
+
             select {
                 appearance: none;
                 box-sizing: border-box;
-                background-color: transparent;
+                background-color: #143063;
                 border: 1px solid white;
                 border-radius: 5px;
                 padding: 1rem;
@@ -139,7 +139,7 @@ export const GlobalStyles = createGlobalStyle`
                 line-height: inherit;
                 color: white;
             }
-            
+
             &:after {
                 position: absolute;
                 top: 50%;


### PR DESCRIPTION
selectbox options not readable on windows firefox as light text on light bg

fixes: #216 