### PR TITLE
temporary BuildingUtils.construct hack to spawn buildings anywhere on map

### DIFF
--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -110,24 +110,6 @@ contract GameDeployer is Script {
         );
     }
 
-    function _constructBuilding(Game ds, bytes24 buildingKind, bytes24 seeker, int16 q, int16 r, int16 s)
-        private
-        returns (bytes24 buildingInstance)
-    {
-        State state = ds.getState();
-        // get our building and give it the resources to construct
-        buildingInstance = Node.Building(0, q, r, s);
-        // magic required items into the construct slot
-        bytes24 buildingBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance)))));
-        state.setEquipSlot(buildingInstance, 0, buildingBag);
-        state.setItemSlot(buildingBag, 0, ItemUtils.Kiki(), 25);
-        state.setItemSlot(buildingBag, 1, ItemUtils.Bouba(), 25);
-        state.setItemSlot(buildingBag, 2, ItemUtils.Semiote(), 25);
-        // construct our building
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CONSTRUCT_BUILDING_SEEKER, (seeker, buildingKind, q, r, s)));
-        return buildingInstance;
-    }
-
     function _loadAllowList(address deployer) private view returns (address[] memory) {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/src/fixtures/allowlist.json");

--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -90,8 +90,8 @@ contract GameDeployer is Script {
             })
         );
 
-        // construct building
-        _constructBuilding(ds, welcomeHutBuildingKind, seeker, -1, 1, 0);
+        // force construct building
+        BuildingUtils.construct(ds, welcomeHutBuildingKind, "building", -1, 1, 0);
 
         vm.stopBroadcast();
     }
@@ -128,7 +128,7 @@ contract GameDeployer is Script {
         return buildingInstance;
     }
 
-    function _loadAllowList(address deployer) private returns (address[] memory) {
+    function _loadAllowList(address deployer) private view returns (address[] memory) {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/src/fixtures/allowlist.json");
         string memory json = vm.readFile(path);

--- a/contracts/src/utils/BuildingUtils.sol
+++ b/contracts/src/utils/BuildingUtils.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+import {State} from "cog/State.sol";
 import {BaseGame} from "cog/Game.sol";
 import {Dispatcher} from "cog/Dispatcher.sol";
-import {Node} from "@ds/schema/Schema.sol";
+import {Node, BiomeKind, Schema} from "@ds/schema/Schema.sol";
 import {Actions} from "@ds/actions/Actions.sol";
+
+using Schema for State;
 
 struct Material {
     uint256 quantity;
@@ -74,5 +77,36 @@ library BuildingUtils {
             );
         }
         return buildingKind;
+    }
+
+    // temporary helper to allow constructing a building without any
+    // materials to test out some objective ideas.
+    // THIS IS A CHEAT AND WILL BE REMOVED
+    function construct(BaseGame ds, bytes24 buildingKind, string memory model, int16 q, int16 r, int16 s)
+        internal
+        returns (bytes24 buildingInstance)
+    {
+        Dispatcher dispatcher = ds.getDispatcher();
+        State state = ds.getState();
+        // force discover tile
+        dispatcher.dispatch(abi.encodeCall(Actions.DEV_SPAWN_TILE, (BiomeKind.DISCOVERED, q, r, s)));
+        bytes24 targetTile = Node.Tile(0, q, r, s);
+        // make instance id
+        buildingInstance = Node.Building(0, q, r, s);
+        // set type of building
+        state.setBuildingKind(buildingInstance, buildingKind);
+        // set building owner to sender
+        state.setOwner(buildingInstance, Node.Player(msg.sender));
+        // set building location
+        state.setFixedLocation(buildingInstance, targetTile);
+        // attach the inputs/output bags
+        bytes24 inputBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance, "input")))));
+        bytes24 outputBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance, "output")))));
+        state.setEquipSlot(buildingInstance, 0, inputBag);
+        state.setEquipSlot(buildingInstance, 1, outputBag);
+        // annotate the building kind's model
+        state.annotate(buildingKind, "model", model);
+        // return id
+        return buildingInstance;
     }
 }


### PR DESCRIPTION
#### what

adds a temporary BuildingUtils.construct function to allow constructing buildings without materials/seeker as a quick hacky way to place buildings/enemies on the map

the function annotates the building kind with a string which we can use to show different models for buildings/enemy .... again this is probably a temp solution... but allows us to play with the objective ideas

#### usage

```
        // force construct building anywhere without need for resources
        BuildingUtils.construct(
            ds,
            buildingKind, // kind id
            "enemy",  // annotate kind with a name to allow switching models
            -10, 10, 0 // q,r,s location
        );

```

#### related

resolves: #248 
resolves: #247 
resolves: #231 