### PR TITLE
show life/def/atk atomic numbers in tooltip

### DIFF
--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -55,7 +55,7 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
         }, [] as string[])
         .map((n: string) => BigInt(n))
         .slice(-4);
-    const tooltip = `${quantity} ${name}\n\nlife: ${life}\ndefense: ${defense}\nattack: ${attack}`;
+    const tooltip = `${quantity} ${name}\n\nLife: ${life}\nDefense: ${defense}\nAttack: ${attack}`;
 
     return (
         <StyledBagItem

--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -44,13 +44,26 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
 
     const isPickable = !isPickedUpItemVisible;
 
+    const [_stackable, life, defense, attack] = [...itemId]
+        .slice(2)
+        .reduce((bs, b, idx) => {
+            if (idx % 8 === 0) {
+                bs.push('0x');
+            }
+            bs[bs.length - 1] += b;
+            return bs;
+        }, [] as string[])
+        .map((n: string) => BigInt(n))
+        .slice(-4);
+    const tooltip = `${quantity} ${name}\n\nlife: ${life}\ndefense: ${defense}\nattack: ${attack}`;
+
     return (
         <StyledBagItem
             {...otherProps}
             onClick={handleClick}
             isPickable={isPickable}
             isInteractable={isInteractable}
-            title={`${quantity} ${name}`}
+            title={tooltip}
         >
             {isPending && <span className="spinner" />}
             <img src={icon} alt={name} className="icon" />

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -1,13 +1,13 @@
 /** @format */
 
+import { BagItem } from '@app/plugins/inventory/bag-item';
+import { getItemDetails } from '@app/plugins/inventory/helpers';
+import { useInventory } from '@app/plugins/inventory/inventory-provider';
+import { ComponentProps } from '@app/types/component-props';
+import { ItemSlotFragment } from '@dawnseekers/core';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { ComponentProps } from '@app/types/component-props';
 import { styles } from './bag-slot.styles';
-import { BagItem } from '@app/plugins/inventory/bag-item';
-import { useInventory } from '@app/plugins/inventory/inventory-provider';
-import { ItemSlotFragment } from '@dawnseekers/core';
-import { getItemDetails } from '@app/plugins/inventory/helpers';
 
 export interface BagSlotProps extends ComponentProps {
     itemSlot?: ItemSlotFragment;
@@ -114,10 +114,7 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
                       />
                   )
                 : placeholderItem && (
-                      <div
-                          className="placeholder"
-                          title={`Requires ${placeholderItem.quantity} ${placeholderItem.name}`}
-                      >
+                      <div className="placeholder" title={`${placeholderItem.quantity} ${placeholderItem.name}`}>
                           <img src={placeholderItem.icon} alt={placeholderItem.name} className="icon" />
                           <span className="amount">{placeholderItem.quantity}</span>
                       </div>


### PR DESCRIPTION

surface the atom number in item tooltips in inventory

resolves: #246 


![Screenshot 2023-06-05 at 13 02 51](https://github.com/playmint/ds/assets/45921/b42119ac-7426-4ea3-b57d-0a6ba17b4aeb)
