### PR TITLE
prevent drop incompatible item

### DIFF
--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -53,6 +53,10 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
         }
 
         const itemSlotBalance = itemSlot?.balance || 0;
+
+        if (itemSlotBalance > 0 && item && item.itemId != pickedUpItem.transferInfo.itemId) {
+            return;
+        }
         const transferQuantity = placeholder
             ? Math.min(dropQuantity, Math.max(placeholder.balance - itemSlotBalance, 0))
             : dropQuantity;

--- a/frontend/src/plugins/inventory/inventory-provider.tsx
+++ b/frontend/src/plugins/inventory/inventory-provider.tsx
@@ -19,7 +19,7 @@ export interface TransferInfo {
     itemId: string;
 }
 
-interface InventoryItem {
+export interface InventoryItem {
     name: string;
     icon: string;
     quantity: number;


### PR DESCRIPTION
stop attempting a TRANSFER_ITEM when dropping itemA onto a slot containing itemB (which will fail)

fixes: #219 