### PR TITLE
indicate invalid item in recipe slot

### DIFF
--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -188,16 +188,16 @@ contract BuildingRule is Rule {
             }
 
             // check recipe items
-            require(gotItem[0] == wantItem[0], "input 0 item does not match construction recipe");
-            require(gotItem[1] == wantItem[1], "input 1 item does not match construction recipe");
-            require(gotItem[2] == wantItem[2], "input 2 item does not match construction recipe");
-            require(gotItem[3] == wantItem[3], "input 3 item does not match construction recipe");
+            require(wantItem[0] == 0x0 || gotItem[0] == wantItem[0], "input 0 item does not match construction recipe");
+            require(wantItem[1] == 0x0 || gotItem[1] == wantItem[1], "input 1 item does not match construction recipe");
+            require(wantItem[2] == 0x0 || gotItem[2] == wantItem[2], "input 2 item does not match construction recipe");
+            require(wantItem[3] == 0x0 || gotItem[3] == wantItem[3], "input 3 item does not match construction recipe");
 
             // check qty
-            require(gotQty[0] >= wantQty[0], "input 0 qty does not match construction recipe");
-            require(gotQty[1] >= wantQty[1], "input 0 qty does not match construction recipe");
-            require(gotQty[2] >= wantQty[2], "input 0 qty does not match construction recipe");
-            require(gotQty[3] >= wantQty[3], "input 0 qty does not match construction recipe");
+            require(wantQty[0] == 0 || gotQty[0] >= wantQty[0], "input 0 qty does not match construction recipe");
+            require(wantQty[1] == 0 || gotQty[1] >= wantQty[1], "input 0 qty does not match construction recipe");
+            require(wantQty[2] == 0 || gotQty[2] >= wantQty[2], "input 0 qty does not match construction recipe");
+            require(wantQty[3] == 0 || gotQty[3] >= wantQty[3], "input 0 qty does not match construction recipe");
 
             // burn everything in the buildingBag so we have a nice clean bag ready
             // to be used for other things like crafting... overpay at your peril

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -308,7 +308,7 @@ const Construct: FunctionComponent<ConstructProps> = ({ selectedTiles, seeker, p
     const canConstruct =
         recipe.every((ingredient, index) => {
             const bag = equipSlot && equipSlot.bag;
-            return bag && bag.slots[index] && bag.slots[index].balance === ingredient.balance;
+            return bag && bag.slots[index] && bag.slots[index].balance >= ingredient.balance;
         }) && selectedTiles.length > 0;
 
     const help = selectedTile?.building

--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -16,6 +16,7 @@ export interface BagItemProps extends ComponentProps {
     itemId: string;
     isInteractable?: boolean;
     isPending?: boolean;
+    isInvalid?: boolean;
 }
 
 const StyledBagItem = styled('div')`
@@ -23,8 +24,19 @@ const StyledBagItem = styled('div')`
 `;
 
 export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) => {
-    const { name, icon, quantity, ownerId, equipIndex, slotKey, itemId, isPending, isInteractable, ...otherProps } =
-        props;
+    const {
+        name,
+        icon,
+        quantity,
+        ownerId,
+        equipIndex,
+        slotKey,
+        itemId,
+        isPending,
+        isInteractable,
+        isInvalid,
+        ...otherProps
+    } = props;
     const { pickUpItem, isPickedUpItemVisible } = useInventory();
 
     const handleClick = () => {
@@ -55,7 +67,9 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
         }, [] as string[])
         .map((n: string) => BigInt(n))
         .slice(-4);
-    const tooltip = `${quantity} ${name}\n\nLife: ${life}\nDefense: ${defense}\nAttack: ${attack}`;
+    const tooltip = isInvalid
+        ? `Slot contains invalid ${name} item\n\nRemove item from slot to continue`
+        : `${quantity} ${name}\n\nLife: ${life}\nDefense: ${defense}\nAttack: ${attack}`;
 
     return (
         <StyledBagItem

--- a/frontend/src/plugins/inventory/bag-slot/bag-slot.styles.ts
+++ b/frontend/src/plugins/inventory/bag-slot/bag-slot.styles.ts
@@ -5,6 +5,7 @@ import { BagSlotProps } from './index';
 
 type BagSlotStyleProps = Partial<BagSlotProps> & {
     isDroppable: boolean;
+    isInvalid: boolean;
 };
 
 /**
@@ -13,12 +14,13 @@ type BagSlotStyleProps = Partial<BagSlotProps> & {
  * @param _ The bag slot properties object
  * @return Base styles for the bag slot component
  */
-const baseStyles = ({ isDroppable, isDisabled, isInteractable }: BagSlotStyleProps) => css`
+const baseStyles = ({ isDroppable, isDisabled, isInteractable, isInvalid }: BagSlotStyleProps) => css`
     box-sizing: content-box;
     width: 4.8rem;
     height: 4.8rem;
     background: ${isDisabled || !isInteractable ? '#19212e' : '#030f25'};
-    border: 1px solid ${isDisabled || !isInteractable ? '#656585' : isDroppable ? 'white' : '#6c98d4'};
+    border: 1px solid
+        ${isDisabled || !isInteractable ? '#656585' : isInvalid ? 'red' : isDroppable ? 'white' : '#6c98d4'};
 
     .placeholder {
         position: relative;

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -42,6 +42,7 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
 
     const item = itemSlot?.balance ? getItemDetails(itemSlot) : null;
     const placeholderItem = placeholder?.balance ? getItemDetails(placeholder) : null;
+    const itemSlotBalance = itemSlot?.balance || 0;
 
     const handleDrop = (dropQuantity: number) => {
         if (!isPickedUpItemVisible || !isInteractable || !pickedUpItem) {
@@ -51,8 +52,6 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
         if (placeholder && placeholder.item.id !== pickedUpItem.transferInfo.itemId) {
             return;
         }
-
-        const itemSlotBalance = itemSlot?.balance || 0;
 
         if (itemSlotBalance > 0 && item && item.itemId != pickedUpItem.transferInfo.itemId) {
             return;
@@ -97,6 +96,10 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
         !item &&
         ((placeholder && placeholder.item.id === pickedUpItem.transferInfo.itemId) || !placeholder);
 
+    // it's possible for a slot to contain an item that doesn't match the slot's
+    // recipe/placeholder, try to detect this invalid state
+    const isInvalid = !!(itemSlotBalance > 0 && placeholderItem && item && placeholderItem.itemId !== item.itemId);
+
     return (
         <StyledBagSlot
             {...otherProps}
@@ -105,6 +108,7 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
             isDroppable={isDroppable}
             isDisabled={isDisabled}
             isInteractable={isInteractable}
+            isInvalid={isInvalid}
         >
             {item
                 ? itemSlot && (
@@ -115,6 +119,7 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
                           slotKey={slotKey}
                           isInteractable={isInteractable}
                           isPending={isPending}
+                          isInvalid={isInvalid}
                       />
                   )
                 : placeholderItem && (


### PR DESCRIPTION
make it a bit clearer that a slot that expects itemA but already contains itemB is in a weird state by:

* highlighting the slot border red
* changing the tooltip to say you need to remove the item

![Screenshot 2023-06-05 at 14 16 27](https://github.com/playmint/ds/assets/45921/12cf72a2-51e9-475c-a82f-08359614807e)

resolves: #225 