### PR TITLE
fetch "model" building kind annotation

### DIFF
--- a/core/src/kinds.graphql
+++ b/core/src/kinds.graphql
@@ -4,6 +4,9 @@ fragment BuildingKind on Node {
         id
         value
     }
+    model: annotation(name: "model") {
+        value
+    }
     # materials are the construction costs to build
     materials: edges(match: { kinds: ["Item"], via: { rel: "Material" } }) {
         ...ItemSlot


### PR DESCRIPTION
adds "model" annotation to the building kind query - we will use this to pick which 3d model (building vs enemy) to show in the map