### PR TITLE
Removed move as default state on selection

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
@@ -168,7 +168,6 @@ public class MapInteractionManager : MonoBehaviour
             {
                 Debug.Log("Select Seeker: " + seekerID);
                 Cog.GameStateMediator.Instance.SendSelectSeekerMsg(seekerID);
-                GameStateMediator.Instance.SendSetIntentMsg(IntentKind.MOVE);
             }
         }
         else if (GameStateMediator.Instance.gameState.Selected.Intent != IntentKind.MOVE)


### PR DESCRIPTION
After discussions with Tom and Baker, we have now gone back to 'select' as the default intent when you select your seeker, rather than 'move' or 'use'.