### PR TITLE
Combat Implementation

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -15,7 +15,7 @@ const DEPLOYER_PRIVATE_KEY = "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff
 const commands = [
     {
         name: 'networks',
-        command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --code-size-limit 9999999999999 --gas-limit 9999999999999999 --silent",
+        command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --code-size-limit 9999999999999 --gas-limit 9999999999999999 --silent --block-time 2",
         prefixColor: 'black',
     },
 

--- a/DawnSeekersUnity/Assets/Map/2D_Assets/RenderTextures/OutlineRenderer.renderTexture
+++ b/DawnSeekersUnity/Assets/Map/2D_Assets/RenderTextures/OutlineRenderer.renderTexture
@@ -14,8 +14,8 @@ RenderTexture:
   m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
   serializedVersion: 5
-  m_Width: 2129
-  m_Height: 1317
+  m_Width: 796
+  m_Height: 910
   m_AntiAliasing: 1
   m_MipCount: -1
   m_DepthStencilFormat: 0

--- a/DawnSeekersUnity/Assets/Map/Prefabs/Intents.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/Intents.prefab
@@ -1,5 +1,53 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1136464793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1136464794}
+  - component: {fileID: 1136464795}
+  m_Layer: 0
+  m_Name: UseIntent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1136464794
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1136464793}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6406227089287717616}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1136464795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1136464793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 674d6db085dee4d019504401c38923e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _validHighlightPrefab: {fileID: 9133061235819889254, guid: 7f40037dbe60e4a0d8b02da7ed0b821d,
+    type: 3}
+  _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: b7c618a848ab743e6a4d96eceec155b2,
+    type: 3}
 --- !u!1 &106823549850996205
 GameObject:
   m_ObjectHideFlags: 0
@@ -30,7 +78,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6406227089287717616}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2624196961274548065
 MonoBehaviour:
@@ -47,6 +95,8 @@ MonoBehaviour:
   _validHighlightPrefab: {fileID: 9133061235819889254, guid: 7f40037dbe60e4a0d8b02da7ed0b821d,
     type: 3}
   _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: b7c618a848ab743e6a4d96eceec155b2,
+    type: 3}
+  _combatHighlightPrefab: {fileID: 9133061235819889254, guid: 50a1730dfb22d9c4ba0618a7b5e18cbc,
     type: 3}
 --- !u!1 &6406227089287717617
 GameObject:
@@ -80,6 +130,7 @@ Transform:
   - {fileID: 6406227090609630111}
   - {fileID: 6406227090700894559}
   - {fileID: 6406227089827611953}
+  - {fileID: 1136464794}
   - {fileID: 2135372240047306440}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -142,7 +193,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _validHighlightPrefab: {fileID: 9133061235819889254, guid: 7f40037dbe60e4a0d8b02da7ed0b821d,
     type: 3}
-  _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: b7c618a848ab743e6a4d96eceec155b2,
+  _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: 43a93c66be47d8e49b1acf2431fe0c98,
     type: 3}
 --- !u!1 &6406227090609630104
 GameObject:

--- a/DawnSeekersUnity/Assets/Map/Prefabs/Intents.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/Intents.prefab
@@ -1,5 +1,53 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &106823549850996205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2135372240047306440}
+  - component: {fileID: 2624196961274548065}
+  m_Layer: 0
+  m_Name: CombatIntent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2135372240047306440
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106823549850996205}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6406227089287717616}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2624196961274548065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106823549850996205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ec2f37c61d144332b7d4739ecc1b4fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _validHighlightPrefab: {fileID: 9133061235819889254, guid: 7f40037dbe60e4a0d8b02da7ed0b821d,
+    type: 3}
+  _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: b7c618a848ab743e6a4d96eceec155b2,
+    type: 3}
 --- !u!1 &6406227089287717617
 GameObject:
   m_ObjectHideFlags: 0
@@ -32,6 +80,7 @@ Transform:
   - {fileID: 6406227090609630111}
   - {fileID: 6406227090700894559}
   - {fileID: 6406227089827611953}
+  - {fileID: 2135372240047306440}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/DawnSeekersUnity/Assets/Map/Prefabs/Intents.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/Intents.prefab
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _validHighlightPrefab: {fileID: 9133061235819889254, guid: 7f40037dbe60e4a0d8b02da7ed0b821d,
     type: 3}
-  _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: b7c618a848ab743e6a4d96eceec155b2,
+  _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: c86ba47b0de074dcea2a4af310a133b6,
     type: 3}
 --- !u!1 &106823549850996205
 GameObject:

--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -2270,54 +2270,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tooltipParent: {fileID: 1118148263}
   tooltipText: {fileID: 462194216}
---- !u!1 &1136464793
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1136464794}
-  - component: {fileID: 1136464795}
-  m_Layer: 0
-  m_Name: UseIntent
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1136464794
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1136464793}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6406227089419367164}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1136464795
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1136464793}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 674d6db085dee4d019504401c38923e9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _validHighlightPrefab: {fileID: 9133061235819889254, guid: 7f40037dbe60e4a0d8b02da7ed0b821d,
-    type: 3}
-  _selectedHighlightPrefab: {fileID: 9133061235819889254, guid: c86ba47b0de074dcea2a4af310a133b6,
-    type: 3}
 --- !u!1 &1163575909
 GameObject:
   m_ObjectHideFlags: 0
@@ -3490,20 +3442,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Intents
       objectReference: {fileID: 0}
-    - target: {fileID: 8967175068638033150, guid: 6aed245e8122049368e7ebb7195afd6e,
-        type: 3}
-      propertyPath: _selectedHighlightPrefab
-      value: 
-      objectReference: {fileID: 9133061235819889254, guid: 43a93c66be47d8e49b1acf2431fe0c98,
-        type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6aed245e8122049368e7ebb7195afd6e, type: 3}
---- !u!4 &6406227089419367164 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6406227089287717616, guid: 6aed245e8122049368e7ebb7195afd6e,
-    type: 3}
-  m_PrefabInstance: {fileID: 6406227089419367163}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6518314204280695803
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Editor/IntentsEditorWindow.cs
@@ -65,7 +65,7 @@ public class IntentsEditorWindow : EditorWindow
 
         if (GUILayout.Button("Combat", GUILayout.Height(50f)))
         {
-            //IntentClick("Kick their ass, sea bass!");
+            IntentClick("combat");
         }
 
         GUILayout.Space(10f);

--- a/DawnSeekersUnity/Assets/Map/Scripts/Helpers/SeekerHelper.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Helpers/SeekerHelper.cs
@@ -4,7 +4,7 @@ public class SeekerHelper
 {
     public static bool IsPlayerSeeker(Seekers3 seeker)
     {
-        return GameStateMediator.Instance.gameState.Player.Id
-            == seeker.Owner.AdditionalProperties["id"] as string;
+        return GameStateMediator.Instance.gameState.Player != null
+            && GameStateMediator.Instance.gameState.Player.Id == seeker.Owner.Id;
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Helpers/TileHelper.cs
@@ -2,6 +2,7 @@ using System;
 using Cog;
 using UnityEngine;
 using System.Linq;
+using System.Collections;
 
 public class TileHelper
 {
@@ -53,15 +54,11 @@ public class TileHelper
 
     public static Vector3Int GetTilePosCube(NextLocation2 loc)
     {
-        // TODO: NextLocation hasn't generated properly so doesn't show the fields it has on it!
-        var tileObj = loc.AdditionalProperties["tile"] as Newtonsoft.Json.Linq.JObject;
-        var coordsObj = tileObj.GetValue("coords");
-        var coords = coordsObj
-            .Values<string>()
+        var coords = loc.Tile.Coords
             .Select(
                 (coord) =>
                 {
-                    return Convert.ToInt16(coord, 16);
+                    return Convert.ToInt16((string)coord, 16);
                 }
             )
             .ToArray();
@@ -89,15 +86,11 @@ public class TileHelper
 
     public static Vector3Int GetTilePosCube(NextLocation4 loc)
     {
-        // TODO: NextLocation hasn't generated properly so doesn't show the fields it has on it!
-        var tileObj = loc.AdditionalProperties["tile"] as Newtonsoft.Json.Linq.JObject;
-        var coordsObj = tileObj.GetValue("coords");
-        var coords = coordsObj
-            .Values<string>()
+        var coords = loc.Tile.Coords
             .Select(
                 (coord) =>
                 {
-                    return Convert.ToInt16(coord, 16);
+                    return Convert.ToInt16((string)coord, 16);
                 }
             )
             .ToArray();
@@ -112,7 +105,7 @@ public class TileHelper
         if (tile.BagBalances != null && tile.BagBalances.Count > 0)
         {
             double totalBalance = tile.BagBalances.Aggregate(
-                0,
+                0.0,
                 (acc, balObj) => acc + balObj.Balance
             );
             return totalBalance > 0;
@@ -129,6 +122,19 @@ public class TileHelper
     public static bool HasBuilding(Tiles2 tile)
     {
         return tile.Building != null;
+    }
+
+    public static bool HasActiveCombatSession(Tiles2 tile)
+    {
+        var activeSession = GetActiveSession(tile);
+        return activeSession != null;
+    }
+
+    public static Sessions2 GetActiveSession(Tiles2 tile)
+    {
+        return tile.Sessions.FirstOrDefault(
+            session => session.IsFinalised == null || session.IsFinalised.Flag != 1
+        );
     }
 
     public static Vector3Int[] GetTileNeighbours(Vector3Int tile)

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/CombatIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/CombatIntent.cs
@@ -17,9 +17,13 @@ public class CombatIntent : IntentHandler
     private Dictionary<Vector3Int, GameObject> _spawnedValidHighlights;
     private Dictionary<Vector3Int, GameObject> _spawnedSelectedHighlights;
 
+    // TODO: Doesn't belong in intent
+    private Dictionary<Vector3Int, GameObject> _spawnedCombatHighlights;
+
     [SerializeField]
     private GameObject _validHighlightPrefab,
-        _selectedHighlightPrefab;
+        _selectedHighlightPrefab,
+        _combatHighlightPrefab;
 
     CombatIntent()
     {
@@ -32,6 +36,7 @@ public class CombatIntent : IntentHandler
         _validTilePositions = Array.Empty<Vector3Int>();
         _spawnedValidHighlights = new Dictionary<Vector3Int, GameObject>();
         _spawnedSelectedHighlights = new Dictionary<Vector3Int, GameObject>();
+        _spawnedCombatHighlights = new Dictionary<Vector3Int, GameObject>();
     }
 
     protected void Start()
@@ -50,6 +55,9 @@ public class CombatIntent : IntentHandler
 
     private void OnStateUpdated(GameState state)
     {
+        // TODO: Doesn't belong in intent
+        HighlightCombatTiles(state.World.Tiles);
+
         if (state.Selected.Intent == Intent)
         {
             _isActiveIntent = true;
@@ -152,6 +160,15 @@ public class CombatIntent : IntentHandler
             .ToArray();
 
         HighlightTiles(validTilePositions, _selectedHighlightPrefab, _spawnedSelectedHighlights);
+    }
+
+    private void HighlightCombatTiles(ICollection<Tiles2> worldTiles)
+    {
+        Vector3Int[] combatTiles = worldTiles
+            .Where((tile) => TileHelper.HasActiveCombatSession(tile))
+            .Select((tile) => TileHelper.GetTilePosCube(tile))
+            .ToArray();
+        HighlightTiles(combatTiles, _combatHighlightPrefab, _spawnedCombatHighlights);
     }
 
     private void RemoveAllHighlights()

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/CombatIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/CombatIntent.cs
@@ -128,8 +128,10 @@ public class CombatIntent : IntentHandler
         var neighbourTiles = TileHelper.GetTileNeighbours(_seekerPos);
         var validTiles = neighbourTiles.Where(cellPosCube =>
         {
-            return TileHelper.IsDiscoveredTile(cellPosCube) && TileHelper.HasBuilding(cellPosCube);
-            // TODO: && !TileHelper.HasCombatSession(cellPosCube);
+            var tile = TileHelper.GetTileByPos(cellPosCube);
+            return TileHelper.IsDiscoveredTile(cellPosCube)
+                && TileHelper.HasBuilding(tile)
+                && !TileHelper.HasActiveCombatSession(tile);
         });
 
         return validTiles.Append(_seekerPos).ToArray();

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/CombatIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/CombatIntent.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Cog;
+using UnityEngine;
+
+public class CombatIntent : IntentHandler
+{
+    public static CombatIntent instance;
+    private bool _isActiveIntent;
+    private Vector3Int _seekerPos;
+    private Vector3Int[] _validTilePositions;
+    private Vector3Int[] _selectedTilePositions;
+
+    // TODO: put in base class
+    private Dictionary<Vector3Int, GameObject> _spawnedValidHighlights;
+    private Dictionary<Vector3Int, GameObject> _spawnedSelectedHighlights;
+
+    [SerializeField]
+    private GameObject _validHighlightPrefab,
+        _selectedHighlightPrefab;
+
+    CombatIntent()
+    {
+        Intent = IntentKind.COMBAT;
+    }
+
+    private void Awake()
+    {
+        instance = this;
+        _validTilePositions = Array.Empty<Vector3Int>();
+        _spawnedValidHighlights = new Dictionary<Vector3Int, GameObject>();
+        _spawnedSelectedHighlights = new Dictionary<Vector3Int, GameObject>();
+    }
+
+    protected void Start()
+    {
+        GameStateMediator.Instance.EventStateUpdated += OnStateUpdated;
+        MapInteractionManager.instance.EventTileLeftClick += OnTileLeftClick;
+        MapInteractionManager.instance.EventTileRightClick += OnTileRightClick;
+    }
+
+    private void OnDestroy()
+    {
+        GameStateMediator.Instance.EventStateUpdated -= OnStateUpdated;
+        MapInteractionManager.instance.EventTileLeftClick -= OnTileLeftClick;
+        MapInteractionManager.instance.EventTileRightClick -= OnTileRightClick;
+    }
+
+    private void OnStateUpdated(GameState state)
+    {
+        if (state.Selected.Intent == Intent)
+        {
+            _isActiveIntent = true;
+            _seekerPos = TileHelper.GetTilePosCube(state.Selected.Seeker.NextLocation);
+            _validTilePositions = GetValidTilePositions(state);
+            _selectedTilePositions = GetSelectedTilePositions(state);
+            if (_selectedTilePositions.Length == 0 || _selectedTilePositions[0] != _seekerPos)
+            {
+                // Player's tile needs to be the first tile selected
+                GameStateMediator.Instance.SendSelectTileMsg(
+                    new List<string>() { TileHelper.GetTileID(_seekerPos) }
+                );
+                return;
+            }
+
+            HighlightSelectedTiles(_selectedTilePositions);
+
+            // Highlight the valid tiles that haven't been selected
+            HighlightValidTiles(
+                _validTilePositions
+                    .Where(cellPosCube => !_spawnedSelectedHighlights.ContainsKey(cellPosCube))
+                    .ToArray()
+            );
+        }
+        else
+        {
+            _isActiveIntent = false;
+            RemoveAllHighlights();
+        }
+    }
+
+    private void OnTileLeftClick(Vector3Int cellPosCube)
+    {
+        if (!_isActiveIntent)
+            return;
+
+        if (_spawnedSelectedHighlights.ContainsKey(cellPosCube) && cellPosCube != _seekerPos)
+        {
+            //return;
+
+            // NOTE: This code allows us to deselect a tile if we decide to reintroduce
+            //
+            // Deselect tile (This is always going to yield an empty list but keeping it here for posterity)
+            var tileIDs = _spawnedSelectedHighlights
+                .Where(kvp => kvp.Key != cellPosCube)
+                .Select(kvp => TileHelper.GetTileID(kvp.Key))
+                .ToList();
+
+            GameStateMediator.Instance.SendSelectTileMsg(tileIDs);
+        }
+        else if (_validTilePositions.Contains(cellPosCube))
+        {
+            // Selection can at maximum be two tiles; the player's and the tile being attacked.
+            GameStateMediator.Instance.SendSelectTileMsg(
+                new List<string>()
+                {
+                    TileHelper.GetTileID(_seekerPos),
+                    TileHelper.GetTileID(cellPosCube)
+                }
+            );
+        }
+    }
+
+    private void OnTileRightClick(Vector3Int cellPosCube)
+    {
+#if UNITY_EDITOR
+#elif UNITY_WEBGL
+        return;
+#endif
+        if (!_isActiveIntent)
+            return;
+    }
+
+    private Vector3Int[] GetValidTilePositions(GameState state)
+    {
+        var neighbourTiles = TileHelper.GetTileNeighbours(_seekerPos);
+        var validTiles = neighbourTiles.Where(cellPosCube =>
+        {
+            return TileHelper.IsDiscoveredTile(cellPosCube) && TileHelper.HasBuilding(cellPosCube);
+            // TODO: && !TileHelper.HasCombatSession(cellPosCube);
+        });
+
+        return validTiles.Append(_seekerPos).ToArray();
+    }
+
+    // -- Tile Highlighting
+
+    private void HighlightValidTiles(Vector3Int[] tilePositions)
+    {
+        HighlightTiles(tilePositions, _validHighlightPrefab, _spawnedValidHighlights);
+    }
+
+    private void HighlightSelectedTiles(Vector3Int[] tilePositions)
+    {
+        // Filter selection to only contain valid tiles
+        var validTilePositions = tilePositions
+            .Where(cellPosCube => _validTilePositions.Contains(cellPosCube))
+            .ToArray();
+
+        HighlightTiles(validTilePositions, _selectedHighlightPrefab, _spawnedSelectedHighlights);
+    }
+
+    private void RemoveAllHighlights()
+    {
+        foreach (var kvp in _spawnedSelectedHighlights)
+        {
+            Destroy(kvp.Value);
+        }
+        foreach (var kvp in _spawnedValidHighlights)
+        {
+            Destroy(kvp.Value);
+        }
+
+        _spawnedSelectedHighlights.Clear();
+        _spawnedValidHighlights.Clear();
+    }
+
+    // TODO: Move to base class or put into a seperate class all intents can use
+    private void HighlightTiles(
+        Vector3Int[] tilePositions,
+        GameObject highlightPrefab,
+        Dictionary<Vector3Int, GameObject> spawnedHighlights
+    )
+    {
+        // Destroy tiles that are no longer on the list
+        var oldHighlights = spawnedHighlights
+            .Where(kvp => !tilePositions.Contains(kvp.Key))
+            .ToArray();
+
+        foreach (var kvp in oldHighlights)
+        {
+            Destroy(kvp.Value);
+            spawnedHighlights.Remove(kvp.Key);
+        }
+
+        // Highlight tiles on the list that haven't been highlighted
+        foreach (Vector3Int cellPosCube in tilePositions)
+        {
+            if (!spawnedHighlights.ContainsKey(cellPosCube))
+            {
+                GameObject highlight = Instantiate(highlightPrefab);
+                Vector3 cellPos = MapManager.instance.grid.CellToWorld(
+                    GridExtensions.CubeToGrid(cellPosCube)
+                );
+                highlight.transform.position = new Vector3(
+                    cellPos.x,
+                    MapHeightManager.instance.GetHeightAtPosition(cellPos),
+                    cellPos.z
+                );
+                spawnedHighlights.Add(cellPosCube, highlight);
+            }
+        }
+    }
+}

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/CombatIntent.cs.meta
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/CombatIntent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ec2f37c61d144332b7d4739ecc1b4fa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Scripts/IntentKind.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/IntentKind.cs
@@ -5,4 +5,5 @@ public class IntentKind
     public const string SCOUT = "scout";
     public const string CONSTRUCT = "construct";
     public const string USE = "use";
+    public const string COMBAT = "combat";
 }

--- a/DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs
@@ -12,17 +12,16 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PartialOfSelectedPlayerFragment
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public PartialOfSelectedPlayerFragment__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Addr { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("seekers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("seekers", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Seekers> Seekers { get; set; }
 
 
@@ -41,14 +40,13 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Player : PartialOfSelectedPlayerFragment
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Player__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Addr { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
 
@@ -57,13 +55,13 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Selection
     {
-        [Newtonsoft.Json.JsonProperty("intent", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("intent", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Intent { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("seeker", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("seeker", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Seeker Seeker { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("tiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("tiles", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Tiles> Tiles { get; set; }
 
 
@@ -82,13 +80,13 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Json
     {
-        [Newtonsoft.Json.JsonProperty("player", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("player", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Player Player { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("selected", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("selected", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Selection Selected { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("world", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("world", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public World World { get; set; }
 
 
@@ -105,38 +103,27 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum PartialOfSelectedPlayerFragment__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
-
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Seekers
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Seekers__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Bags> Bags { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Key { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("nextLocation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("nextLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public NextLocation NextLocation { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Owner Owner { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("prevLocation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("prevLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PrevLocation PrevLocation { get; set; }
 
 
@@ -153,38 +140,27 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Player__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
-
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Seeker
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Seeker__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Bags2> Bags { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Key { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("nextLocation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("nextLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public NextLocation2 NextLocation { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Owner2 Owner { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("prevLocation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("prevLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PrevLocation2 PrevLocation { get; set; }
 
 
@@ -203,30 +179,35 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Tiles
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Tiles__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("bagCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("bagBalances", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<BagBalances> BagBalances { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("bagCount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double BagCount { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Bags3> Bags { get; set; }
 
         [Newtonsoft.Json.JsonProperty("biome", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Biome { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("building", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("building", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Building Building { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<object> Coords { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("seekers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("seekers", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Seekers2> Seekers { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("sessions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Sessions> Sessions { get; set; }
 
 
 
@@ -244,17 +225,19 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class World
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public World__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("block", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("block", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Block { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("players", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("buildings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Buildings> Buildings { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("players", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Players> Players { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("tiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("tiles", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Tiles2> Tiles { get; set; }
 
 
@@ -271,29 +254,18 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Seekers__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
-
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Bags
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Bags__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Bag Bag { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Key { get; set; }
 
 
@@ -312,6 +284,21 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class NextLocation
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile Tile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Time { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -328,6 +315,12 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Owner
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -344,6 +337,21 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PrevLocation
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile2 Tile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Time { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -358,29 +366,18 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Seeker__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
-
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Bags2
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Bags2__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Bag2 Bag { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Key { get; set; }
 
 
@@ -399,6 +396,21 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class NextLocation2
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile3 Tile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Time { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -415,6 +427,12 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Owner2
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -431,6 +449,21 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PrevLocation2
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile4 Tile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Time { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -445,29 +478,40 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Tiles__typename
+    public partial class BagBalances
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
 
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Bags3
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Bags3__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Bag3 Bag { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Key { get; set; }
 
 
@@ -486,6 +530,18 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Building
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Bags4> Bags { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("kind", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Kind Kind { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -502,23 +558,22 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Seekers2
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Seekers2__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Key { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("nextLocation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("nextLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public NextLocation3 NextLocation { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Owner3 Owner { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("prevLocation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("prevLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PrevLocation3 PrevLocation { get; set; }
 
 
@@ -535,26 +590,80 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum World__typename
+    public partial class Sessions
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"State")]
-        State = 0,
+        [Newtonsoft.Json.JsonProperty("attackTile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public AttackTile AttackTile { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Bags5> Bags { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("defenceTile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public DefenceTile DefenceTile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("isFinalised", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IsFinalised IsFinalised { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("sessionUpdates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<SessionUpdates> SessionUpdates { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Buildings
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Bags6> Bags { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("kind", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Kind2 Kind { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Players
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Players__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Addr { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
 
@@ -573,30 +682,32 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Tiles2
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Tiles2__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("bagCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("bagBalances", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<BagBalances2> BagBalances { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("bagCount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double BagCount { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("bagBalances")]
-        public System.Collections.Generic.ICollection<BagBalance> BagBalances { get; set; }
 
         [Newtonsoft.Json.JsonProperty("biome", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Biome { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("building", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("building", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Building2 Building { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<object> Coords { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("seekers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("seekers", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Seekers3> Seekers { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("sessions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Sessions2> Sessions { get; set; }
 
 
 
@@ -611,36 +722,19 @@ namespace Cog
 
     }
 
-    public partial class BagBalance
-    {
-        [Newtonsoft.Json.JsonProperty("balance")]
-        public int Balance { get; set; }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Bags__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Edge")]
-        Edge = 0,
-
-
-    }
-
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Bag
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Bag__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Key { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Slots> Slots { get; set; }
 
 
@@ -657,29 +751,68 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Bags2__typename
+    public partial class Tile
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Edge")]
-        Edge = 0,
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<object> Coords { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<object> Coords { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Bag2
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Bag2__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Key { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Slots2> Slots { get; set; }
 
 
@@ -696,29 +829,68 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Bags3__typename
+    public partial class Tile3
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Edge")]
-        Edge = 0,
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<object> Coords { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile4
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<object> Coords { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Bag3
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Bag3__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Key { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Slots3> Slots { get; set; }
 
 
@@ -735,18 +907,88 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Seekers2__typename
+    public partial class Bags4
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Bag4 Bag { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Kind
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("inputs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Inputs> Inputs { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("materials", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Materials> Materials { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("model", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Model Model { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name Name { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("outputs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Outputs> Outputs { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class NextLocation3
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile5 Tile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Time { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -763,6 +1005,12 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Owner3
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -779,6 +1027,21 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PrevLocation3
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile6 Tile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Time { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -793,28 +1056,232 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Players__typename
+    public partial class AttackTile
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("startBlock", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double StartBlock { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile7 Tile { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Tiles2__typename
+    public partial class Bags5
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Bag5 Bag { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class DefenceTile
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("startBlock", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double StartBlock { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile8 Tile { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class IsFinalised
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("flag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Flag { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class SessionUpdates
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Bags6
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Bag6 Bag { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Kind2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("inputs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Inputs2> Inputs { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("materials", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Materials2> Materials { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("model", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Model2 Model { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name2 Name { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("outputs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Outputs2> Outputs { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class BagBalances2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Building2
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Bags7> Bags { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("kind", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Kind3 Kind { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -831,23 +1298,22 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Seekers3
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Seekers3__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public object Key { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("nextLocation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("nextLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public NextLocation4 NextLocation { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Owner4 Owner { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("prevLocation", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("prevLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PrevLocation4 PrevLocation { get; set; }
 
 
@@ -864,29 +1330,55 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Bag__typename
+    public partial class Sessions2
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("attackTile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public AttackTile2 AttackTile { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("bags", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Bags8> Bags { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("defenceTile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public DefenceTile2 DefenceTile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("isFinalised", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IsFinalised2 IsFinalised { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("sessionUpdates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<SessionUpdates2> SessionUpdates { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Slots
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Slots__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Balance { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Item Item { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Key { get; set; }
 
 
@@ -899,33 +1391,22 @@ namespace Cog
             get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
             set { _additionalProperties = value; }
         }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Bag2__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
-
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Slots2
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Slots2__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Balance { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Item2 Item { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Key { get; set; }
 
 
@@ -938,33 +1419,22 @@ namespace Cog
             get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
             set { _additionalProperties = value; }
         }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Bag3__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
-
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Slots3
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Slots3__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Balance { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Item3 Item { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Key { get; set; }
 
 
@@ -981,18 +1451,528 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Seekers3__typename
+    public partial class Bag4
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public object Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Slots4> Slots { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Inputs
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item4 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Materials
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item5 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Model
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Outputs
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item6 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile5
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<object> Coords { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile6
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<object> Coords { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile7
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Bag5
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public object Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Slots5> Slots { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile8
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Bag6
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public object Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Slots6> Slots { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Inputs2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item7 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Materials2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item8 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Model2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Outputs2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item9 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Bags7
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Bag7 Bag { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Kind3
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("inputs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Inputs3> Inputs { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("materials", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Materials3> Materials { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("model", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Model3 Model { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name3 Name { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("outputs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Outputs3> Outputs { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class NextLocation4
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile9 Tile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Time { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -1009,6 +1989,12 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Owner4
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -1025,6 +2011,21 @@ namespace Cog
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PrevLocation4
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile10 Tile { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Time { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -1039,27 +2040,144 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Slots__typename
+    public partial class AttackTile2
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Edge")]
-        Edge = 0,
+        [Newtonsoft.Json.JsonProperty("startBlock", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double StartBlock { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile11 Tile { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Bags8
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("bag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Bag8 Bag { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class DefenceTile2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("startBlock", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double StartBlock { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("tile", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Tile12 Tile { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class IsFinalised2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("flag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Flag { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class SessionUpdates2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Item
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Item__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("kind", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Kind { get; set; }
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name4 Name { get; set; }
 
 
 
@@ -1071,31 +2189,23 @@ namespace Cog
             get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
             set { _additionalProperties = value; }
         }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Slots2__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Edge")]
-        Edge = 0,
-
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Item2
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Item2__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon2 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("kind", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Kind { get; set; }
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name5 Name { get; set; }
 
 
 
@@ -1107,31 +2217,23 @@ namespace Cog
             get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
             set { _additionalProperties = value; }
         }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Slots3__typename
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Edge")]
-        Edge = 0,
-
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class Item3
     {
-        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public Item3__typename __typename { get; set; }
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon3 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Id { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("kind", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Kind { get; set; }
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name6 Name { get; set; }
 
 
 
@@ -1147,32 +2249,1665 @@ namespace Cog
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Item__typename
+    public partial class Slots4
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item10 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Item2__typename
+    public partial class Item4
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon4 Icon { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name7 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
-    public enum Item3__typename
+    public partial class Item5
     {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Node")]
-        Node = 0,
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon5 Icon { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name8 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item6
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon6 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name9 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Slots5
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item11 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Slots6
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item12 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item7
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon7 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name10 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item8
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon8 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name11 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item9
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon9 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name12 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Bag7
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public object Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Slots7> Slots { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Inputs3
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item13 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Materials3
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item14 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Model3
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name3
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Outputs3
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item15 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile9
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<object> Coords { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile10
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("coords", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<object> Coords { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile11
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Bag8
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public object Key { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("slots", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<Slots8> Slots { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Tile12
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name4
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon2
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name5
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon3
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name6
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item10
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon10 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name13 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon4
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name7
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon5
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name8
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon6
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name9
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item11
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon11 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name14 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item12
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon12 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name15 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon7
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name10
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon8
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name11
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon9
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name12
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Slots7
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item16 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item13
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon13 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name16 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item14
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon14 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name17 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item15
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon15 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name18 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Slots8
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Balance { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("item", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Item17 Item { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Key { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon10
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name13
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon11
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name14
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon12
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name15
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item16
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon16 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name19 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon13
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name16
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon14
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name17
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon15
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name18
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Item17
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("icon", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Icon17 Icon { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Name20 Name { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon16
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name19
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Icon17
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.8.0.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class Name20
+    {
+        [Newtonsoft.Json.JsonProperty("__typename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string __typename { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Value { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
 
     }
 }

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,2 +1,4 @@
-cog/=lib/cog/contracts/src
-@ds/=src
+@ds/=src/
+cog/=lib/cog/contracts/src/
+ds-test/=lib/forge-std/lib/ds-test/src/
+forge-std/=lib/forge-std/src/

--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -46,9 +46,9 @@ contract GameDeployer is Script {
 
         // find the base item ids
         bytes24 none = 0x0;
-        bytes24 kiki = ItemUtils.Kiki();
-        bytes24 bouba = ItemUtils.Bouba();
-        bytes24 semiote = ItemUtils.Semiote();
+        bytes24 kiki = ItemUtils.Kiki(); // Life
+        bytes24 bouba = ItemUtils.Bouba(); // Defence
+        bytes24 semiote = ItemUtils.Semiote(); // Attack
 
         // register a new item id
         bytes24 welcomeCocktail = ItemUtils.register(
@@ -57,10 +57,10 @@ contract GameDeployer is Script {
                 id: 100,
                 name: "Welcome Cocktail",
                 icon: "02-40",
-                life: 1,
+                life: 0,
                 defense: 1,
-                attack: 0,
-                stackable: true,
+                attack: 2,
+                stackable: false,
                 implementation: address(0),
                 plugin: ""
             })
@@ -79,8 +79,8 @@ contract GameDeployer is Script {
                     Material({quantity: 0, item: none})
                 ],
                 inputs: [
-                    Input({quantity: 2, item: kiki}),
                     Input({quantity: 2, item: bouba}),
+                    Input({quantity: 2, item: semiote}),
                     Input({quantity: 0, item: none}),
                     Input({quantity: 0, item: none})
                 ],

--- a/contracts/src/Game.sol
+++ b/contracts/src/Game.sol
@@ -19,6 +19,7 @@ import {BuildingRule} from "@ds/rules/BuildingRule.sol";
 import {CraftingRule} from "@ds/rules/CraftingRule.sol";
 import {PluginRule} from "@ds/rules/PluginRule.sol";
 import {NewPlayerRule} from "@ds/rules/NewPlayerRule.sol";
+import {CombatRule} from "@ds/rules/CombatRule.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 
 using Schema for StateGraph;
@@ -71,6 +72,8 @@ contract Game is BaseGame {
         state.registerNodeType(Kind.Building.selector, "Building", CompoundKeyKind.INT16_ARRAY);
         state.registerNodeType(Kind.Extension.selector, "Extension", CompoundKeyKind.ADDRESS);
         state.registerNodeType(Kind.ClientPlugin.selector, "ClientPlugin", CompoundKeyKind.UINT160);
+        state.registerNodeType(Kind.CombatSession.selector, "CombatSession", CompoundKeyKind.UINT160);
+        state.registerNodeType(Kind.Hash.selector, "Hash", CompoundKeyKind.BYTES);
 
         // register the relationship ids we are using
         state.registerEdgeType(Rel.Owner.selector, "Owner", WeightKind.UINT64);
@@ -84,6 +87,9 @@ contract Game is BaseGame {
         state.registerEdgeType(Rel.Is.selector, "Is", WeightKind.UINT64);
         state.registerEdgeType(Rel.Implementation.selector, "Implementation", WeightKind.UINT64);
         state.registerEdgeType(Rel.Supports.selector, "Supports", WeightKind.UINT64);
+        state.registerEdgeType(Rel.Has.selector, "Has", WeightKind.UINT64);
+        state.registerEdgeType(Rel.Combat.selector, "Combat", WeightKind.UINT64);
+        state.registerEdgeType(Rel.IsFinalised.selector, "IsFinalised", WeightKind.UINT64);
 
         // create a session router
         SessionRouter router = new DawnseekersRouter();
@@ -99,6 +105,7 @@ contract Game is BaseGame {
         dispatcher.registerRule(new CraftingRule(this));
         dispatcher.registerRule(new PluginRule());
         dispatcher.registerRule(new NewPlayerRule(allowlist));
+        dispatcher.registerRule(new CombatRule());
         dispatcher.registerRouter(router);
 
         // update the game with this config

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {BiomeKind} from "@ds/schema/Schema.sol";
+import {CombatRule} from "@ds/rules/CombatRule.sol";
 
 // ----------------------------------
 // define some actions
@@ -80,6 +81,22 @@ interface Actions {
 
     // spawn a seeker for the sender
     function SPAWN_SEEKER(bytes24 seeker) external;
+
+    function START_COMBAT(bytes24 seekerID, bytes24 tileID, bytes24[] calldata attackers, bytes24[] calldata defenders)
+        external;
+
+    function CLAIM_COMBAT(
+        bytes24 seekerID,
+        bytes24 sessionID,
+        CombatRule.CombatAction[][] calldata sessionUpdates,
+        uint32[] calldata sortedListIndexes
+    ) external;
+
+    function FINALISE_COMBAT(
+        bytes24 sessionID,
+        CombatRule.CombatAction[][] calldata sessionUpdates,
+        uint32[] calldata sortedListIndexes
+    ) external;
 
     // [dev/debug only] set a tile biome at any location
     function DEV_SPAWN_TILE(BiomeKind kind, int16 q, int16 r, int16 s) external;

--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -224,7 +224,7 @@ contract CombatRule is Rule {
         return state;
     }
 
-    function _finaliseSession(State state, CombatState memory combatState, bytes24 sessionID, Context calldata ctx)
+    function _finaliseSession(State state, CombatState memory combatState, bytes24 sessionID, Context calldata /*ctx*/ )
         private
     {
         console.log("Finalising Session");
@@ -474,7 +474,7 @@ contract CombatRule is Rule {
         CombatSideKey combatSide,
         uint64 blockNum,
         uint32 entityNum
-    ) private view {
+    ) private pure {
         // TODO: obviously not random
         bytes32 rnd = keccak256(abi.encode(blockNum, combatState.tickCount, entityNum));
 
@@ -583,7 +583,7 @@ contract CombatRule is Rule {
     }
 
     // TODO: Add an end flag after the first claim so we don't have to wait until timeout for this session to end
-    function _getActiveSession(State state, bytes24 tileID, Context calldata ctx) private view returns (bytes24) {
+    function _getActiveSession(State state, bytes24 tileID, Context calldata /*ctx*/ ) private view returns (bytes24) {
         (bytes24 sessionID, uint64 startBlockNum) = state.get(Rel.Has.selector, 0, tileID);
         if (startBlockNum > 0 && !state.getIsFinalised(sessionID)) return sessionID;
 

--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -39,8 +39,6 @@ error EnityNotOnWinningSide();
 error NoDamageInflicedCannotClaim();
 
 uint64 constant BLOCKS_PER_TICK = 1;
-uint64 constant COMBAT_MAX_TICKS = 100;
-uint64 constant COMBAT_MAX_BLOCKS = COMBAT_MAX_TICKS * BLOCKS_PER_TICK;
 uint8 constant MAX_ENTITIES_PER_SIDE = 100; // No higher than 256 due to there being a reward bag for each entity and edges being 8 bit indices
 uint8 constant TILE_ATTACK_INDEX = 0;
 uint8 constant TILE_DEFEND_INDEX = 1;

--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -282,8 +282,24 @@ contract CombatRule is Rule {
         // Destroy the building
         // TODO: Maybe the building rule should be doing this so all building construction/destruction logic is in the same place
         //       The building rule would need to be able to check that the action was dispatched by the CombatRule
+        if (bytes4(buildingState.entityID) == Kind.Building.selector) {
+            _destroyBuilding(state, buildingState.entityID);
+        }
 
         state.setIsFinalised(sessionID, true);
+    }
+
+    function _destroyBuilding(State state, bytes24 buildingInstance) private {
+        // set type of building
+        state.setBuildingKind(buildingInstance, bytes24(0));
+        // set building owner to player who created it
+        state.setOwner(buildingInstance, bytes24(0));
+        // set building location
+        state.setFixedLocation(buildingInstance, bytes24(0));
+
+        // TODO: Orphaned bags
+        state.setEquipSlot(buildingInstance, 0, bytes24(0));
+        state.setEquipSlot(buildingInstance, 1, bytes24(0));
     }
 
     function _makeClaim(

--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -1,0 +1,791 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {State, CompoundKeyDecoder} from "cog/State.sol";
+import {Context, Rule} from "cog/Dispatcher.sol";
+
+import {
+    Schema,
+    Node,
+    Kind,
+    BiomeKind,
+    Rel,
+    LocationKey,
+    TRAVEL_SPEED,
+    DEFAULT_ZONE,
+    ATOM_LIFE,
+    ATOM_DEFENSE,
+    ATOM_ATTACK
+} from "@ds/schema/Schema.sol";
+import {TileUtils} from "@ds/utils/TileUtils.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import "forge-std/console.sol";
+import "@ds/utils/Base64.sol";
+import "@ds/utils/LibString.sol";
+import {ItemUtils} from "@ds/utils/ItemUtils.sol";
+
+using Schema for State;
+
+error SeekerNotOwnedByPlayer();
+error SeekerNotAtDestination();
+error EntityNotAtAttackTile();
+error EntityNotAtDefenceTile();
+error CombatSessionAlreadyActive();
+error CombatNotAdjacent();
+error CombatSessionHashIncorrect();
+error EntityNotFound();
+error EntityAlreadyClaimed();
+error EnityNotOnWinningSide();
+error NoDamageInflicedCannotClaim();
+
+uint64 constant BLOCKS_PER_TICK = 1;
+uint64 constant COMBAT_MAX_TICKS = 100;
+uint64 constant COMBAT_MAX_BLOCKS = COMBAT_MAX_TICKS * BLOCKS_PER_TICK;
+uint8 constant MAX_ENTITIES_PER_SIDE = 100; // No higher than 256 due to there being a reward bag for each entity and edges being 8 bit indices
+uint8 constant TILE_ATTACK_INDEX = 0;
+uint8 constant TILE_DEFEND_INDEX = 1;
+uint8 constant HASH_EDGE_INDEX = 2;
+
+contract CombatRule is Rule {
+    uint64 public prevCombatSessionID = 0; // combat sessions are incremented
+
+    enum CombatSideKey {
+        ATTACK,
+        DEFENCE
+    }
+
+    enum CombatActionKind {
+        NONE,
+        JOIN,
+        LEAVE,
+        CLAIM,
+        EQUIP, // not now
+        UNEQUIP // Maybe?
+    }
+
+    struct CombatAction {
+        CombatActionKind kind;
+        bytes24 entityID; // Can be seeker or building
+        uint64 blockNum;
+        bytes data;
+    }
+
+    struct JoinActionInfo {
+        CombatSideKey combatSide; // Attack or Defence
+        uint32[3] stats; // Based off of atoms. The key is Schema.AtomKind
+    }
+
+    struct LeaveActionInfo {
+        CombatSideKey combatSide; // Attack or Defence
+    }
+
+    struct EquipActionInfo {
+        uint32[3] stats; // Based off of atoms. The key is Schema.AtomKind
+    }
+
+    struct CombatState {
+        EntityState[] attackerStates;
+        EntityState[] defenderStates;
+        uint16 attackerCount;
+        uint16 defenderCount;
+        CombatWinState winState;
+        uint16 tickCount;
+    }
+
+    struct EntityState {
+        bytes24 entityID;
+        uint32[3] stats;
+        uint64 damage;
+        uint64 damageInflicted;
+        bool isPresent;
+        bool isDead;
+        bool hasClaimed;
+    }
+
+    enum CombatWinState {
+        NONE,
+        ATTACKERS,
+        DEFENDERS,
+        DRAW
+    }
+
+    event SessionUpdate(uint64 indexed sessionID, bytes combatActions);
+
+    function reduce(State state, bytes calldata action, Context calldata ctx) public returns (State) {
+        if (bytes4(action) == Actions.SPAWN_SEEKER.selector) {
+            // decode action
+            (bytes24 seeker) = abi.decode(action[4:], (bytes24));
+
+            {
+                // If destination has active session then join
+                (bytes24 nextTileID, uint64 arrivalBlockNum) =
+                    state.get(Rel.Location.selector, uint8(LocationKey.NEXT), seeker);
+                bytes24 sessionID = _getActiveSession(state, nextTileID, ctx);
+                if (sessionID != 0) {
+                    _joinSession(state, sessionID, nextTileID, arrivalBlockNum, seeker);
+                }
+            }
+        }
+
+        if (bytes4(action) == Actions.MOVE_SEEKER.selector) {
+            // NOTE: The MovementRule will revert if the following are true:
+            //       The sender doesn't own the seeker
+            //       The destination tile is undiscoved
+            //       The tile isn't a direct 6-axis line
+
+            // decode the action
+            (uint32 sid, /*int16 q*/, /*int16 r*/, /*int16 s*/ ) = abi.decode(action[4:], (uint32, int16, int16, int16));
+
+            // encode the full seeker node id
+            bytes24 seeker = Node.Seeker(sid);
+
+            {
+                // If prev tile has an active session then leave
+                (bytes24 prevTileID, /*uint64 arrivalBlockNum*/ ) =
+                    state.get(Rel.Location.selector, uint8(LocationKey.PREV), seeker);
+                bytes24 sessionID = _getActiveSession(state, prevTileID, ctx);
+                if (sessionID != 0) {
+                    _leaveSession(state, sessionID, prevTileID, seeker, ctx);
+                }
+            }
+
+            {
+                // If destination has active session then join
+                (bytes24 nextTileID, uint64 arrivalBlockNum) =
+                    state.get(Rel.Location.selector, uint8(LocationKey.NEXT), seeker);
+                bytes24 sessionID = _getActiveSession(state, nextTileID, ctx);
+                if (sessionID != 0) {
+                    _joinSession(state, sessionID, nextTileID, arrivalBlockNum, seeker);
+                }
+            }
+        }
+
+        if (bytes4(action) == Actions.START_COMBAT.selector) {
+            // Decode the action - START_COMBAT(bytes24 seekerID, bytes24 tileID) external;
+            (bytes24 seekerID, bytes24 targetTileID, bytes24[] memory attackers, bytes24[] memory defenders) =
+                abi.decode(action[4:], (bytes24, bytes24, bytes24[], bytes24[]));
+
+            // Is the seeker owned by the player that dispatched this action?
+            _requirePlayerOwnedSeeker(state, seekerID, Node.Player(ctx.sender));
+
+            // Get the current location
+            (bytes24 seekerTile) = state.getCurrentLocation(seekerID, ctx.clock);
+
+            // Revert if the current location doesn't match their seeker destination (cannot start a battle whilst moving)
+            if (state.getNextLocation(seekerID) != seekerTile) revert SeekerNotAtDestination();
+
+            // Check that the seeker tile (attack) and target tile (defend) are adjacent
+            if (TileUtils.distance(seekerTile, targetTileID) != 1) {
+                revert CombatNotAdjacent();
+            }
+
+            // Revert if either of the tiles have an active combat session
+            if (_getActiveSession(state, seekerTile, ctx) != 0) revert CombatSessionAlreadyActive();
+            if (_getActiveSession(state, targetTileID, ctx) != 0) revert CombatSessionAlreadyActive();
+
+            _startSession(state, seekerTile, targetTileID, attackers, defenders, ctx);
+        }
+
+        if (bytes4(action) == Actions.CLAIM_COMBAT.selector) {
+            (
+                bytes24 seekerID,
+                bytes24 sessionID,
+                CombatRule.CombatAction[][] memory sessionUpdates,
+                uint32[] memory sortedListIndexes
+            ) = abi.decode(action[4:], (bytes24, bytes24, CombatRule.CombatAction[][], uint32[]));
+
+            // Check hash of actions matches hash of session (ensures supplied actions haven't been tampered with)
+            if (!_checkSessionHash(state, sessionID, sessionUpdates)) revert CombatSessionHashIncorrect();
+
+            // Might not need this anymore as the first entry would have the first block
+            // ( /*bytes24 attackTileID*/ , uint64 startBlock) =
+            //     state.get(Rel.Has.selector, uint8(CombatSideKey.ATTACK), sessionID);
+
+            CombatState memory combatState = calcCombatState(sessionUpdates, sortedListIndexes, ctx.clock);
+
+            console.log("Win state: ", uint256(combatState.winState));
+
+            _makeClaim(state, combatState, sessionID, seekerID, ctx);
+        }
+
+        if (bytes4(action) == Actions.FINALISE_COMBAT.selector) {
+            (bytes24 sessionID, CombatRule.CombatAction[][] memory sessionUpdates, uint32[] memory sortedListIndexes) =
+                abi.decode(action[4:], (bytes24, CombatRule.CombatAction[][], uint32[]));
+
+            // Check hash of actions matches hash of session (ensures supplied actions haven't been tampered with)
+            if (!_checkSessionHash(state, sessionID, sessionUpdates)) revert CombatSessionHashIncorrect();
+
+            CombatState memory combatState = calcCombatState(sessionUpdates, sortedListIndexes, ctx.clock);
+            if (combatState.winState != CombatWinState.NONE && !state.getIsFinalised(sessionID)) {
+                _finaliseSession(state, combatState, sessionID, ctx);
+            }
+        }
+
+        return state;
+    }
+
+    function _finaliseSession(State state, CombatState memory combatState, bytes24 sessionID, Context calldata ctx)
+        private
+    {
+        console.log("Finalising Session");
+        // Can we still have a draw?
+
+        // Get the winning entities
+        EntityState[] memory winnerStates =
+            combatState.winState == CombatWinState.ATTACKERS ? combatState.attackerStates : combatState.defenderStates;
+        EntityState[] memory loserStates =
+            combatState.winState == CombatWinState.ATTACKERS ? combatState.defenderStates : combatState.attackerStates;
+
+        uint256 totalDamageInflicted = _getTotalDamageInflicted(winnerStates);
+        console.log("totalDamageInflicted: ", totalDamageInflicted);
+
+        // Get fallen building
+        EntityState memory buildingState;
+        for (uint256 i = 0; i < loserStates.length; i++) {
+            if (bytes4(loserStates[i].entityID) == Kind.Building.selector) {
+                buildingState = loserStates[i];
+            }
+        }
+
+        // Spawn bags with winnings for each of the seekers
+        for (uint8 i; i < MAX_ENTITIES_PER_SIDE; i++) {
+            if (!winnerStates[i].isPresent) continue;
+            // TODO: Don't give buildings awards
+
+            console.log("Reward for winner: ", i);
+
+            // Create bag using a combination of sessionID and entityID
+            bytes24 rewardBag = Node.RewardBag(sessionID, winnerStates[i].entityID);
+            // state.set(Rel.Has.selector, 0x0, rewardBag, sessionID, 0); // Bag -> Session
+            state.set(Rel.Equip.selector, i, sessionID, rewardBag, 0); // Session -> Bag
+
+            uint256 damagePercent = (winnerStates[i].damageInflicted * 100) / totalDamageInflicted;
+            console.log("damagePercent: ", damagePercent);
+
+            // Because the resources carry 2 atoms each, we make half the resources to atom count. dividing by 200 effectively is 50%
+            console.log("LIFE: ", (damagePercent * buildingState.stats[ATOM_LIFE]) / 100);
+            state.setItemSlot(
+                rewardBag, 0, ItemUtils.Kiki(), uint64((damagePercent * buildingState.stats[ATOM_LIFE]) / 200)
+            );
+            console.log("DEF: ", (damagePercent * buildingState.stats[ATOM_DEFENSE]) / 100);
+            state.setItemSlot(
+                rewardBag, 1, ItemUtils.Bouba(), uint64((damagePercent * buildingState.stats[ATOM_DEFENSE]) / 200)
+            );
+            console.log("ATK: ", (damagePercent * buildingState.stats[ATOM_ATTACK]) / 100);
+            state.setItemSlot(
+                rewardBag, 2, ItemUtils.Semiote(), uint64((damagePercent * buildingState.stats[ATOM_ATTACK]) / 200)
+            );
+        }
+
+        // If the building has a bag, then transfer to the seeker with the most damage inflicted
+
+        // Destroy the building
+        // TODO: Maybe the building rule should be doing this so all building construction/destruction logic is in the same place
+        //       The building rule would need to be able to check that the action was dispatched by the CombatRule
+
+        state.setIsFinalised(sessionID, true);
+    }
+
+    function _makeClaim(
+        State state,
+        CombatState memory combatState,
+        bytes24 sessionID,
+        bytes24 seekerID,
+        Context calldata ctx
+    ) private {
+        // find the seeker in the list
+        (EntityState memory entityState, bool isAttacker) = _getEntityState(combatState, seekerID);
+
+        if (entityState.entityID != seekerID) revert EntityNotFound();
+
+        // have they claimed yet?
+        if (entityState.hasClaimed) revert EntityAlreadyClaimed();
+
+        // were they on the winning side?
+        if (
+            (isAttacker && combatState.winState != CombatWinState.ATTACKERS)
+                || (!isAttacker && combatState.winState != CombatWinState.DEFENDERS)
+        ) {
+            revert EnityNotOnWinningSide();
+        }
+
+        // calculate their winnings
+        uint256 totalDamageInflicted = _getTotalDamageInflicted(
+            combatState.winState == CombatWinState.ATTACKERS ? combatState.attackerStates : combatState.defenderStates
+        );
+
+        if (totalDamageInflicted == 0) {
+            revert NoDamageInflicedCannotClaim();
+        }
+
+        uint256 damagePercent = (entityState.damageInflicted * 100) / totalDamageInflicted;
+
+        console.log("totalDamageInflicted: ", totalDamageInflicted);
+        console.log("damagePercent: ", damagePercent);
+        console.log("wood: ", (damagePercent * 50) / 100);
+
+        CombatAction[] memory combatActions = new CombatAction[](1);
+        combatActions[0] = CombatAction(CombatActionKind.CLAIM, seekerID, ctx.clock, new bytes(0));
+
+        _emitSessionUpdate(state, sessionID, combatActions);
+    }
+
+    // Only counts entities that are present
+    function _getTotalDamageInflicted(EntityState[] memory entityStates)
+        private
+        pure
+        returns (uint256 totalDamageInflicted)
+    {
+        for (uint256 i = 0; i < entityStates.length; i++) {
+            // Doesn't matter if they are dead or alive, just need to be present
+            if (entityStates[i].isPresent) {
+                totalDamageInflicted += entityStates[i].damageInflicted;
+            }
+        }
+
+        return totalDamageInflicted;
+    }
+
+    function _getEntityState(CombatState memory combatState, bytes24 entityID)
+        private
+        pure
+        returns (EntityState memory entityState, bool isAttacker)
+    {
+        // Search attackers
+        for (uint256 i = 0; i < combatState.attackerStates.length; i++) {
+            entityState = combatState.attackerStates[i];
+            if (entityState.entityID == entityID) return (entityState, true);
+        }
+
+        // Search defenders
+        for (uint256 i = 0; i < combatState.defenderStates.length; i++) {
+            entityState = combatState.defenderStates[i];
+            if (entityState.entityID == entityID) return (entityState, false);
+        }
+
+        return (entityState, false);
+    }
+
+    // Calculates combat state by stepping through the actions and playing the tick by tick logic until `endBlockNum`
+    function calcCombatState(
+        CombatAction[][] memory sessionUpdates,
+        uint32[] memory sortedListIndexes,
+        uint64 endBlockNum
+    ) public view returns (CombatState memory combatState) {
+        combatState = CombatState({
+            attackerStates: new EntityState[](MAX_ENTITIES_PER_SIDE),
+            defenderStates: new EntityState[](MAX_ENTITIES_PER_SIDE),
+            attackerCount: 0,
+            defenderCount: 0,
+            winState: CombatWinState.NONE,
+            tickCount: 0
+        });
+
+        for (uint64 x = 0; x < sortedListIndexes.length; x++) {
+            CombatAction memory combatAction =
+                sessionUpdates[uint16(sortedListIndexes[x])][uint16(sortedListIndexes[x] >> 16)];
+
+            if (combatAction.blockNum >= endBlockNum) {
+                // Battle not finished
+                return (combatState);
+            }
+
+            // How many ticks does this action apply to?
+            uint64 actionEndBlock = x + 1 < sortedListIndexes.length
+                ? sessionUpdates[uint16(sortedListIndexes[x + 1])][uint16(sortedListIndexes[x + 1] >> 16)].blockNum
+                : endBlockNum;
+
+            if (actionEndBlock > endBlockNum) {
+                actionEndBlock = endBlockNum;
+            }
+
+            // Apply action
+            if (combatAction.kind == CombatActionKind.JOIN) {
+                (JoinActionInfo memory info) = abi.decode(combatAction.data, (JoinActionInfo));
+                if (
+                    info.combatSide == CombatSideKey.ATTACK
+                        && _addEntityToCombat(combatState.attackerStates, combatAction, info.stats)
+                ) {
+                    combatState.attackerCount++;
+                } else if (_addEntityToCombat(combatState.defenderStates, combatAction, info.stats)) {
+                    combatState.defenderCount++;
+                }
+            } else if (combatAction.kind == CombatActionKind.LEAVE) {
+                (LeaveActionInfo memory info) = abi.decode(combatAction.data, (LeaveActionInfo));
+                info.combatSide == CombatSideKey.ATTACK ? combatState.attackerCount-- : combatState.defenderCount--;
+                if (combatState.attackerCount == 0) {
+                    combatState.winState = CombatWinState.DEFENDERS;
+                } else if (combatState.defenderCount == 0) {
+                    combatState.winState = CombatWinState.ATTACKERS;
+                }
+            } else if (combatAction.kind == CombatActionKind.CLAIM) {
+                (EntityState memory entityState, /*bool isAttacker*/ ) =
+                    _getEntityState(combatState, combatAction.entityID);
+                entityState.hasClaimed = true;
+                console.log("Claim action: ", uint192(combatAction.entityID));
+            }
+
+            // Tick the battle until the next action
+            uint64 numTicks = (actionEndBlock - combatAction.blockNum) / BLOCKS_PER_TICK;
+            for (uint16 t = 0; t < numTicks; t++) {
+                // console.log("______tick");
+                // Apply the combat logic
+                uint16 i = 0;
+                uint16 j = 0;
+                while (
+                    combatState.winState == CombatWinState.NONE
+                        && (i < combatState.attackerCount || j < combatState.defenderCount)
+                ) {
+                    if (i < combatState.attackerCount) {
+                        _combatLogic(combatState, i, CombatSideKey.ATTACK, combatAction.blockNum, i + j);
+                        i++;
+
+                        if (combatState.defenderCount == 0) {
+                            combatState.winState = CombatWinState.ATTACKERS;
+                            // return (combatState);
+                        }
+                    }
+
+                    if (j < combatState.defenderCount) {
+                        _combatLogic(combatState, j, CombatSideKey.DEFENCE, combatAction.blockNum, i + j);
+                        j++;
+
+                        if (combatState.attackerCount == 0) {
+                            combatState.winState = CombatWinState.DEFENDERS;
+                            // return (combatState);
+                        }
+                    }
+                }
+
+                combatState.tickCount++;
+            }
+        }
+
+        // console.log("Combat tickCount: ", tickCount);
+        if (combatState.winState == CombatWinState.NONE) {
+            combatState.winState = CombatWinState.DRAW;
+        }
+    }
+
+    // NOTE: entityIndex is the index within one of the two arrays and entityNum is witin the whole battle
+    function _combatLogic(
+        CombatState memory combatState,
+        uint16 entityIndex,
+        CombatSideKey combatSide,
+        uint64 blockNum,
+        uint32 entityNum
+    ) private view {
+        // TODO: obviously not random
+        bytes32 rnd = keccak256(abi.encode(blockNum, combatState.tickCount, entityNum));
+
+        // Select attacker
+        EntityState memory attackerState = combatSide == CombatSideKey.ATTACK
+            ? combatState.attackerStates[entityIndex]
+            : combatState.defenderStates[entityIndex];
+
+        // Select entity from opposing side
+        EntityState memory enemyState = _selectPresentEntity(
+            combatSide == CombatSideKey.ATTACK ? combatState.defenderStates : combatState.attackerStates,
+            uint16(uint256(rnd))
+                % (combatSide == CombatSideKey.ATTACK ? combatState.defenderCount : combatState.attackerCount)
+        );
+
+        // Attack if ATK is more than enemy's DEF
+        if (attackerState.stats[ATOM_ATTACK] > enemyState.stats[ATOM_DEFENSE]) {
+            attackerState.damageInflicted += attackerState.stats[ATOM_ATTACK] - enemyState.stats[ATOM_DEFENSE];
+            enemyState.damage += attackerState.stats[ATOM_ATTACK] - enemyState.stats[ATOM_DEFENSE];
+        }
+
+        // Is enemy defeated?
+        if (enemyState.damage >= enemyState.stats[ATOM_LIFE]) {
+            enemyState.isDead = true;
+            if (combatSide == CombatSideKey.ATTACK) {
+                combatState.defenderCount--;
+            } else {
+                combatState.attackerCount--;
+            }
+        }
+
+        // console.log(
+        //     "combatSide: ",
+        //     uint8(combatSide),
+        //     "atk: ",
+        //     attackerState.stats[uint8(AtomKind.ATK)] - enemyState.stats[uint8(AtomKind.DEF)]
+        // );
+        // console.log("Enemy damage: ", enemyState.damage);
+    }
+
+    function _selectPresentEntity(EntityState[] memory entityStates, uint16 entityNum)
+        private
+        pure
+        returns (EntityState memory)
+    {
+        uint16 entityCount;
+        for (uint16 i = 0; i < entityStates.length; i++) {
+            if (entityStates[i].isPresent && !entityStates[i].isDead) {
+                if (entityCount == entityNum) {
+                    return entityStates[i];
+                }
+                entityCount++;
+            }
+        }
+
+        revert("CombatRule::_selectPrensentEntity() EntityNum out of range");
+    }
+
+    function _addEntityToCombat(
+        EntityState[] memory entityStates,
+        CombatAction memory combatAction,
+        uint32[3] memory stats
+    ) private pure returns (bool) {
+        for (uint256 i = 0; i < entityStates.length; i++) {
+            if (entityStates[i].entityID == combatAction.entityID) {
+                if (entityStates[i].isPresent || entityStates[i].isDead) {
+                    return false;
+                }
+                // Rejoin
+                entityStates[i].isPresent = true;
+                return true;
+            }
+            if (entityStates[i].entityID == 0) {
+                // First time joining
+                entityStates[i] = EntityState({
+                    entityID: combatAction.entityID,
+                    stats: stats,
+                    damage: 0,
+                    damageInflicted: 0,
+                    isPresent: true,
+                    isDead: false,
+                    hasClaimed: false
+                });
+
+                return true;
+            }
+        }
+
+        // Ran out of slots!
+        return false;
+    }
+
+    function _checkSessionHash(State state, bytes24 sessionID, CombatRule.CombatAction[][] memory sessionUpdates)
+        private
+        view
+        returns (bool)
+    {
+        // Check that the hashes match. Every combat list update is hashed against the last
+        bytes20 combatActionsHash;
+        for (uint256 i = 0; i < sessionUpdates.length; i++) {
+            combatActionsHash = bytes20(keccak256(abi.encodePacked(combatActionsHash, abi.encode(sessionUpdates[i]))));
+        }
+
+        bytes20 storedHash = state.getHash(sessionID, HASH_EDGE_INDEX);
+        return storedHash == combatActionsHash;
+    }
+
+    // TODO: Add an end flag after the first claim so we don't have to wait until timeout for this session to end
+    function _getActiveSession(State state, bytes24 tileID, Context calldata ctx) private view returns (bytes24) {
+        (bytes24 sessionID, uint64 startBlockNum) = state.get(Rel.Has.selector, 0, tileID);
+        if (startBlockNum > 0 && !state.getIsFinalised(sessionID)) return sessionID;
+
+        return 0;
+    }
+
+    function _startSession(
+        State state,
+        bytes24 attTileID,
+        bytes24 defTileID,
+        bytes24[] memory attackers,
+        bytes24[] memory defenders,
+        Context calldata ctx
+    ) private {
+        // Create a new session
+        prevCombatSessionID++;
+        uint64 sessionID = prevCombatSessionID;
+
+        {
+            // Link the session to the tiles
+            bytes24 sessionNode = Node.CombatSession(sessionID);
+            state.set(Rel.Has.selector, uint8(CombatSideKey.ATTACK), sessionNode, attTileID, ctx.clock);
+            state.set(Rel.Has.selector, uint8(CombatSideKey.DEFENCE), sessionNode, defTileID, ctx.clock);
+
+            // TODO: Find another way of doing this because making a two way connection is expensive
+            // TODO: Refactor 'Has' to 'Session' and increment the index so that rewards can be seen on tiles for old sessions
+            state.set(Rel.Has.selector, 0, attTileID, sessionNode, ctx.clock);
+            state.set(Rel.Has.selector, 0, defTileID, sessionNode, ctx.clock);
+        }
+
+        // Need a join action for each of the entities on the tiles
+        CombatAction[] memory sessionActions = new CombatAction[](attackers.length + defenders.length);
+
+        // Join each of the attackers to the session
+        // NOTE: Actions are not held in the graph!
+        // NOTE: For now not including buildings because with auto opt in, a building owned by the same person as the adjacent
+        //       building end up attacking their own building which seems really odd.
+        {
+            for (uint256 i = 0; i < attackers.length; i++) {
+                uint64 arrivalBlockNum;
+                bytes24 entityTileID;
+
+                if (bytes4(attackers[i]) == Kind.Seeker.selector) {
+                    (entityTileID, arrivalBlockNum) =
+                        state.get(Rel.Location.selector, uint8(LocationKey.NEXT), attackers[i]);
+
+                    if (entityTileID != attTileID) revert EntityNotAtAttackTile();
+                }
+
+                JoinActionInfo memory info =
+                    JoinActionInfo({combatSide: CombatSideKey.ATTACK, stats: _getStatsForEntity(state, attackers[i])});
+
+                sessionActions[i] = CombatAction(
+                    CombatActionKind.JOIN,
+                    attackers[i],
+                    arrivalBlockNum > ctx.clock ? arrivalBlockNum : ctx.clock,
+                    abi.encode(info)
+                );
+            }
+        }
+
+        // Join each of the defenders to the session
+        {
+            for (uint256 i = 0; i < defenders.length; i++) {
+                uint64 arrivalBlockNum;
+                bytes24 entityTileID;
+
+                if (bytes4(defenders[i]) == Kind.Seeker.selector) {
+                    (entityTileID, arrivalBlockNum) =
+                        state.get(Rel.Location.selector, uint8(LocationKey.NEXT), defenders[i]);
+                    if (entityTileID != defTileID) revert EntityNotAtDefenceTile();
+                }
+
+                JoinActionInfo memory info =
+                    JoinActionInfo({combatSide: CombatSideKey.DEFENCE, stats: _getStatsForEntity(state, defenders[i])});
+
+                sessionActions[attackers.length + i] = CombatAction(
+                    CombatActionKind.JOIN,
+                    defenders[i],
+                    arrivalBlockNum > ctx.clock ? arrivalBlockNum : ctx.clock,
+                    abi.encode(info)
+                );
+            }
+        }
+
+        _emitSessionUpdate(state, Node.CombatSession(sessionID), sessionActions);
+    }
+
+    // NOTE: Using the term entity as it can be either a Seeker or a Building
+    // TODO: A more scalable way of encoding could be a byte array encoded AtomKind,Amount,AtomKind,Amount
+    //       Or maybe just an array of Schema.AtomCount
+    function _getStatsForEntity(State state, bytes24 entityID) private view returns (uint32[3] memory) {
+        uint32[3] memory stats;
+
+        if (bytes4(entityID) == Kind.Seeker.selector) {
+            // Made up base stats for seeker
+            stats[ATOM_LIFE] = 50;
+            stats[ATOM_DEFENSE] = 48;
+            stats[ATOM_ATTACK] = 50; // Was 25. Needs to be > 50 to defeat a building
+
+            // iterate over Items within Bags and sum up Atoms that belong to the Items (limited to 2 bags)
+            for (uint8 i = 0; i < 2; i++) {
+                bytes24 bag = state.getEquipSlot(entityID, i);
+                if (bytes4(bag) == Kind.Bag.selector) {
+                    // 4 items slots per bag
+                    for (uint8 j = 0; j < 4; j++) {
+                        (bytes24 item, uint64 balance) = state.getItemSlot(bag, j);
+                        (uint32[3] memory inputAtoms, bool isStackable) = state.getItemStructure(item);
+                        if (!isStackable && balance > 0) {
+                            for (uint8 k = 0; k < 3; k++) {
+                                stats[k] += inputAtoms[k];
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            for (uint8 i = 0; i < 4; i++) {
+                (bytes24 item, uint64 qty) = state.getMaterial(state.getBuildingKind(entityID), i);
+                (uint32[3] memory inputAtoms, /*bool isStackable*/ ) = state.getItemStructure(item);
+                for (uint8 j = 0; j < 3; j++) {
+                    stats[j] += inputAtoms[j] * uint32(qty);
+                }
+            }
+        }
+
+        return stats;
+    }
+
+    function _joinSession(
+        State state,
+        bytes24 sessionID,
+        bytes24 seekerTileID,
+        uint64 arrivalBlockNum,
+        bytes24 seekerID
+    ) private {
+        (bytes24 attackTileID, /*uint64 combatStartBlock*/ ) =
+            state.get(Rel.Has.selector, uint8(CombatSideKey.ATTACK), sessionID);
+
+        JoinActionInfo memory info = JoinActionInfo({
+            combatSide: attackTileID == seekerTileID ? CombatSideKey.ATTACK : CombatSideKey.DEFENCE,
+            stats: _getStatsForEntity(state, seekerID)
+        });
+
+        // NOTE: Held in an array to keep it the same as the encoding used when starting combat
+        CombatAction[] memory combatActions = new CombatAction[](1);
+        combatActions[0] = CombatAction(CombatActionKind.JOIN, seekerID, arrivalBlockNum, abi.encode(info));
+
+        _emitSessionUpdate(state, sessionID, combatActions);
+    }
+
+    function _leaveSession(State state, bytes24 sessionID, bytes24 seekerTileID, bytes24 seekerID, Context calldata ctx)
+        private
+    {
+        (bytes24 attackTileID, /*uint64 combatStartBlock*/ ) =
+            state.get(Rel.Has.selector, uint8(CombatSideKey.ATTACK), sessionID);
+
+        LeaveActionInfo memory info =
+            LeaveActionInfo({combatSide: attackTileID == seekerTileID ? CombatSideKey.ATTACK : CombatSideKey.DEFENCE});
+
+        // NOTE: Held in an array to keep it the same encoding as used when starting combat
+        CombatAction[] memory combatActions = new CombatAction[](1);
+        combatActions[0] = CombatAction(CombatActionKind.LEAVE, seekerID, ctx.clock, abi.encode(info));
+
+        _emitSessionUpdate(state, sessionID, combatActions);
+    }
+
+    // NOTE: sessionUpdate is an encoded array of CombatActions
+    function _updateHash(State state, uint64 sessionID, bytes memory sessionUpdate) private {
+        bytes24 sessionNode = Node.CombatSession(sessionID);
+        bytes20 prevHash = state.getHash(sessionNode, HASH_EDGE_INDEX); // NOTE: Starts at 2 as I'm also using 'Has' edges to point to the 2 combat tiles
+        bytes20 newHash = bytes20(keccak256(abi.encodePacked(prevHash, sessionUpdate)));
+
+        // NOTE: Starts at 2 as I'm also using 'Has' edges to point to the 2 combat tiles
+        state.setHash(newHash, sessionNode, HASH_EDGE_INDEX);
+    }
+
+    function _requirePlayerOwnedSeeker(State state, bytes24 seeker, bytes24 player) private view {
+        if (state.getOwner(seeker) != player) {
+            revert SeekerNotOwnedByPlayer();
+        }
+    }
+
+    function _emitSessionUpdate(State state, bytes24 sessionID, CombatAction[] memory sessionActions) private {
+        _updateHash(state, CompoundKeyDecoder.UINT64(sessionID), abi.encode(sessionActions));
+        emit SessionUpdate(CompoundKeyDecoder.UINT64(sessionID), abi.encode(sessionActions));
+        state.annotate(
+            sessionID,
+            string(
+                abi.encodePacked("action-", LibString.toString(block.number), "-", LibString.toString(block.timestamp))
+            ),
+            Base64.encode(abi.encode(sessionActions))
+        );
+    }
+
+    // -- MATH
+
+    // function min(int256 a, int256 b) public pure returns (int256) {
+    //     return a < b ? a : b;
+    // }
+
+    // function max(int256 a, int256 b) public pure returns (int256) {
+    //     return a > b ? a : b;
+    // }
+}

--- a/contracts/src/rules/MovementRule.sol
+++ b/contracts/src/rules/MovementRule.sol
@@ -47,6 +47,9 @@ contract MovementRule is Rule {
         // fetch the seeker's current location
         (bytes24 currentTile) = state.getCurrentLocation(seeker, nowTime);
 
+        // TODO: if currentTile doesn't equal tile at LocationKey.NEXT then movement was cancelled.
+        //       dispatch MOVE_CANCEL action here so any systems that were tracking mvoement know about it
+
         // check that destTile is direct 6-axis line from currentTile
         if (!TileUtils.isDirect(currentTile, destTile)) {
             revert NoMoveToIndirect();

--- a/contracts/src/utils/BagUtils.sol
+++ b/contracts/src/utils/BagUtils.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {State} from "cog/State.sol";
-import {Schema, Node, Kind} from "@ds/schema/Schema.sol";
+import {Schema, Node, Kind, Rel} from "@ds/schema/Schema.sol";
 import {TileUtils} from "@ds/utils/TileUtils.sol";
 
 error NoTransferUnsupportedEquipeeKind();
@@ -37,6 +37,16 @@ library BagUtils {
             if (
                 TileUtils.distance(location, otherSeekerLocation) > 1
                     || !TileUtils.isDirect(location, otherSeekerLocation)
+            ) {
+                revert NoTransferNotSameLocation();
+            }
+        } else if (bytes4(equipee) == Kind.CombatSession.selector) {
+            // Belongs to combat session. Check both tiles that belong to the session
+            (bytes24 tileA,) = state.get(Rel.Has.selector, 0, equipee);
+            (bytes24 tileB,) = state.get(Rel.Has.selector, 1, equipee);
+            if (
+                (TileUtils.distance(location, tileA) > 1 || !TileUtils.isDirect(location, tileA))
+                    && (TileUtils.distance(location, tileB) > 1 || !TileUtils.isDirect(location, tileB))
             ) {
                 revert NoTransferNotSameLocation();
             }

--- a/contracts/src/utils/Base64.sol
+++ b/contracts/src/utils/Base64.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.7.0) (utils/Base64.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Provides a set of functions to operate with Base64 strings.
+ *
+ * _Available since v4.5._
+ */
+library Base64 {
+    /**
+     * @dev Base64 Encoding/Decoding Table
+     */
+    string internal constant _TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    /**
+     * @dev Converts a `bytes` to its Bytes64 `string` representation.
+     */
+    function encode(bytes memory data) internal pure returns (string memory) {
+        /**
+         * Inspired by Brecht Devos (Brechtpd) implementation - MIT licence
+         * https://github.com/Brechtpd/base64/blob/e78d9fd951e7b0977ddca77d92dc85183770daf4/base64.sol
+         */
+        if (data.length == 0) return "";
+
+        // Loads the table into memory
+        string memory table = _TABLE;
+
+        // Encoding takes 3 bytes chunks of binary data from `bytes` data parameter
+        // and split into 4 numbers of 6 bits.
+        // The final Base64 length should be `bytes` data length multiplied by 4/3 rounded up
+        // - `data.length + 2`  -> Round up
+        // - `/ 3`              -> Number of 3-bytes chunks
+        // - `4 *`              -> 4 characters for each chunk
+        string memory result = new string(4 * ((data.length + 2) / 3));
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Prepare the lookup table (skip the first "length" byte)
+            let tablePtr := add(table, 1)
+
+            // Prepare result pointer, jump over length
+            let resultPtr := add(result, 32)
+
+            // Run over the input, 3 bytes at a time
+            for {
+                let dataPtr := data
+                let endPtr := add(data, mload(data))
+            } lt(dataPtr, endPtr) {} {
+                // Advance 3 bytes
+                dataPtr := add(dataPtr, 3)
+                let input := mload(dataPtr)
+
+                // To write each character, shift the 3 bytes (18 bits) chunk
+                // 4 times in blocks of 6 bits for each character (18, 12, 6, 0)
+                // and apply logical AND with 0x3F which is the number of
+                // the previous character in the ASCII table prior to the Base64 Table
+                // The result is then added to the table to get the character to write,
+                // and finally write it in the result pointer but with a left shift
+                // of 256 (1 byte) - 8 (1 ASCII char) = 248 bits
+
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(18, input), 0x3F))))
+                resultPtr := add(resultPtr, 1) // Advance
+
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(12, input), 0x3F))))
+                resultPtr := add(resultPtr, 1) // Advance
+
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(6, input), 0x3F))))
+                resultPtr := add(resultPtr, 1) // Advance
+
+                mstore8(resultPtr, mload(add(tablePtr, and(input, 0x3F))))
+                resultPtr := add(resultPtr, 1) // Advance
+            }
+
+            // When data `bytes` is not exactly 3 bytes long
+            // it is padded with `=` characters at the end
+            switch mod(mload(data), 3)
+            case 1 {
+                mstore8(sub(resultPtr, 1), 0x3d)
+                mstore8(sub(resultPtr, 2), 0x3d)
+            }
+            case 2 { mstore8(sub(resultPtr, 1), 0x3d) }
+        }
+
+        return result;
+    }
+}

--- a/contracts/test/rules/CombatRule.t.sol
+++ b/contracts/test/rules/CombatRule.t.sol
@@ -1,0 +1,540 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import {State, AnnotationKind} from "cog/State.sol";
+import {Dispatcher} from "cog/Dispatcher.sol";
+
+import {Game} from "@ds/Game.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {
+    Schema,
+    Node,
+    Rel,
+    LocationKey,
+    BiomeKind,
+    DEFAULT_ZONE,
+    ATOM_LIFE,
+    ATOM_DEFENSE,
+    ATOM_ATTACK
+} from "@ds/schema/Schema.sol";
+import {NoMoveNotOwner, NoMoveToIndirect, NoMoveToUndiscovered} from "@ds/rules/MovementRule.sol";
+import {
+    CombatRule,
+    CombatSessionAlreadyActive,
+    EntityAlreadyClaimed,
+    COMBAT_MAX_BLOCKS,
+    HASH_EDGE_INDEX
+} from "@ds/rules/CombatRule.sol";
+import {ItemUtils} from "@ds/utils/ItemUtils.sol";
+
+using Schema for State;
+
+contract CombatRuleTest is Test {
+    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref, string data);
+
+    Game internal game;
+    Dispatcher internal dispatcher;
+    State internal state;
+
+    bytes24[4] defaultMaterialItem;
+    uint64[4] defaultMaterialQty;
+
+    // accounts
+    address aliceAccount;
+    address bobAccount;
+    address thirdAccount;
+    address buildingOwnerAccount;
+
+    // seekers
+    uint32 sid;
+
+    bytes24 aliceSeekerID;
+    bytes24 bobSeekerID;
+    bytes24 thirdSeekerID;
+    bytes24 buildingOwnerSeekerID;
+
+    function setUp() public {
+        // setup users
+        uint256 alicePrivateKey = 0xA11CE;
+        aliceAccount = vm.addr(alicePrivateKey);
+        uint256 bobPrivateKey = 0xB0B;
+        bobAccount = vm.addr(bobPrivateKey);
+        uint256 thirdPrivateKey = 0x3;
+        thirdAccount = vm.addr(thirdPrivateKey);
+        uint256 buildingOwnerPrivateKey = 0x4;
+        buildingOwnerAccount = vm.addr(buildingOwnerPrivateKey);
+
+        // setup allowlist
+        address[] memory allowlist = new address[](4);
+        allowlist[0] = aliceAccount;
+        allowlist[1] = bobAccount;
+        allowlist[2] = thirdAccount;
+        allowlist[3] = buildingOwnerAccount;
+
+        // setup game
+        game = new Game(allowlist);
+        dispatcher = game.getDispatcher();
+
+        // fetch the State to play with
+        state = game.getState();
+
+        // discover a star shape of tiles 6-axis from center
+        for (int16 i = 0; i < 3; i++) {
+            _discover(0, -i, i);
+            _discover(0, i, -i);
+            _discover(i, 0, -i);
+            _discover(-i, 0, i);
+            _discover(-i, i, 0);
+            _discover(i, -i, 0);
+        }
+
+        // place seekers (maybe using separate accounts was overkill...)
+
+        vm.startPrank(aliceAccount);
+        aliceSeekerID = _spawnSeeker(++sid, 0, 0, 0);
+        vm.stopPrank();
+
+        vm.startPrank(bobAccount);
+        bobSeekerID = _spawnSeeker(++sid, 1, 0, -1);
+        vm.stopPrank();
+
+        vm.startPrank(thirdAccount);
+        thirdSeekerID = _spawnSeeker(++sid, 0, 1, -1);
+        vm.stopPrank();
+
+        // setup default material construction costs
+        defaultMaterialItem[0] = ItemUtils.Kiki();
+        defaultMaterialItem[1] = ItemUtils.Bouba();
+        defaultMaterialItem[2] = ItemUtils.Semiote();
+        defaultMaterialQty[0] = 25;
+        defaultMaterialQty[1] = 25;
+        defaultMaterialQty[2] = 25;
+    }
+
+    function _discover(int16 q, int16 r, int16 s) private {
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.DEV_SPAWN_TILE,
+                (
+                    BiomeKind.DISCOVERED,
+                    q, // q
+                    r, // r
+                    s // s
+                )
+            )
+        );
+    }
+
+    function testStartCombat() public {
+        bytes24 targetTileID = Node.Tile(0, 1, 0, -1);
+        bytes24[] memory attackers = new bytes24[](1);
+        attackers[0] = aliceSeekerID;
+
+        bytes24[] memory defenders = new bytes24[](1);
+        defenders[0] = bobSeekerID;
+
+        vm.recordLogs();
+
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
+        vm.stopPrank();
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        Vm.Log[] memory sessionUpdates = new Vm.Log[](entries.length);
+
+        uint256 sessionUpdatesLength;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].topics[0] == keccak256("SessionUpdate(uint64,bytes)")) {
+                sessionUpdates[sessionUpdatesLength] = entries[i];
+                sessionUpdatesLength++;
+            }
+        }
+
+        assertGt(sessionUpdatesLength, 0, "no combat logs found");
+
+        // NOTE: The first two uint256 I think are the two unused topics of the event.
+        //       Also this doesn't work quite like the example at https://book.getfoundry.sh/cheatcodes/get-recorded-logs
+        //       In the example data on the log is the data bytes unlike what we have here where it includes the unindexed topics
+        ( /* uint256 */ , /* uint256 */, bytes memory data) =
+            abi.decode(sessionUpdates[0].data, (uint256, uint256, bytes));
+
+        (CombatRule.CombatAction[] memory actions) = abi.decode(data, (CombatRule.CombatAction[]));
+        assertEq(actions.length, 2, "combat action list expected to have 2 entries for the two seekers");
+        assertEq(uint8(actions[0].kind), uint8(CombatRule.CombatActionKind.JOIN));
+        assertEq(uint8(actions[1].kind), uint8(CombatRule.CombatActionKind.JOIN));
+
+        {
+            // Check that the hashes match. Every combat list update is hashed against the last
+            bytes20 combatActionsHash;
+            for (uint256 i = 0; i < sessionUpdatesLength; i++) {
+                ( /* uint256 */ , /* uint256 */, bytes memory listUpdate) =
+                    abi.decode(sessionUpdates[i].data, (uint256, uint256, bytes));
+
+                combatActionsHash = bytes20(keccak256(abi.encodePacked(combatActionsHash, listUpdate)));
+            }
+
+            bytes20 storedHash = state.getHash(bytes24(Node.CombatSession(1)), HASH_EDGE_INDEX);
+            assertGt(uint160(storedHash), 0, "Stored hash is null");
+            assertEq(storedHash, combatActionsHash, "Hashes do not match");
+        }
+    }
+
+    function testDuplicateSessions() public {
+        bytes24 targetTileID = Node.Tile(0, 1, 0, -1);
+        bytes24[] memory attackers = new bytes24[](1);
+        attackers[0] = aliceSeekerID;
+
+        bytes24[] memory defenders = new bytes24[](1);
+        defenders[0] = bobSeekerID;
+
+        vm.recordLogs();
+
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
+
+        vm.expectRevert(CombatSessionAlreadyActive.selector);
+
+        dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
+
+        // Should be allowed to start a combat session after a finished session has been finalised
+        vm.roll(block.number + COMBAT_MAX_BLOCKS); // TODO: Remove MAX_BLOCKS
+        CombatRule.CombatAction[][] memory sessionUpdates = _getSessionUpdates();
+
+        // We need to process the actions in blockNum order however we can't pass them in ordered because
+        // Hashes wouldn't compute the same. Ordering the list client side could be a problem as it's something
+        // that could be tampered with.
+        uint32[] memory sortedListIndexes = getOrderedListIndexes(sessionUpdates);
+
+        dispatcher.dispatch(
+            abi.encodeCall(Actions.FINALISE_COMBAT, (Node.CombatSession(1), sessionUpdates, sortedListIndexes))
+        );
+
+        dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
+
+        vm.stopPrank();
+    }
+
+    function testJoiningAndLeaving() public {
+        bytes24 targetTileID = Node.Tile(0, 1, 0, -1);
+        bytes24[] memory attackers = new bytes24[](1);
+        attackers[0] = aliceSeekerID;
+
+        bytes24[] memory defenders = new bytes24[](1);
+        defenders[0] = bobSeekerID;
+
+        vm.recordLogs();
+
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
+        vm.stopPrank();
+
+        vm.startPrank(thirdAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.MOVE_SEEKER, (state.getSid(thirdSeekerID), 0, 0, 0)));
+        vm.roll(block.number + 10);
+        dispatcher.dispatch(abi.encodeCall(Actions.MOVE_SEEKER, (state.getSid(thirdSeekerID), 0, 1, -1)));
+        vm.stopPrank();
+
+        // Gather session update events
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        Vm.Log[] memory sessionUpdates = new Vm.Log[](entries.length);
+
+        // Filter by SessionUpdate
+        uint256 sessionUpdatesLength;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].topics[0] == keccak256("SessionUpdate(uint64,bytes)")) {
+                sessionUpdates[sessionUpdatesLength] = entries[i];
+                sessionUpdatesLength++;
+            }
+        }
+
+        assertEq(sessionUpdatesLength, 3, "Expected 3 session updates: start, join and leave");
+
+        {
+            // Check that the hashes match. Every combat list update is hashed against the last
+            bytes20 combatActionsHash;
+            for (uint256 i = 0; i < sessionUpdatesLength; i++) {
+                ( /* uint256 */ , /* uint256 */, bytes memory listUpdate) =
+                    abi.decode(sessionUpdates[i].data, (uint256, uint256, bytes));
+
+                combatActionsHash = bytes20(keccak256(abi.encodePacked(combatActionsHash, listUpdate)));
+                // _logActionList(listUpdate);
+            }
+
+            bytes20 storedHash = state.getHash(bytes24(Node.CombatSession(1)), HASH_EDGE_INDEX);
+            assertGt(uint160(storedHash), 0, "Stored hash is null");
+            assertEq(storedHash, combatActionsHash, "Hashes do not match");
+        }
+    }
+
+    function testClaiming() public {
+        // Move the third seeker onto the same tile as alice
+        vm.startPrank(thirdAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.MOVE_SEEKER, (state.getSid(thirdSeekerID), 0, 0, 0)));
+        vm.stopPrank();
+
+        bytes24[] memory attackers = new bytes24[](2);
+        attackers[0] = aliceSeekerID;
+        attackers[1] = thirdSeekerID;
+
+        bytes24[] memory defenders = new bytes24[](1);
+        defenders[0] = bobSeekerID;
+
+        vm.recordLogs();
+
+        // Start combat
+        bytes24 targetTileID = Node.Tile(0, 1, 0, -1);
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
+
+        // Roll forward to end of combat
+        vm.roll(block.number + COMBAT_MAX_BLOCKS);
+
+        CombatRule.CombatAction[][] memory sessionUpdates = _getSessionUpdates();
+
+        // We need to process the actions in blockNum order however we can't pass them in ordered because
+        // Hashes wouldn't compute the same. Ordering the list client side could be a problem as it's something
+        // that could be tampered with.
+        uint32[] memory sortedListIndexes = getOrderedListIndexes(sessionUpdates);
+
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.CLAIM_COMBAT, (aliceSeekerID, Node.CombatSession(1), sessionUpdates, sortedListIndexes)
+            )
+        );
+
+        vm.roll(block.number + 1);
+
+        // TODO: I think it's possible to hack as many claims as you want. I think it's possible to supply the action list
+        //       again with the claim event tacked on the end. That way the hashes would match however because we are still
+        //       in the same block, the list will only get processed up to the block before the claim and the `hasClaimed`
+        //       flag won't be set!
+
+        // Claiming created a new action so we need to fetch them again
+        sessionUpdates = _getSessionUpdates(sessionUpdates);
+        sortedListIndexes = getOrderedListIndexes(sessionUpdates);
+
+        // Expecting double claim to fail
+        vm.expectRevert(EntityAlreadyClaimed.selector);
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.CLAIM_COMBAT, (aliceSeekerID, Node.CombatSession(1), sessionUpdates, sortedListIndexes)
+            )
+        );
+    }
+
+    function testStartCombatAgainstBuilding() public {
+        bytes24 targetTileID = Node.Tile(0, 1, -1, 0);
+        bytes24[] memory attackers = new bytes24[](1);
+        attackers[0] = aliceSeekerID;
+        // attackers[1] = thirdSeekerID;
+
+        bytes24[] memory defenders = new bytes24[](1);
+        defenders[0] = _constructBuilding();
+
+        vm.recordLogs();
+
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
+        vm.stopPrank();
+
+        // Fast forward to end of battle and finalise
+        vm.roll(block.number + COMBAT_MAX_BLOCKS); // TODO: Remove MAX_BLOCKS
+        CombatRule.CombatAction[][] memory sessionUpdates = _getSessionUpdates();
+        uint32[] memory sortedListIndexes = getOrderedListIndexes(sessionUpdates);
+        dispatcher.dispatch(
+            abi.encodeCall(Actions.FINALISE_COMBAT, (Node.CombatSession(1), sessionUpdates, sortedListIndexes))
+        );
+    }
+
+    function _getSessionUpdates() private returns (CombatRule.CombatAction[][] memory) {
+        return _getSessionUpdates(new CombatRule.CombatAction[][](0));
+    }
+
+    function _getSessionUpdates(CombatRule.CombatAction[][] memory prevSessionUpdates)
+        private
+        returns (CombatRule.CombatAction[][] memory)
+    {
+        // Gather session update events
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        Vm.Log[] memory sessionUpdateEvents = new Vm.Log[](entries.length);
+
+        // Filter by SessionUpdate
+        uint256 sessionUpdatesLength;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].topics[0] == keccak256("SessionUpdate(uint64,bytes)")) {
+                sessionUpdateEvents[sessionUpdatesLength] = entries[i];
+                sessionUpdatesLength++;
+            }
+        }
+
+        // Copy over previous events
+        CombatRule.CombatAction[][] memory sessionUpdates =
+            new CombatRule.CombatAction[][](sessionUpdatesLength + prevSessionUpdates.length);
+        for (uint256 i = 0; i < prevSessionUpdates.length; i++) {
+            sessionUpdates[i] = prevSessionUpdates[i];
+        }
+
+        // Decode new events
+        for (uint256 i = 0; i < sessionUpdatesLength; i++) {
+            ( /* uint256 */ , /* uint256 */, bytes memory combatActionsEncoded) =
+                abi.decode(sessionUpdateEvents[i].data, (uint256, uint256, bytes));
+            // _logActionList(combatActionsEncoded);
+            (sessionUpdates[i + prevSessionUpdates.length]) =
+                abi.decode(combatActionsEncoded, (CombatRule.CombatAction[]));
+        }
+
+        return sessionUpdates;
+    }
+
+    function _logActionList(bytes memory encodedActions) private view {
+        (CombatRule.CombatAction[] memory combatActions) = abi.decode(encodedActions, (CombatRule.CombatAction[]));
+        for (uint256 i = 0; i < combatActions.length; i++) {
+            console.log("actionKind: ", uint8(combatActions[i].kind));
+            console.log("entityID: ", uint192(combatActions[i].entityID));
+            console.log("blockNum: ", combatActions[i].blockNum);
+            if (combatActions[i].kind == CombatRule.CombatActionKind.JOIN) {
+                (CombatRule.JoinActionInfo memory info) = abi.decode(combatActions[i].data, (CombatRule.JoinActionInfo));
+                console.log("combatSide: ", uint8(info.combatSide));
+                console.log("LIFE: ", info.stats[ATOM_LIFE]);
+                console.log("ATK: ", info.stats[ATOM_ATTACK]);
+                console.log("DEF: ", info.stats[ATOM_DEFENSE]);
+            }
+        }
+    }
+
+    struct CombatActionIndex {
+        uint64 blockNum;
+        uint16 i;
+        uint16 j;
+    }
+
+    function getOrderedListIndexes(CombatRule.CombatAction[][] memory sessionUpdates)
+        private
+        pure
+        returns (uint32[] memory)
+    {
+        uint256 totalLength = 0;
+
+        for (uint256 i = 0; i < sessionUpdates.length; i++) {
+            totalLength += sessionUpdates[i].length;
+        }
+
+        CombatActionIndex[] memory flattenedIndexes = new CombatActionIndex[](totalLength);
+        uint256 currentIndex = 0;
+
+        for (uint256 i = 0; i < sessionUpdates.length; i++) {
+            for (uint256 j = 0; j < sessionUpdates[i].length; j++) {
+                flattenedIndexes[currentIndex] = CombatActionIndex(sessionUpdates[i][j].blockNum, uint16(i), uint16(j));
+                currentIndex++;
+            }
+        }
+
+        for (uint256 i = 0; i < flattenedIndexes.length - 1; i++) {
+            for (uint256 j = i + 1; j < flattenedIndexes.length; j++) {
+                if (flattenedIndexes[i].blockNum > flattenedIndexes[j].blockNum) {
+                    CombatActionIndex memory temp = flattenedIndexes[i];
+                    flattenedIndexes[i] = flattenedIndexes[j];
+                    flattenedIndexes[j] = temp;
+                }
+            }
+        }
+
+        uint32[] memory indexes = new uint32[](flattenedIndexes.length);
+        for (uint256 i = 0; i < flattenedIndexes.length; i++) {
+            indexes[i] = flattenedIndexes[i].i | (uint32(flattenedIndexes[i].j) << 16);
+        }
+
+        return indexes;
+    }
+
+    function _constructBuilding() private returns (bytes24) {
+        // register a building kind
+        bytes24 buildingKind = Node.BuildingKind(20);
+        string memory buildingName = "hut";
+        vm.expectEmit(true, true, true, true, address(state));
+        emit AnnotationSet(buildingKind, AnnotationKind.CALLDATA, "name", keccak256(bytes(buildingName)), buildingName);
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.REGISTER_BUILDING_KIND, (buildingKind, "hut", defaultMaterialItem, defaultMaterialQty)
+            )
+        );
+        // spawn a seeker
+        vm.startPrank(buildingOwnerAccount);
+        bytes24 seeker = _spawnSeekerWithResources();
+        // discover an adjacent tile for our building site
+        (int16 q, int16 r, int16 s) = (1, -1, 0);
+        _discover(q, r, s);
+        // get our building and give it the resources to construct
+        bytes24 buildingInstance = Node.Building(DEFAULT_ZONE, q, r, s);
+        // construct our building
+        _transferFromSeeker(seeker, 0, 25, buildingInstance);
+        _transferFromSeeker(seeker, 1, 25, buildingInstance);
+        _transferFromSeeker(seeker, 2, 25, buildingInstance);
+        dispatcher.dispatch(abi.encodeCall(Actions.CONSTRUCT_BUILDING_SEEKER, (seeker, buildingKind, q, r, s)));
+        vm.stopPrank();
+        // check the building has a location at q/r/s
+        assertEq(
+            state.getFixedLocation(buildingInstance),
+            Node.Tile(DEFAULT_ZONE, q, r, s),
+            "expected building to have location"
+        );
+        // check building has owner
+        assertEq(
+            state.getOwner(buildingInstance),
+            Node.Player(buildingOwnerAccount),
+            "expected building to be owned by alice"
+        );
+        // check building has kind
+        assertEq(state.getBuildingKind(buildingInstance), buildingKind, "expected building to have kind");
+        // check building has a bag equip
+        assertTrue(state.getEquipSlot(buildingInstance, 0) != 0x0, "expected building to have a bag equip");
+
+        return buildingInstance;
+    }
+
+    // _spawnSeekerWithResources spawns a seeker for the current sender at
+    // 0,0,0 with 100 of each resource in an equiped bag
+    function _spawnSeekerWithResources() private returns (bytes24) {
+        sid++;
+        bytes24 seeker = Node.Seeker(sid);
+        _discover(0, 0, 0);
+        dispatcher.dispatch(abi.encodeCall(Actions.SPAWN_SEEKER, (seeker)));
+        bytes24[] memory items = new bytes24[](3);
+        items[0] = ItemUtils.Kiki();
+        items[1] = ItemUtils.Bouba();
+        items[2] = ItemUtils.Semiote();
+
+        uint64[] memory balances = new uint64[](3);
+        balances[0] = 100;
+        balances[1] = 100;
+        balances[2] = 100;
+
+        uint64 seekerBag = uint64(uint256(keccak256(abi.encode(seeker))));
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.DEV_SPAWN_BAG, (seekerBag, state.getOwnerAddress(seeker), seeker, 0, items, balances)
+            )
+        );
+
+        return seeker;
+    }
+
+    function _spawnSeeker(uint32 seekerID, int16 q, int16 r, int16 s) private returns (bytes24) {
+        dispatcher.dispatch(abi.encodeCall(Actions.SPAWN_SEEKER, (Node.Seeker(seekerID))));
+        dispatcher.dispatch(abi.encodeCall(Actions.MOVE_SEEKER, (sid, q, r, s)));
+        vm.roll(block.number + 100);
+        return Node.Seeker(sid);
+    }
+
+    function _transferFromSeeker(bytes24 seeker, uint8 slot, uint64 qty, bytes24 toBuilding) private {
+        bytes24 buildingBag = Node.Bag(uint64(uint256(keccak256(abi.encode(toBuilding)))));
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.TRANSFER_ITEM_SEEKER, (seeker, [seeker, toBuilding], [0, 0], [slot, slot], buildingBag, qty)
+            )
+        );
+    }
+}

--- a/contracts/test/rules/CombatRule.t.sol
+++ b/contracts/test/rules/CombatRule.t.sol
@@ -21,13 +21,7 @@ import {
     ATOM_ATTACK
 } from "@ds/schema/Schema.sol";
 import {NoMoveNotOwner, NoMoveToIndirect, NoMoveToUndiscovered} from "@ds/rules/MovementRule.sol";
-import {
-    CombatRule,
-    CombatSessionAlreadyActive,
-    EntityAlreadyClaimed,
-    COMBAT_MAX_BLOCKS,
-    HASH_EDGE_INDEX
-} from "@ds/rules/CombatRule.sol";
+import {CombatRule, CombatSessionAlreadyActive, EntityAlreadyClaimed, HASH_EDGE_INDEX} from "@ds/rules/CombatRule.sol";
 import {ItemUtils} from "@ds/utils/ItemUtils.sol";
 
 using Schema for State;
@@ -200,7 +194,7 @@ contract CombatRuleTest is Test {
         dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
 
         // Should be allowed to start a combat session after a finished session has been finalised
-        vm.roll(block.number + COMBAT_MAX_BLOCKS); // TODO: Remove MAX_BLOCKS
+        vm.roll(block.number + 100);
         CombatRule.CombatAction[][] memory sessionUpdates = _getSessionUpdates();
 
         // We need to process the actions in blockNum order however we can't pass them in ordered because
@@ -290,7 +284,7 @@ contract CombatRuleTest is Test {
         dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
 
         // Roll forward to end of combat
-        vm.roll(block.number + COMBAT_MAX_BLOCKS);
+        vm.roll(block.number + 100);
 
         CombatRule.CombatAction[][] memory sessionUpdates = _getSessionUpdates();
 
@@ -341,7 +335,7 @@ contract CombatRuleTest is Test {
         vm.stopPrank();
 
         // Fast forward to end of battle and finalise
-        vm.roll(block.number + COMBAT_MAX_BLOCKS); // TODO: Remove MAX_BLOCKS
+        vm.roll(block.number + 100);
         CombatRule.CombatAction[][] memory sessionUpdates = _getSessionUpdates();
         uint32[] memory sortedListIndexes = getOrderedListIndexes(sessionUpdates);
         dispatcher.dispatch(

--- a/core/package.json
+++ b/core/package.json
@@ -1,118 +1,118 @@
 {
-  "name": "@dawnseekers/core",
-  "description": "dawnseekers client library",
-  "version": "0.1.0",
-  "author": "playmint",
-  "source": "./src/index.ts",
-  "main": "./dist/core",
-  "module": "./dist/core.mjs",
-  "types": "./dist/core.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/core.mjs",
-      "require": "./dist/core.js",
-      "types": "./dist/core.d.ts",
-      "source": "./src/index.ts"
+    "name": "@dawnseekers/core",
+    "description": "dawnseekers client library",
+    "version": "0.1.0",
+    "author": "playmint",
+    "source": "./src/index.ts",
+    "main": "./dist/core",
+    "module": "./dist/core.mjs",
+    "types": "./dist/core.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/core.mjs",
+            "require": "./dist/core.js",
+            "types": "./dist/core.d.ts",
+            "source": "./src/index.ts"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "sideEffects": false,
-  "files": [
-    "src",
-    "dist",
-    "*.md"
-  ],
-  "keywords": [
-    "ds",
-    "dawnseekers",
-    "playmint",
-    "typescript"
-  ],
-  "scripts": {
-    "test": "vitest run",
-    "check": "tsc",
-    "lint": "eslint --ext=js,ts .",
-    "build": "npm run build:graphql && npm run build:abi && npm run build:package",
-    "build:package": "rollup -c scripts/rollup.config.mjs",
-    "build:graphql": "graphql-codegen",
-    "build:abi": "typechain --target ethers-v6 --out-dir src/abi ../contracts/out/Actions.sol/Actions.json",
-    "build:watch": "rollup -c scripts/rollup.config.mjs -w",
-    "clean": "rimraf dist node_modules/.cache",
-    "prepublishOnly": "run-s clean build check test"
-  },
-  "repository": "https://github.com/playmint/ds",
-  "bugs": {
-    "url": "https://github.com/playmint/ds/issues"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "tabWidth": 4,
-    "printWidth": 120,
-    "arrowParens": "always",
-    "trailingComma": "all"
-  },
-  "lint-staged": {
-    "*.{ts,js}": "eslint -c scripts/eslint-preset.js --fix",
-    "*.json": "prettier --write",
-    "*.md": "prettier --write"
-  },
-  "eslintConfig": {
-    "root": true,
-    "extends": [
-      "./scripts/eslint-preset.js"
-    ]
-  },
-  "devDependencies": {
-    "@babel/core": "^7.21.3",
-    "@graphql-codegen/cli": "^3.2.2",
-    "@graphql-codegen/client-preset": "^2.1.1",
-    "@graphql-codegen/urql-introspection": "^2.2.1",
-    "@graphql-eslint/eslint-plugin": "^3.16.1",
-    "@graphql-typed-document-node/core": "^3.1.2",
-    "@rollup/plugin-buble": "^1.0.1",
-    "@rollup/plugin-commonjs": "^23.0.3",
-    "@rollup/plugin-node-resolve": "^15.0.1",
-    "@rollup/plugin-terser": "^0.1.0",
-    "@rollup/plugin-typescript": "^10.0.1",
-    "@rollup/pluginutils": "^5.0.2",
-    "@typechain/ethers-v6": "^0.3.0",
-    "@types/node": "^18.15.3",
-    "@types/react": "^18.0.28",
-    "@typescript-eslint/eslint-plugin": "^5.45.0",
-    "@typescript-eslint/parser": "^5.45.0",
-    "eslint": "^8.29.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-tsdoc": "^0.2.17",
-    "glob": "^8.0.3",
-    "graphql": "^16.6.0",
-    "isomorphic-fetch": "^3.0.0",
-    "lint-staged": "^13.0.4",
-    "npm-run-all": "^4.1.5",
-    "prettier": "^2.8.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "rimraf": "^3.0.2",
-    "rollup": "^3.5.1",
-    "rollup-plugin-cjs-check": "^1.0.1",
-    "rollup-plugin-dts": "^5.1.1",
-    "tslib": "^2.4.1",
-    "typechain": "^8.1.1",
-    "typescript": "^4.9.5",
-    "vitest": "^0.25.3",
-    "ws": "^8.13.0"
-  },
-  "dependencies": {
-    "@metamask/detect-provider": "^2.0.0",
-    "@urql/core": "^3.2.2",
-    "@urql/exchange-graphcache": "^5.2.0",
-    "ethers": "^6.1.0",
-    "graphql-ws": "^5.12.0",
-    "quickjs-emscripten": "^0.22.0"
-  },
-  "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "wonka": "^6.2.5"
-  }
+    "sideEffects": false,
+    "files": [
+        "src",
+        "dist",
+        "*.md"
+    ],
+    "keywords": [
+        "ds",
+        "dawnseekers",
+        "playmint",
+        "typescript"
+    ],
+    "scripts": {
+        "test": "vitest run",
+        "check": "tsc",
+        "lint": "eslint --ext=js,ts .",
+        "build": "npm run build:graphql && npm run build:abi && npm run build:package",
+        "build:package": "rollup -c scripts/rollup.config.mjs",
+        "build:graphql": "graphql-codegen",
+        "build:abi": "typechain --target ethers-v6 --out-dir src/abi ../contracts/out/Actions.sol/Actions.json ../contracts/out/CombatRule.sol/CombatRule.json",
+        "build:watch": "rollup -c scripts/rollup.config.mjs -w",
+        "clean": "rimraf dist node_modules/.cache",
+        "prepublishOnly": "run-s clean build check test"
+    },
+    "repository": "https://github.com/playmint/ds",
+    "bugs": {
+        "url": "https://github.com/playmint/ds/issues"
+    },
+    "prettier": {
+        "singleQuote": true,
+        "tabWidth": 4,
+        "printWidth": 120,
+        "arrowParens": "always",
+        "trailingComma": "all"
+    },
+    "lint-staged": {
+        "*.{ts,js}": "eslint -c scripts/eslint-preset.js --fix",
+        "*.json": "prettier --write",
+        "*.md": "prettier --write"
+    },
+    "eslintConfig": {
+        "root": true,
+        "extends": [
+            "./scripts/eslint-preset.js"
+        ]
+    },
+    "devDependencies": {
+        "@babel/core": "^7.21.3",
+        "@graphql-codegen/cli": "^3.2.2",
+        "@graphql-codegen/client-preset": "^2.1.1",
+        "@graphql-codegen/urql-introspection": "^2.2.1",
+        "@graphql-eslint/eslint-plugin": "^3.16.1",
+        "@graphql-typed-document-node/core": "^3.1.2",
+        "@rollup/plugin-buble": "^1.0.1",
+        "@rollup/plugin-commonjs": "^23.0.3",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-terser": "^0.1.0",
+        "@rollup/plugin-typescript": "^10.0.1",
+        "@rollup/pluginutils": "^5.0.2",
+        "@typechain/ethers-v6": "^0.3.0",
+        "@types/node": "^18.15.3",
+        "@types/react": "^18.0.28",
+        "@typescript-eslint/eslint-plugin": "^5.45.0",
+        "@typescript-eslint/parser": "^5.45.0",
+        "eslint": "^8.29.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-tsdoc": "^0.2.17",
+        "glob": "^8.0.3",
+        "graphql": "^16.6.0",
+        "isomorphic-fetch": "^3.0.0",
+        "lint-staged": "^13.0.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.8.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "rimraf": "^3.0.2",
+        "rollup": "^3.5.1",
+        "rollup-plugin-cjs-check": "^1.0.1",
+        "rollup-plugin-dts": "^5.1.1",
+        "tslib": "^2.4.1",
+        "typechain": "^8.1.1",
+        "typescript": "^4.9.5",
+        "vitest": "^0.25.3",
+        "ws": "^8.13.0"
+    },
+    "dependencies": {
+        "@metamask/detect-provider": "^2.0.0",
+        "@urql/core": "^3.2.2",
+        "@urql/exchange-graphcache": "^5.2.0",
+        "ethers": "^6.1.0",
+        "graphql-ws": "^5.12.0",
+        "quickjs-emscripten": "^0.22.0"
+    },
+    "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "wonka": "^6.2.5"
+    }
 }

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -42,6 +42,53 @@ fragment WorldBuilding on Node {
     }
 }
 
+fragment WorldCombatSession on Node {
+    id
+    attackTile: edge(match: { kinds: "Tile", via: { rel: "Has", key: 0 } }) {
+        startBlock: weight
+        tile: node {
+            id
+        }
+    }
+    defenceTile: edge(match: { kinds: "Tile", via: { rel: "Has", key: 1 } }) {
+        startBlock: weight
+        tile: node {
+            id
+        }
+    }
+    sessionUpdates: annotations {
+        name
+        value
+    }
+    # flag is either 1 or 0 TODO: Use real boolean and if possible have the weight directly on `isFinalised`
+    isFinalised: edge(match: { kinds: "CombatSession", via: { rel: "IsFinalised" } }) {
+        flag: weight
+    }
+    bags: edges(match: { kinds: "Bag", via: { rel: "Equip" } }) {
+        id
+        key
+        bag: node {
+            id
+            key
+            slots: edges(match: { kinds: ["Item"], via: { rel: "Balance" } }) {
+                key
+                balance: weight
+                item: node {
+                    id
+                    name: annotation(name: "name") {
+                        id
+                        value
+                    }
+                    icon: annotation(name: "icon") {
+                        id
+                        value
+                    }
+                }
+            }
+        }
+    }
+}
+
 fragment WorldTile on Node {
     id
     # the keys break down the coords
@@ -65,6 +112,9 @@ fragment WorldTile on Node {
     }
     seekers: nodes(match: { kinds: "Seeker", via: { rel: "Location", dir: IN, key: 1 } }) {
         ...WorldSeeker
+    }
+    sessions: nodes(match: { kinds: "CombatSession", via: { rel: "Has", dir: IN } }) {
+        ...WorldCombatSession
     }
 }
 

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -65,27 +65,7 @@ fragment WorldCombatSession on Node {
         flag: weight
     }
     bags: edges(match: { kinds: "Bag", via: { rel: "Equip" } }) {
-        id
-        key
-        bag: node {
-            id
-            key
-            slots: edges(match: { kinds: ["Item"], via: { rel: "Balance" } }) {
-                key
-                balance: weight
-                item: node {
-                    id
-                    name: annotation(name: "name") {
-                        id
-                        value
-                    }
-                    icon: annotation(name: "icon") {
-                        id
-                        value
-                    }
-                }
-            }
-        }
+        ...EquipmentSlot
     }
 }
 

--- a/core/src/world.ts
+++ b/core/src/world.ts
@@ -65,6 +65,7 @@ function getUnscoutedTile(tiles: WorldTileFragment[], q: number, r: number, s: n
         bagBalances: [],
         biome: BiomeKind.UNDISCOVERED,
         seekers: [],
+        sessions: [],
     };
 }
 

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -8,7 +8,7 @@ import { ActionContextPanel } from '@app/plugins/action-context-panel';
 import { SeekerInventory } from '@app/plugins/inventory/seeker-inventory';
 import { TileCoords } from '@app/plugins/tile-coords';
 import { ComponentProps } from '@app/types/component-props';
-import { CompoundKeyEncoder, NodeSelectors, usePlayer, useSelection } from '@dawnseekers/core';
+import { CompoundKeyEncoder, NodeSelectors, usePlayer, useSelection, useWorld } from '@dawnseekers/core';
 import detectEthereumProvider from '@metamask/detect-provider';
 import { Fragment, FunctionComponent, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -13,6 +13,7 @@ import detectEthereumProvider from '@metamask/detect-provider';
 import { Fragment, FunctionComponent, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { styles } from './shell.styles';
+import { CombatSummary } from '@app/plugins/combat-summary';
 
 export interface ShellProps extends ComponentProps {}
 
@@ -24,6 +25,8 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
     const { ...otherProps } = props;
     const player = usePlayer();
     const { seeker: selectedSeeker, selectSeeker, tiles: selectedTiles } = useSelection();
+    const world = useWorld();
+    const block = world ? world.block : 0;
 
     const [providerAvailable, setProviderAvailable] = useState<boolean>(false);
 
@@ -99,7 +102,18 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
                 </div>
                 <div className="bottom-left">
                     {selectedTiles && selectedTiles.length > 0 && (
-                        <TileCoords className="action" selectedTiles={selectedTiles} />
+                        <Fragment>
+                            {selectedTiles[0].sessions.length > 0 && (
+                                <CombatSummary
+                                    className="action"
+                                    selectedTiles={selectedTiles}
+                                    block={block}
+                                    player={player}
+                                    selectedSeeker={selectedSeeker}
+                                />
+                            )}
+                            <TileCoords className="action" selectedTiles={selectedTiles} />
+                        </Fragment>
                     )}
                 </div>
                 <div className="top-middle"></div>

--- a/frontend/src/helpers/combat.ts
+++ b/frontend/src/helpers/combat.ts
@@ -169,16 +169,12 @@ export class Combat {
                     combatSide: Number(result[0])
                 };
 
-                if (info.combatSide === CombatSideKey.ATTACK) {
-                    combatState.attackerCount--;
-                    if (combatState.attackerCount === 0) {
-                        combatState.winState = CombatWinState.DEFENDERS;
-                    }
-                } else {
-                    combatState.defenderCount--;
-                    if (combatState.defenderCount === 0) {
-                        combatState.winState = CombatWinState.ATTACKERS;
-                    }
+                _removeEntityFromCombat(combatState, combatAction, info);
+
+                if (combatState.attackerCount === 0) {
+                    combatState.winState = CombatWinState.DEFENDERS;
+                } else if (combatState.defenderCount === 0) {
+                    combatState.winState = CombatWinState.ATTACKERS;
                 }
             } else if (combatAction.kind === CombatActionKind.CLAIM) {
                 const [entityState] = this._getEntityState(combatState, combatAction.entityID);
@@ -342,5 +338,21 @@ export class Combat {
         }
 
         return indexes;
+    }
+}
+function _removeEntityFromCombat(combatState: CombatState, combatAction: CombatAction, info: LeaveActionInfo) {
+    const entityStates =
+        info.combatSide === CombatSideKey.ATTACK ? combatState.attackerStates : combatState.defenderStates;
+
+    for (let i = 0; i < entityStates.length; i++) {
+        if (entityStates[i] && entityStates[i].entityID == combatAction.entityID && entityStates[i].isPresent) {
+            entityStates[i].isPresent = false;
+            if (info.combatSide == CombatSideKey.ATTACK) {
+                combatState.attackerCount--;
+            } else {
+                combatState.defenderCount--;
+            }
+            return;
+        }
     }
 }

--- a/frontend/src/helpers/combat.ts
+++ b/frontend/src/helpers/combat.ts
@@ -3,8 +3,6 @@
 import { ethers, getUint, keccak256 } from 'ethers';
 
 const BLOCKS_PER_TICK = 1;
-const COMBAT_MAX_TICKS = 100;
-const COMBAT_MAX_BLOCKS = COMBAT_MAX_TICKS * BLOCKS_PER_TICK;
 const MAX_ENTITIES_PER_SIDE = 100;
 
 export const ATOM_LIFE = 0;

--- a/frontend/src/helpers/combat.ts
+++ b/frontend/src/helpers/combat.ts
@@ -1,0 +1,346 @@
+// CONVERTED FROM SOLIDITY, CODE WILL READ A BIT WEIRD
+
+import { ethers, getUint, keccak256 } from 'ethers';
+
+const BLOCKS_PER_TICK = 1;
+const COMBAT_MAX_TICKS = 100;
+const COMBAT_MAX_BLOCKS = COMBAT_MAX_TICKS * BLOCKS_PER_TICK;
+const MAX_ENTITIES_PER_SIDE = 100;
+
+export const ATOM_LIFE = 0;
+export const ATOM_DEFENSE = 1;
+export const ATOM_ATTACK = 2;
+
+enum CombatSideKey {
+    ATTACK,
+    DEFENCE
+}
+
+export enum CombatActionKind {
+    NONE,
+    JOIN,
+    LEAVE,
+    CLAIM,
+    EQUIP,
+    UNEQUIP
+}
+
+export interface CombatAction {
+    kind: CombatActionKind;
+    entityID: ethers.BytesLike;
+    blockNum: number;
+    data: ethers.BytesLike;
+}
+
+interface JoinActionInfo {
+    combatSide: CombatSideKey;
+    stats: [number, number, number];
+}
+
+interface LeaveActionInfo {
+    combatSide: CombatSideKey;
+}
+
+interface EquipActionInfo {
+    stats: [number, number, number];
+}
+
+interface CombatState {
+    attackerStates: EntityState[];
+    defenderStates: EntityState[];
+    attackerCount: number;
+    defenderCount: number;
+    winState: CombatWinState;
+    tickCount: number;
+}
+
+interface EntityState {
+    entityID: ethers.BytesLike;
+    stats: [number, number, number];
+    damage: number;
+    damageInflicted: number;
+    isPresent: boolean;
+    isDead: boolean;
+    hasClaimed: boolean;
+}
+
+interface CombatActionIndex {
+    blockNum: number;
+    i: number;
+    j: number;
+}
+
+export enum CombatWinState {
+    NONE,
+    ATTACKERS,
+    DEFENDERS,
+    DRAW
+}
+
+export class Combat {
+    prevCombatSessionID: number = 0;
+
+    constructor() {
+        // Constructor logic here
+    }
+
+    private _getTotalDamageInflicted(entityStates: EntityState[]): number {
+        let totalDamageInflicted = 0;
+        for (let i = 0; i < entityStates.length; i++) {
+            if (entityStates[i].isPresent) {
+                totalDamageInflicted += entityStates[i].damageInflicted;
+            }
+        }
+        return totalDamageInflicted;
+    }
+
+    private _getEntityState(combatState: CombatState, entityID: ethers.BytesLike): [EntityState, boolean] {
+        for (let i = 0; i < combatState.attackerStates.length; i++) {
+            const entityState = combatState.attackerStates[i];
+            if (entityState.entityID === entityID) {
+                return [entityState, true];
+            }
+        }
+
+        for (let i = 0; i < combatState.defenderStates.length; i++) {
+            const entityState = combatState.defenderStates[i];
+            if (entityState.entityID === entityID) {
+                return [entityState, false];
+            }
+        }
+
+        return [
+            {
+                entityID: '',
+                stats: [0, 0, 0],
+                damage: 0,
+                damageInflicted: 0,
+                isPresent: false,
+                isDead: false,
+                hasClaimed: false
+            },
+            false
+        ];
+    }
+
+    calcCombatState(sessionUpdates: CombatAction[][], sortedListIndexes: number[], endBlockNum: number): CombatState {
+        const combatState: CombatState = {
+            attackerStates: new Array<EntityState>(MAX_ENTITIES_PER_SIDE),
+            defenderStates: new Array<EntityState>(MAX_ENTITIES_PER_SIDE),
+            attackerCount: 0,
+            defenderCount: 0,
+            winState: CombatWinState.NONE,
+            tickCount: 0
+        };
+
+        for (let x = 0; x < sortedListIndexes.length; x++) {
+            const combatAction = sessionUpdates[sortedListIndexes[x] & 0xffff][sortedListIndexes[x] >> 16];
+
+            if (combatAction.blockNum >= endBlockNum) {
+                return combatState;
+            }
+
+            let actionEndBlock =
+                x + 1 < sortedListIndexes.length
+                    ? sessionUpdates[sortedListIndexes[x + 1] & 0xffff][sortedListIndexes[x + 1] >> 16].blockNum
+                    : endBlockNum;
+
+            if (actionEndBlock > endBlockNum) {
+                actionEndBlock = endBlockNum;
+            }
+
+            if (combatAction.kind === CombatActionKind.JOIN) {
+                const result = ethers.AbiCoder.defaultAbiCoder().decode(['uint8', 'uint32[3]'], combatAction.data);
+                const info: JoinActionInfo = {
+                    combatSide: Number(result[0]),
+                    stats: [Number(result[1][0]), Number(result[1][1]), Number(result[1][2])]
+                };
+                if (
+                    info.combatSide === CombatSideKey.ATTACK &&
+                    this._addEntityToCombat(combatState.attackerStates, combatAction, info.stats)
+                ) {
+                    combatState.attackerCount++;
+                } else if (this._addEntityToCombat(combatState.defenderStates, combatAction, info.stats)) {
+                    combatState.defenderCount++;
+                }
+            } else if (combatAction.kind === CombatActionKind.LEAVE) {
+                const result = ethers.AbiCoder.defaultAbiCoder().decode(['uint8'], combatAction.data);
+                const info: LeaveActionInfo = {
+                    combatSide: Number(result[0])
+                };
+
+                if (info.combatSide === CombatSideKey.ATTACK) {
+                    combatState.attackerCount--;
+                    if (combatState.attackerCount === 0) {
+                        combatState.winState = CombatWinState.DEFENDERS;
+                    }
+                } else {
+                    combatState.defenderCount--;
+                    if (combatState.defenderCount === 0) {
+                        combatState.winState = CombatWinState.ATTACKERS;
+                    }
+                }
+            } else if (combatAction.kind === CombatActionKind.CLAIM) {
+                const [entityState] = this._getEntityState(combatState, combatAction.entityID);
+                entityState.hasClaimed = true;
+            }
+
+            const numTicks = Math.floor((actionEndBlock - combatAction.blockNum) / BLOCKS_PER_TICK);
+            for (let t = 0; t < numTicks; t++) {
+                let i = 0;
+                let j = 0;
+                while (
+                    combatState.winState === CombatWinState.NONE &&
+                    (i < combatState.attackerCount || j < combatState.defenderCount)
+                ) {
+                    if (i < combatState.attackerCount) {
+                        this._combatLogic(combatState, i, CombatSideKey.ATTACK, combatAction.blockNum, i + j);
+                        i++;
+
+                        if (combatState.defenderCount === 0) {
+                            combatState.winState = CombatWinState.ATTACKERS;
+                        }
+                    }
+
+                    if (j < combatState.defenderCount) {
+                        this._combatLogic(combatState, j, CombatSideKey.DEFENCE, combatAction.blockNum, i + j);
+                        j++;
+
+                        if (combatState.attackerCount === 0) {
+                            combatState.winState = CombatWinState.DEFENDERS;
+                        }
+                    }
+                }
+
+                combatState.tickCount++;
+            }
+        }
+
+        // There isn't a hard limit on number of ticks at the moment so cannot draw
+        // if (combatState.winState === CombatWinState.NONE) {
+        //     combatState.winState = CombatWinState.DRAW;
+        // }
+
+        return combatState;
+    }
+
+    private _combatLogic(
+        combatState: CombatState,
+        entityIndex: number,
+        combatSide: CombatSideKey,
+        blockNum: number,
+        entityNum: number
+    ): void {
+        const rnd = keccak256(
+            ethers.AbiCoder.defaultAbiCoder().encode(
+                ['uint64', 'uint16', 'uint32'],
+                [blockNum, combatState.tickCount, entityNum]
+            )
+        );
+        const attackerState =
+            combatSide === CombatSideKey.ATTACK
+                ? combatState.attackerStates[entityIndex]
+                : combatState.defenderStates[entityIndex];
+        const enemyRnd = Number(getUint(rnd) & getUint('0xFFFF')); // get first 16bits from rnd
+        const enemyState = this._selectPresentEntity(
+            combatSide === CombatSideKey.ATTACK ? combatState.defenderStates : combatState.attackerStates,
+            enemyRnd % (combatSide === CombatSideKey.ATTACK ? combatState.defenderCount : combatState.attackerCount)
+        );
+
+        if (attackerState.stats[ATOM_ATTACK] > enemyState.stats[ATOM_DEFENSE]) {
+            attackerState.damageInflicted += attackerState.stats[ATOM_ATTACK] - enemyState.stats[ATOM_DEFENSE];
+            enemyState.damage += attackerState.stats[ATOM_ATTACK] - enemyState.stats[ATOM_DEFENSE];
+        }
+
+        if (enemyState.damage >= enemyState.stats[ATOM_LIFE]) {
+            enemyState.isDead = true;
+            if (combatSide === CombatSideKey.ATTACK) {
+                combatState.defenderCount--;
+            } else {
+                combatState.attackerCount--;
+            }
+        }
+    }
+
+    private _selectPresentEntity(entityStates: EntityState[], entityNum: number): EntityState {
+        let entityCount = 0;
+        for (let i = 0; i < entityStates.length; i++) {
+            if (entityStates[i] && entityStates[i].isPresent && !entityStates[i].isDead) {
+                if (entityCount === entityNum) {
+                    return entityStates[i];
+                }
+                entityCount++;
+            }
+        }
+
+        throw new Error('CombatRule::_selectPresentEntity() EntityNum out of range');
+    }
+
+    private _addEntityToCombat(
+        entityStates: EntityState[],
+        combatAction: CombatAction,
+        stats: [number, number, number]
+    ): boolean {
+        for (let i = 0; i < entityStates.length; i++) {
+            if (entityStates[i] && entityStates[i].entityID === combatAction.entityID) {
+                if (entityStates[i].isPresent || entityStates[i].isDead) {
+                    return false;
+                }
+                entityStates[i].isPresent = true;
+                return true;
+            }
+            if (!entityStates[i]) {
+                entityStates[i] = {
+                    entityID: combatAction.entityID,
+                    stats: stats,
+                    damage: 0,
+                    damageInflicted: 0,
+                    isPresent: true,
+                    isDead: false,
+                    hasClaimed: false
+                };
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public getOrderedListIndexes(sessionUpdates: CombatAction[][]): number[] {
+        let totalLength = 0;
+
+        for (let i = 0; i < sessionUpdates.length; i++) {
+            totalLength += sessionUpdates[i].length;
+        }
+
+        const flattenedIndexes: CombatActionIndex[] = new Array<CombatActionIndex>(totalLength);
+        let currentIndex = 0;
+
+        for (let i = 0; i < sessionUpdates.length; i++) {
+            for (let j = 0; j < sessionUpdates[i].length; j++) {
+                flattenedIndexes[currentIndex] = {
+                    blockNum: sessionUpdates[i][j].blockNum,
+                    i: i,
+                    j: j
+                };
+                currentIndex++;
+            }
+        }
+
+        for (let i = 0; i < flattenedIndexes.length - 1; i++) {
+            for (let j = i + 1; j < flattenedIndexes.length; j++) {
+                if (flattenedIndexes[i].blockNum > flattenedIndexes[j].blockNum) {
+                    const temp = flattenedIndexes[i];
+                    flattenedIndexes[i] = flattenedIndexes[j];
+                    flattenedIndexes[j] = temp;
+                }
+            }
+        }
+
+        const indexes: number[] = new Array<number>(flattenedIndexes.length);
+        for (let i = 0; i < flattenedIndexes.length; i++) {
+            indexes[i] = flattenedIndexes[i].i | (flattenedIndexes[i].j << 16);
+        }
+
+        return indexes;
+    }
+}

--- a/frontend/src/plugins/action-bar/index.tsx
+++ b/frontend/src/plugins/action-bar/index.tsx
@@ -128,6 +128,8 @@ export const ActionBar: FunctionComponent<ActionBarProps> = (props: ActionBarPro
                         Scout
                     </button>
                 </li>
+            </ul>
+            <ul className="actions">
                 <li>
                     <button
                         className={`action-icon-button ${intent === CONSTRUCT_INTENT ? 'active' : ''}`}

--- a/frontend/src/plugins/action-bar/index.tsx
+++ b/frontend/src/plugins/action-bar/index.tsx
@@ -11,6 +11,7 @@ const CONSTRUCT_INTENT = 'construct';
 const USE_INTENT = 'use';
 const MOVE_INTENT = 'move';
 const SCOUT_INTENT = 'scout';
+const COMBAT_INTENT = 'combat';
 
 export interface ActionBarProps extends ComponentProps {}
 
@@ -143,6 +144,15 @@ export const ActionBar: FunctionComponent<ActionBarProps> = (props: ActionBarPro
                         onClick={() => handleSelectIntent(USE_INTENT, selectedTileId)}
                     >
                         Use
+                    </button>
+                </li>
+                <li>
+                    <button
+                        className={`action-icon-button ${intent === COMBAT_INTENT ? 'active' : ''}`}
+                        disabled={!canUse || intent === COMBAT_INTENT}
+                        onClick={() => handleSelectIntent(COMBAT_INTENT, selectedTileId)}
+                    >
+                        Attack
                     </button>
                 </li>
             </ul>

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -439,7 +439,7 @@ const Combat: FunctionComponent<CombatProps> = ({ selectTiles, selectIntent, sel
         .filter((t) => t.biome === BiomeKind.DISCOVERED)
         .filter(({ sessions }) => {
             // cannot start combat if any of the tiles have an active session
-            return sessions.filter((session: any) => !session.isFinalised) == 0;
+            return sessions.filter((session: any) => !session.isFinalised).length == 0;
         });
 
     const startCombat = () => {

--- a/frontend/src/plugins/combat-summary/combat-summary.styles.ts
+++ b/frontend/src/plugins/combat-summary/combat-summary.styles.ts
@@ -1,0 +1,24 @@
+/** @format */
+
+import { css } from 'styled-components';
+import { CombatSummaryProps } from './index';
+
+/**
+ * Base styles for the seeker list component
+ *
+ * @param _ The seeker list properties object
+ * @return Base styles for the seeker list component
+ */
+const baseStyles = (_: Partial<CombatSummaryProps>) => css`
+    width: 30rem;
+`;
+
+/**
+ * The seeker list component styles
+ *
+ * @param props The seeker list properties object
+ * @return Styles for the seeker list component
+ */
+export const styles = (props: Partial<CombatSummaryProps>) => css`
+    ${baseStyles(props)}
+`;

--- a/frontend/src/plugins/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat-summary/index.tsx
@@ -198,8 +198,8 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
     const combatState = combat.calcCombatState(convertedActions, orderedListIndexes, estimatedBlock);
     const entityStates = isAttackTile ? combatState.attackerStates : combatState.defenderStates;
 
-    const totalTileHealth = entityStates.reduce((acc, val) => acc + val.stats[ATOM_LIFE], 0);
-    const totalTileDamage = entityStates.reduce((acc, val) => acc + val.damage, 0);
+    const totalTileHealth = entityStates.reduce((acc, val) => (val.isPresent ? acc + val.stats[ATOM_LIFE] : acc), 0);
+    const totalTileDamage = entityStates.reduce((acc, val) => (val.isPresent ? acc + val.damage : acc), 0);
     const totalPresentAliveEntities = entityStates.reduce(
         (acc, val) => acc + (!val.isDead && val.isPresent ? 1 : 0),
         0

--- a/frontend/src/plugins/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat-summary/index.tsx
@@ -1,0 +1,259 @@
+/** @format */
+
+import { Fragment, FunctionComponent, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { ComponentProps } from '@app/types/component-props';
+import { styles } from './combat-summary.styles';
+import { AbiCoder, BytesLike, BigNumberish } from 'ethers';
+import {
+    CogAction,
+    ConnectedPlayer,
+    SelectedSeekerFragment,
+    SelectedTileFragment,
+    WorldTileFragment
+} from '@app/../../core/dist/core';
+import { CombatAction, Combat, ATOM_LIFE, CombatWinState } from '@app/helpers/combat';
+import { Bag } from '../inventory/bag';
+
+type CombatSession = WorldTileFragment['sessions'][number];
+
+// NOTE: I wasn't able to import this from core as the namespace wasn't exported. Not sure how to fix
+type CombatActionStruct = {
+    kind: BigNumberish;
+    entityID: BytesLike;
+    blockNum: BigNumberish;
+    data: BytesLike;
+};
+
+export interface CombatSummaryProps extends ComponentProps {
+    selectedTiles: SelectedTileFragment[];
+    block: number;
+    player?: ConnectedPlayer;
+    selectedSeeker?: SelectedSeekerFragment;
+}
+
+const StyledCombatSummary = styled('div')`
+    ${styles}
+`;
+
+export function getActionsFlat(session: CombatSession): CombatActionStruct[] {
+    // A sessionUpdate is an array of actions
+    const sessionUpdates = session.sessionUpdates.map((actionUpdate) => {
+        if (!actionUpdate) return null;
+
+        const binaryString = atob(actionUpdate.value);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+            bytes[i] = binaryString.charCodeAt(i);
+        }
+
+        const decoder = AbiCoder.defaultAbiCoder();
+        // TODO: I'm not sure why the decoder is putting my array of tuples in a one element array.
+        //       Bad feelin this'll bite me later
+        //
+        // NOTE: The tuple is actually a struct
+        // struct CombatAction {
+        //     CombatActionKind kind;
+        //     bytes24 entityID; // Can be seeker or building
+        //     uint64 blockNum;
+        //     bytes data;
+        // }
+        return decoder.decode(['tuple(uint8,bytes24,uint64,bytes)[]'], bytes)[0];
+    });
+
+    const actions = sessionUpdates.flatMap((actionTuples): CombatActionStruct => {
+        // Turn the tuples back into structs
+        return actionTuples.map((actionTuple: any) => {
+            const [actionKind, entityID, blockNum, data] = actionTuple;
+            return {
+                actionKind,
+                entityID,
+                blockNum,
+                data
+            };
+        });
+    });
+
+    return actions;
+}
+
+export function getActions(session: CombatSession) {
+    // A sessionUpdate is an array of actions
+    const sessionUpdates = session.sessionUpdates.map((actionUpdate) => {
+        if (!actionUpdate) return null;
+
+        const binaryString = atob(actionUpdate.value);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+            bytes[i] = binaryString.charCodeAt(i);
+        }
+
+        const decoder = AbiCoder.defaultAbiCoder();
+        return decoder.decode(['tuple(uint8,bytes24,uint64,bytes)[]'], bytes)[0];
+    });
+
+    const actions = sessionUpdates.map((actionTuples): CombatActionStruct[] => {
+        // Turn the tuples back into structs
+        return actionTuples.map((actionTuple: any): CombatActionStruct => {
+            const [kind, entityID, blockNum, data] = actionTuple;
+            return {
+                kind,
+                entityID,
+                blockNum,
+                data
+            };
+        });
+    });
+
+    return actions;
+}
+
+function convertCombatActions(actions: CombatActionStruct[][]): CombatAction[][] {
+    const convertedActions: CombatAction[][] = [];
+
+    for (let i = 0; i < actions.length; i++) {
+        const row: CombatAction[] = [];
+
+        for (let j = 0; j < actions[i].length; j++) {
+            const actionStruct = actions[i][j];
+
+            const convertedAction: CombatAction = {
+                kind: Number(actionStruct.kind),
+                entityID: actionStruct.entityID,
+                blockNum: Number(actionStruct.blockNum),
+                data: actionStruct.data
+            };
+
+            row.push(convertedAction);
+        }
+
+        convertedActions.push(row);
+    }
+
+    return convertedActions;
+}
+
+function getWinState(winState: CombatWinState): string {
+    switch (winState) {
+        case CombatWinState.ATTACKERS:
+            return 'Attackers have won';
+        case CombatWinState.DEFENDERS:
+            return 'Defenders have won';
+        case CombatWinState.DRAW:
+            return 'Draw';
+    }
+
+    return 'Tile in combat';
+}
+
+const BLOCK_TIME_SECS = 5;
+
+export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: CombatSummaryProps) => {
+    const { selectedTiles, block, player, selectedSeeker, ...otherProps } = props;
+    const latestSession =
+        selectedTiles.length > 0 &&
+        selectedTiles[0].sessions.length > 0 &&
+        selectedTiles[0].sessions[selectedTiles[0].sessions.length - 1];
+    const rewardBags =
+        latestSession && selectedSeeker
+            ? latestSession.bags.filter((equipSlot) => {
+                  // reward containing bags have an ID that is made up of 16bits of sessionID and 48bits of SeekerID
+                  // bagIDs are 64bits
+                  const seekerIdMask = BigInt('0xFFFFFFFFFFFF'); // 48bit mask (6 bytes)
+                  const bagSeekerID = (BigInt(equipSlot.bag.id) >> BigInt(16)) & seekerIdMask;
+                  const truncatedSeekerID = BigInt(selectedSeeker.id) & seekerIdMask;
+                  return bagSeekerID === truncatedSeekerID;
+              })
+            : [];
+
+    const actions = latestSession ? getActions(latestSession) : [];
+    const isAttackTile = latestSession && latestSession.attackTile?.tile.id == selectedTiles[0].id;
+    const [lastBlock, updateLastBlock] = useState<number>(0);
+    const [lastBlockTime, updateLastBlockTime] = useState<number>(0);
+    const [estimatedBlock, updateEstimatedBlock] = useState<number>(0);
+
+    useEffect(() => {
+        if (block > lastBlock) {
+            const nowTime = new Date().getTime() / 1000;
+            updateLastBlock(block);
+            updateLastBlockTime(nowTime);
+
+            console.log('TIME UPDATED: ', nowTime);
+        }
+    }, [block, lastBlock]);
+
+    useEffect(() => {
+        const id = setInterval(() => {
+            const nowTime = new Date().getTime() / 1000;
+            const elapsed = nowTime - lastBlockTime;
+            const newBlocks = Math.floor(elapsed / BLOCK_TIME_SECS);
+            updateEstimatedBlock(block + newBlocks);
+        }, BLOCK_TIME_SECS);
+        return () => clearInterval(id);
+    }, [block, lastBlockTime]);
+
+    const convertedActions = convertCombatActions(actions);
+    const combat = new Combat(); // Is a class because it was converted from solidity
+    const orderedListIndexes = combat.getOrderedListIndexes(convertedActions);
+    const combatState = combat.calcCombatState(convertedActions, orderedListIndexes, estimatedBlock);
+    const entityStates = isAttackTile ? combatState.attackerStates : combatState.defenderStates;
+
+    const totalTileHealth = entityStates.reduce((acc, val) => acc + val.stats[ATOM_LIFE], 0);
+    const totalTileDamage = entityStates.reduce((acc, val) => acc + val.damage, 0);
+    const totalPresentAliveEntities = entityStates.reduce(
+        (acc, val) => acc + (!val.isDead && val.isPresent ? 1 : 0),
+        0
+    );
+
+    // Finalise the combat session if it has been calculated as finished
+    useEffect(() => {
+        if (latestSession && !latestSession.isFinalised && player && combatState.winState != CombatWinState.NONE) {
+            console.log('Finalising session');
+            // function FINALISE_COMBAT(
+            //     bytes24 sessionID,
+            //     CombatRule.CombatAction[][] calldata sessionUpdates,
+            //     uint32[] calldata sortedListIndexes
+            // ) external;
+            const action: CogAction = {
+                name: 'FINALISE_COMBAT',
+                args: [latestSession.id, actions, orderedListIndexes]
+            };
+            player.dispatch(action);
+        }
+    }, [latestSession, actions, orderedListIndexes, player, combatState.winState]);
+
+    return (
+        <StyledCombatSummary {...otherProps}>
+            <h3>Tile in Combat</h3>
+            {actions && (
+                <Fragment>
+                    <p>
+                        {isAttackTile ? 'Attackers: ' : 'Defenders: '}
+                        {totalPresentAliveEntities}
+                    </p>
+                    <p>Current block: {block}</p>
+                    <p>Current block estimate: {estimatedBlock}</p>
+                    <p>Current tick: {combatState.tickCount}</p>
+                    <p>
+                        Health: {Math.max(totalTileHealth - totalTileDamage, 0)} / {totalTileHealth}
+                    </p>
+                    <p>Combat state: {getWinState(combatState.winState)}</p>
+                    <ul className="bags">
+                        {latestSession &&
+                            rewardBags.length > 0 &&
+                            rewardBags.map((equipSlot) => (
+                                <Bag
+                                    key={equipSlot.key}
+                                    bag={equipSlot.bag}
+                                    equipIndex={equipSlot.key}
+                                    ownerId={latestSession.id}
+                                    isInteractable={true}
+                                    as="li"
+                                />
+                            ))}
+                    </ul>
+                </Fragment>
+            )}
+        </StyledCombatSummary>
+    );
+};

--- a/frontend/src/plugins/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat-summary/index.tsx
@@ -146,7 +146,7 @@ function getWinState(winState: CombatWinState): string {
     return 'Tile in combat';
 }
 
-const BLOCK_TIME_SECS = 5;
+const BLOCK_TIME_SECS = 2;
 
 export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: CombatSummaryProps) => {
     const { selectedTiles, block, player, selectedSeeker, ...otherProps } = props;

--- a/frontend/src/plugins/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat-summary/index.tsx
@@ -153,7 +153,9 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
     const latestSession =
         selectedTiles.length > 0 &&
         selectedTiles[0].sessions.length > 0 &&
-        selectedTiles[0].sessions[selectedTiles[0].sessions.length - 1];
+        selectedTiles[0].sessions.sort((a, b) => {
+            return a.attackTile && b.attackTile ? b.attackTile.startBlock - a.attackTile.startBlock : 0;
+        })[0];
     const rewardBags =
         latestSession && selectedSeeker
             ? latestSession.bags.filter((equipSlot) => {

--- a/frontend/src/plugins/tile-coords/tile-coords.styles.ts
+++ b/frontend/src/plugins/tile-coords/tile-coords.styles.ts
@@ -10,9 +10,7 @@ import { TileCoordsProps } from './index';
  * @return Base styles for the seeker list component
  */
 const baseStyles = (_: Partial<TileCoordsProps>) => css`
-    /* h3 {
-        margin-bottom: 0;
-    } */
+    width: 30rem;
 
     .tile-container {
         position: relative;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -33,7 +33,8 @@
     "paths": {
       "@app/*": [
         "*"
-      ]
+      ],
+      "*": ["../node_modules/*"]
     },
     "skipLibCheck": true,
     "strict": true,

--- a/state-schema-gen/README.md
+++ b/state-schema-gen/README.md
@@ -9,13 +9,17 @@
 3. Run the json schema generator from the `core` folder
    `npx typescript-json-schema tsconfig.json GameState -o dist/json-schema.json`
 
-    NOTE: If it fails to compile then it's probably because of our use of typescript 4.9 when `typescript-json-schema` still uses 4.8 and therefore is missing the `satisfies` keyword. The project seems to be in active development so hopefully they'll update soon but if not, just globally replace `satisfies` for `as` to make it work.
-
     NOTE: If it fails due to bigint not being serialisable, You need to add the following decorator to the bigint typed field
     `/** @TJS-type string */`
 
 4. Build the release version of `state-schema-gen` (I used Visual Studio to do this but it should be possible with command line tools)
    This will build to `json-schema/bin/Release/net7.0/json-schema`
 
-5. then from the root of ds repo run:  
+5. A workaround hack until we find the right config - Do a find a replace for `anyOf` to `oneOf` in the generated schema found in `core/dist/json-schema.json`
+   For some reason NJsonSchema that does the conversion to C# doesn't recognise `anyOf` and it won't generated the expected properties for that object!
+
+6. then from the root of ds repo run:  
    `state-schema-gen/json-schema/bin/Release/net7.0/state-schema-gen core/dist/json-schema.json DawnSeekersUnity/Assets/Scripts/Cog/StateSchema.cs`
+
+7. Another unfortunate manual part of the process until we work out the correct config. You need to do a find an replace on the generated `StateSchema.cs` for the following
+   `DisallowNull` to `Default` (Allows all fields to be nullable. We only require a couple but it's fiddly to target just those)


### PR DESCRIPTION
# What

This is the implementation of the combat system without the designed frontend. It has some very basic UI to allow for testing.  

- Initiate combat against an adjacent building.
- Seeker base stats are currently set to LIFE:50, DEF:48, ATK: 50
- Non stackable items buff the seeker
- When combat is initiated, all seekers and builds on the two tiles in combat will be automatically entered into combat
- Walking off a tile will automatically make the seeker leave the combat
- Walking onto a tile will automatically enter the seeker into the combat
- Equipping an item mid battle will update the seekers stats accordingly

## Walkthrough

Seeker's base stats are such that the building will win the the combat session. If a seeker equips at least one welcome drink they are able to defeat the building and collect their proportion of the rewards

New combat intent button named 'attack' has been added to the actions panel
<img width="278" alt="image" src="https://github.com/playmint/ds/assets/51167118/7f3a4664-4375-4d42-b9f9-d03c3be3b020">

This will highlight any adjacent tiles which have a building that isn't already in combat
<img width="149" alt="image" src="https://github.com/playmint/ds/assets/51167118/18c16fea-8c9a-4c40-b92a-52d7c61c5f7a">

Click the building will select it for combat
<img width="156" alt="image" src="https://github.com/playmint/ds/assets/51167118/65142694-0e61-495b-925c-91b70ee38381">

After starting the combat from the right hand panel the tiles will light up red to indicate they are now in combat

<img width="210" alt="image" src="https://github.com/playmint/ds/assets/51167118/8ff2185d-187f-4b5e-a53c-8f79383d7a94">

If at least one of the seekers on the attacker tile is equipped with a welcome drink, their stats will be buffed enough to destroy the building after 25 ticks of combat. Rewards for the selected seeker are shown in the combat summary if they were on the winning side and present at the end of the battle.

<img width="200" alt="image" src="https://github.com/playmint/ds/assets/51167118/04150ba2-f8ad-441c-b793-14ce798228dd">

<img width="277" alt="image" src="https://github.com/playmint/ds/assets/51167118/05b956f6-04b3-41aa-9c18-89470f6b8cff">

## Known issues

Build rewards are currently set to be the same as recipe of the building instead of half. This was intentional so that I could knock buildings down and recreate them. When we're happy that the system works this can be set to half

Walking off a tile during battle isn't altering the attack stats. The health for the tile appears to go down however if the seeker with the drink walks off the building still appears to be incurring damage which is wrong

## Tasks addressed by this PR
#190 #191 #233