### PR TITLE
Combat bug fixes

### DIFF
--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -534,9 +534,9 @@ contract CombatRule is Rule {
         bytes32 rnd = keccak256(abi.encode(blockNum, combatState.tickCount, entityNum));
 
         // Select attacker
-        EntityState memory attackerState = combatSide == CombatSideKey.ATTACK
-            ? combatState.attackerStates[entityIndex]
-            : combatState.defenderStates[entityIndex];
+        EntityState memory attackerState = _selectPresentEntity(
+            combatSide == CombatSideKey.ATTACK ? combatState.attackerStates : combatState.defenderStates, entityIndex
+        );
 
         // Select entity from opposing side
         EntityState memory enemyState = _selectPresentEntity(

--- a/frontend/src/plugins/combat/combat-modal/index.tsx
+++ b/frontend/src/plugins/combat/combat-modal/index.tsx
@@ -15,7 +15,13 @@ import {
     SelectedTileFragment,
     useSelection
 } from '@dawnseekers/core';
-import { buildingRegex, CombatSession, convertCombatActions, getActions } from '@app/plugins/combat/helpers';
+import {
+    buildingNodeKind,
+    CombatSession,
+    convertCombatActions,
+    getActions,
+    nodeKindMask
+} from '@app/plugins/combat/helpers';
 import { ATOM_ATTACK, ATOM_DEFENSE, ATOM_LIFE, Combat, CombatWinState, EntityState } from '@app/plugins/combat/combat';
 import { formatUnitKey } from '@app/helpers';
 import { BytesLike, hexlify } from 'ethers';
@@ -413,9 +419,8 @@ export const CombatModal: FunctionComponent<CombatModalProps> = (props: CombatMo
 };
 
 const getIcon = (entityID: BytesLike) => {
-    const id = hexlify(entityID);
-
-    if (buildingRegex.test(id)) {
+    const nodeKind = (BigInt(hexlify(entityID)) >> BigInt(160)) & nodeKindMask;
+    if (nodeKind === buildingNodeKind) {
         return '/building-tower.png';
     }
 

--- a/frontend/src/plugins/combat/combat-modal/index.tsx
+++ b/frontend/src/plugins/combat/combat-modal/index.tsx
@@ -79,14 +79,18 @@ const CombatParticipants: FunctionComponent<CombatParticipantsProps> = (props) =
     return (
         <Fragment>
             <div className="attackers">
-                {attackers.map((participant, index) => (
-                    <CombatParticipant key={index} {...participant} className="participant" />
-                ))}
+                {attackers
+                    .filter((participant) => participant.isPresent)
+                    .map((participant, index) => (
+                        <CombatParticipant key={index} {...participant} className="participant" />
+                    ))}
             </div>
             <div className="defenders">
-                {defenders.map((participant, index) => (
-                    <CombatParticipant key={index} {...participant} className="participant" />
-                ))}
+                {defenders
+                    .filter((participant) => participant.isPresent)
+                    .map((participant, index) => (
+                        <CombatParticipant key={index} {...participant} className="participant" />
+                    ))}
             </div>
         </Fragment>
     );

--- a/frontend/src/plugins/combat/combat-modal/index.tsx
+++ b/frontend/src/plugins/combat/combat-modal/index.tsx
@@ -326,9 +326,11 @@ export const CombatModal: FunctionComponent<CombatModalProps> = (props: CombatMo
     const { seeker: selectedSeeker, tiles: selectedTiles = [] } = useSelection();
     const { blockNumber, blockTime } = useBlockTime();
     const latestSession =
-        selectedTiles.length > 0 &&
-        selectedTiles[0].sessions.length > 0 &&
-        selectedTiles[0].sessions[selectedTiles[0].sessions.length - 1];
+        selectedTiles.length > 0 && selectedTiles[0].sessions.length > 0
+            ? selectedTiles[0].sessions.sort((a, b) => {
+                  return a.attackTile && b.attackTile ? b.attackTile.startBlock - a.attackTile.startBlock : 0;
+              })[0]
+            : undefined;
     const actions = latestSession && getActions(latestSession);
 
     // Before combat has started
@@ -435,7 +437,9 @@ const entityStateToCombatParticipantProps = ({ entityID, damage, stats, isDead, 
 
 const sumParticipants = (
     [participantsMaxHealth, participantsCurrentHealth]: number[],
-    { maxHealth, currentHealth }: CombatParticipantProps
+    { maxHealth, currentHealth, isPresent }: CombatParticipantProps
 ) => {
-    return [participantsMaxHealth + maxHealth, participantsCurrentHealth + currentHealth];
+    return isPresent
+        ? [participantsMaxHealth + maxHealth, participantsCurrentHealth + currentHealth]
+        : [participantsMaxHealth, participantsCurrentHealth];
 };

--- a/frontend/src/plugins/combat/combat-participant/combat-participant.styles.ts
+++ b/frontend/src/plugins/combat/combat-participant/combat-participant.styles.ts
@@ -9,7 +9,7 @@ import { CombatParticipantProps } from './index';
  * @param _ The combat participant properties object
  * @return Base styles for the combat participant component
  */
-const baseStyles = ({ isDead, isPresent }: Partial<CombatParticipantProps>) => css`
+const baseStyles = ({ isDead }: Partial<CombatParticipantProps>) => css`
     display: grid;
     grid-template-columns: max-content 1fr max-content;
     grid-template-rows: auto auto;

--- a/frontend/src/plugins/combat/combat-participant/combat-participant.styles.ts
+++ b/frontend/src/plugins/combat/combat-participant/combat-participant.styles.ts
@@ -21,7 +21,7 @@ const baseStyles = ({ isDead, isPresent }: Partial<CombatParticipantProps>) => c
     background: #143063;
     border: 2px solid #487bb3;
     padding: 0.8rem 1.8rem 0.8rem 1.2rem;
-    opacity: ${isDead || !isPresent ? 0.5 : 1};
+    opacity: ${isDead ? 0.5 : 1};
 
     .icon {
         grid-area: icon;

--- a/frontend/src/plugins/combat/combat-rewards/index.tsx
+++ b/frontend/src/plugins/combat/combat-rewards/index.tsx
@@ -21,9 +21,11 @@ export const CombatRewards: FunctionComponent<CombatRewardsProps> = (props: Comb
     const { selectedTiles, player, selectedSeeker, ...otherProps } = props;
 
     const latestSession =
-        selectedTiles.length > 0 &&
-        selectedTiles[0].sessions.length > 0 &&
-        selectedTiles[0].sessions[selectedTiles[0].sessions.length - 1];
+        selectedTiles.length > 0 && selectedTiles[0].sessions.length > 0
+            ? selectedTiles[0].sessions.sort((a, b) => {
+                  return a.attackTile && b.attackTile ? b.attackTile.startBlock - a.attackTile.startBlock : 0;
+              })[0]
+            : undefined;
 
     const rewardBags =
         latestSession && selectedSeeker

--- a/frontend/src/plugins/combat/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat/combat-summary/index.tsx
@@ -29,7 +29,9 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
     if (selectedTiles.length === 0 || selectedTiles[0].sessions.length === 0) return null;
 
     const sessions = selectedTiles[0].sessions;
-    const latestSession = sessions[selectedTiles[0].sessions.length - 1];
+    const latestSession = sessions.sort((a, b) => {
+        return a.attackTile && b.attackTile ? b.attackTile.startBlock - a.attackTile.startBlock : 0;
+    })[0];
 
     const actions = latestSession && getActions(latestSession);
 
@@ -40,9 +42,12 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
     const orderedListIndexes = combat.getOrderedListIndexes(convertedActions);
     const combatState = combat.calcCombatState(convertedActions, orderedListIndexes, blockNumber);
 
-    const sumStats = ([participantsMaxHealth, participantsCurrentHealth]: number[], { stats, damage }: EntityState) => {
-        const maxHealth = stats[ATOM_LIFE];
-        const currentHealth = Math.max(stats[ATOM_LIFE] - damage, 0);
+    const sumStats = (
+        [participantsMaxHealth, participantsCurrentHealth]: number[],
+        { stats, damage, isPresent }: EntityState
+    ) => {
+        const maxHealth = isPresent ? stats[ATOM_LIFE] : 0;
+        const currentHealth = isPresent ? Math.max(stats[ATOM_LIFE] - damage, 0) : 0;
         return [participantsMaxHealth + maxHealth, participantsCurrentHealth + currentHealth];
     };
     const [attackersMaxHealth, attackersCurrentHealth] = combatState.attackerStates.reduce(sumStats, [0, 0]);

--- a/frontend/src/plugins/combat/combat.ts
+++ b/frontend/src/plugins/combat/combat.ts
@@ -225,10 +225,10 @@ export class Combat {
                 [blockNum, combatState.tickCount, entityNum]
             )
         );
-        const attackerState =
-            combatSide === CombatSideKey.ATTACK
-                ? combatState.attackerStates[entityIndex]
-                : combatState.defenderStates[entityIndex];
+        const attackerState = this._selectPresentEntity(
+            combatSide === CombatSideKey.ATTACK ? combatState.attackerStates : combatState.defenderStates,
+            entityIndex
+        );
         const enemyRnd = Number(getUint(rnd) & getUint('0xFFFF')); // get first 16bits from rnd
         const enemyState = this._selectPresentEntity(
             combatSide === CombatSideKey.ATTACK ? combatState.defenderStates : combatState.attackerStates,

--- a/frontend/src/plugins/combat/helpers.ts
+++ b/frontend/src/plugins/combat/helpers.ts
@@ -4,6 +4,8 @@ import { CombatAction } from '@app/plugins/combat/combat';
 
 export const buildingRegex = /^0x34cf8a7e[0-9a-f]+$/g;
 export const seekerRegex = /^0x3fbc56a4[0-9a-f]+$/g;
+export const nodeKindMask = BigInt('0xffffffff');
+export const buildingNodeKind = BigInt('0x34cf8a7e');
 
 export type CombatSession = WorldTileFragment['sessions'][number];
 


### PR DESCRIPTION
# What

- The total health for either the attackers or defenders now only shows the sum of the present entities
- Non present entities are now not shown at all instead of faded out. This solved the weird UX of seeing the same entity on both sides if a unity switches sides.
- Ordering sessions by blockNum to ensure we are seeing the latest session. This fixes the problem where sometimes the modal and summary would display a previous combat session instead of the latest
- Combat logic was erroneously selecting entities that were not present. This is because I was using the iterator in the loop where I'm looping over the entities as the index for the entity array instead of selecting present entity n
- Regex was failing for the building icon when a building is one of the attackers. For the life of me I couldn't see what was wrong with the regex, it looked totally fine. The ID didn't have any whitespace either so instead I made the code compare the node kind IDs numerically and that solved the problem