### PR TITLE
Actions occurring in the same block were being overwritten

### DIFF
--- a/frontend/src/plugins/combat/combat.ts
+++ b/frontend/src/plugins/combat/combat.ts
@@ -275,6 +275,7 @@ export class Combat {
                     return false;
                 }
                 entityStates[i].isPresent = true;
+                entityStates[i].stats = stats;
                 return true;
             }
             if (!entityStates[i]) {


### PR DESCRIPTION
# What

Added 4 bytes of the actions list hash to the label of the annotation. This ensures that two events that happen within the same block have unique labels. If the labels aren't unique then the last event will overwrite the first

Also as a separate issue that I fixed on the way, the frontend wasn't updating the stats when a unit rejoined the battle so if a unit left the battle, equipped something and rejoined their stats would be incorrect.

# Why

Because the events use annotations which are indexed by label all events that happen in the same block have the same label (uses blockNum and timestamp) which meant that only the last event survived. An example of this would be if a unit moved from one side of combat to the other. The leave and join events happen in the same call and only join was indexed which meant that we saw the same unit on both sides of the battle and it wouldn't finalise because the hashes wouldn't match as the hash contained both the leave and join action.