### PR TITLE
Combat bug fixes

### DIFF
--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -85,13 +85,6 @@ interface Actions {
     function START_COMBAT(bytes24 seekerID, bytes24 tileID, bytes24[] calldata attackers, bytes24[] calldata defenders)
         external;
 
-    function CLAIM_COMBAT(
-        bytes24 seekerID,
-        bytes24 sessionID,
-        CombatRule.CombatAction[][] calldata sessionUpdates,
-        uint32[] calldata sortedListIndexes
-    ) external;
-
     function FINALISE_COMBAT(
         bytes24 sessionID,
         CombatRule.CombatAction[][] calldata sessionUpdates,

--- a/contracts/test/rules/CombatRule.t.sol
+++ b/contracts/test/rules/CombatRule.t.sol
@@ -239,62 +239,6 @@ contract CombatRuleTest is Test {
         );
     }
 
-    function testClaiming() public {
-        // Move the third seeker onto the same tile as alice
-        vm.startPrank(thirdAccount);
-        dispatcher.dispatch(abi.encodeCall(Actions.MOVE_SEEKER, (state.getSid(thirdSeekerID), 0, 0, 0)));
-        vm.stopPrank();
-
-        bytes24[] memory attackers = new bytes24[](2);
-        attackers[0] = aliceSeekerID;
-        attackers[1] = thirdSeekerID;
-
-        bytes24[] memory defenders = new bytes24[](1);
-        defenders[0] = bobSeekerID;
-
-        vm.recordLogs();
-
-        // Start combat
-        bytes24 targetTileID = Node.Tile(0, 1, 0, -1);
-        vm.startPrank(aliceAccount);
-        dispatcher.dispatch(abi.encodeCall(Actions.START_COMBAT, (aliceSeekerID, targetTileID, attackers, defenders)));
-
-        // Roll forward to end of combat
-        vm.roll(block.number + 100);
-
-        CombatRule.CombatAction[][] memory sessionUpdates = _getSessionUpdates();
-
-        // We need to process the actions in blockNum order however we can't pass them in ordered because
-        // Hashes wouldn't compute the same. Ordering the list client side could be a problem as it's something
-        // that could be tampered with.
-        uint32[] memory sortedListIndexes = getOrderedListIndexes(sessionUpdates);
-
-        dispatcher.dispatch(
-            abi.encodeCall(
-                Actions.CLAIM_COMBAT, (aliceSeekerID, Node.CombatSession(1), sessionUpdates, sortedListIndexes)
-            )
-        );
-
-        vm.roll(block.number + 1);
-
-        // TODO: I think it's possible to hack as many claims as you want. I think it's possible to supply the action list
-        //       again with the claim event tacked on the end. That way the hashes would match however because we are still
-        //       in the same block, the list will only get processed up to the block before the claim and the `hasClaimed`
-        //       flag won't be set!
-
-        // Claiming created a new action so we need to fetch them again
-        sessionUpdates = _getSessionUpdates(sessionUpdates);
-        sortedListIndexes = getOrderedListIndexes(sessionUpdates);
-
-        // Expecting double claim to fail
-        vm.expectRevert(EntityAlreadyClaimed.selector);
-        dispatcher.dispatch(
-            abi.encodeCall(
-                Actions.CLAIM_COMBAT, (aliceSeekerID, Node.CombatSession(1), sessionUpdates, sortedListIndexes)
-            )
-        );
-    }
-
     function testStartCombatAgainstBuilding() public {
         bytes24 targetTileID = Node.Tile(0, 1, -1, 0);
         bytes24[] memory attackers = new bytes24[](1);

--- a/frontend/src/plugins/combat/combat.ts
+++ b/frontend/src/plugins/combat/combat.ts
@@ -76,35 +76,6 @@ export class Combat {
         // Constructor logic here
     }
 
-    private _getEntityState(combatState: CombatState, entityID: ethers.BytesLike): [EntityState, boolean] {
-        for (let i = 0; i < combatState.attackerStates.length; i++) {
-            const entityState = combatState.attackerStates[i];
-            if (entityState.entityID === entityID) {
-                return [entityState, true];
-            }
-        }
-
-        for (let i = 0; i < combatState.defenderStates.length; i++) {
-            const entityState = combatState.defenderStates[i];
-            if (entityState.entityID === entityID) {
-                return [entityState, false];
-            }
-        }
-
-        return [
-            {
-                entityID: '',
-                stats: [0, 0, 0],
-                damage: 0,
-                damageInflicted: 0,
-                isPresent: false,
-                isDead: false,
-                hasClaimed: false
-            },
-            false
-        ];
-    }
-
     calcCombatState(sessionUpdates: CombatAction[][], sortedListIndexes: number[], endBlockNum: number): CombatState {
         const combatState: CombatState = {
             attackerStates: new Array<EntityState>(MAX_ENTITIES_PER_SIDE),

--- a/frontend/src/plugins/combat/combat.ts
+++ b/frontend/src/plugins/combat/combat.ts
@@ -18,9 +18,7 @@ export enum CombatActionKind {
     NONE,
     JOIN,
     LEAVE,
-    CLAIM,
-    EQUIP,
-    UNEQUIP
+    EQUIP
 }
 
 export interface CombatAction {
@@ -157,12 +155,11 @@ export class Combat {
 
                 if (combatState.attackerCount === 0) {
                     combatState.winState = CombatWinState.DEFENDERS;
+                    return combatState;
                 } else if (combatState.defenderCount === 0) {
                     combatState.winState = CombatWinState.ATTACKERS;
+                    return combatState;
                 }
-            } else if (combatAction.kind === CombatActionKind.CLAIM) {
-                const [entityState] = this._getEntityState(combatState, combatAction.entityID);
-                entityState.hasClaimed = true;
             } else if (combatAction.kind === CombatActionKind.EQUIP) {
                 const result = ethers.AbiCoder.defaultAbiCoder().decode(['uint8', 'uint32[3]'], combatAction.data);
                 const info: JoinActionInfo = {
@@ -177,16 +174,14 @@ export class Combat {
             for (let t = 0; t < numTicks; t++) {
                 let i = 0;
                 let j = 0;
-                while (
-                    combatState.winState === CombatWinState.NONE &&
-                    (i < combatState.attackerCount || j < combatState.defenderCount)
-                ) {
+                while (i < combatState.attackerCount || j < combatState.defenderCount) {
                     if (i < combatState.attackerCount) {
                         this._combatLogic(combatState, i, CombatSideKey.ATTACK, combatAction.blockNum, i + j);
                         i++;
 
                         if (combatState.defenderCount === 0) {
                             combatState.winState = CombatWinState.ATTACKERS;
+                            return combatState;
                         }
                     }
 
@@ -196,6 +191,7 @@ export class Combat {
 
                         if (combatState.attackerCount === 0) {
                             combatState.winState = CombatWinState.DEFENDERS;
+                            return combatState;
                         }
                     }
                 }

--- a/frontend/src/plugins/combat/helpers.ts
+++ b/frontend/src/plugins/combat/helpers.ts
@@ -60,18 +60,25 @@ export function getActionsFlat(session: CombatSession): CombatActionStruct[] {
 
 export function getActions(session: CombatSession) {
     // A sessionUpdate is an array of actions
-    const sessionUpdates = session.sessionUpdates.map((actionUpdate) => {
-        if (!actionUpdate) return null;
+    const sessionUpdates = session.sessionUpdates
+        .sort((a, b) => {
+            if (!a || !b) return 0;
+            const actionNumA = BigInt(a.name.split('-')[1]);
+            const actionNumB = BigInt(b.name.split('-')[1]);
+            return Number(actionNumA - actionNumB);
+        })
+        .map((actionUpdate) => {
+            if (!actionUpdate) return null;
 
-        const binaryString = atob(actionUpdate.value);
-        const bytes = new Uint8Array(binaryString.length);
-        for (let i = 0; i < binaryString.length; i++) {
-            bytes[i] = binaryString.charCodeAt(i);
-        }
+            const binaryString = atob(actionUpdate.value);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+                bytes[i] = binaryString.charCodeAt(i);
+            }
 
-        const decoder = AbiCoder.defaultAbiCoder();
-        return decoder.decode(['tuple(uint8,bytes24,uint64,bytes)[]'], bytes)[0];
-    });
+            const decoder = AbiCoder.defaultAbiCoder();
+            return decoder.decode(['tuple(uint8,bytes24,uint64,bytes)[]'], bytes)[0];
+        });
 
     const actions = sessionUpdates.map((actionTuples): CombatActionStruct[] => {
         // Turn the tuples back into structs


### PR DESCRIPTION
# What

## Fix to session update ordering
As GraphQL doesn't give me the list of events in the order they happen we were relying on the block number to order them. If more than one event happens within the same block there isn't any guarantee we are ordering the list correctly which means it would sometimes work and sometimes not.

## Removal of old CLAIM code and returning out of combat calculation after a winner has been decided.
There isn't such thing as 'claiming' anymore, instead all the rewards are given out during finalisation. Removed old claim code and also return early out of the combat calculation if a winner has been decided.

Also as we return early out of the combat calculation on the frontend the combat screen will now show the state of the combat as it was when it ended and not including any new joiners since a winner was decided. This can be easily seen by starting a 1v1 combat and moving the unit to the building to lose the battle. The panel should show the building as the sole entity in combat.