### PR TITLE
Naming enemy objects 'Building' so they get tidied up

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementManager.cs
@@ -29,11 +29,11 @@ public class MapElementManager : MonoBehaviour
 
     public void CreateEnemy(Vector3Int cubicCoords)
     {
-        if (!GameObject.Find("Enemy_" + cubicCoords.ToString()))
+        if (!GameObject.Find("Building_" + cubicCoords.ToString()))
         {
             MapElementController building = Instantiate(enemyPrefab, transform, true)
                 .GetComponent<MapElementController>();
-            building.gameObject.name = "Enemy_" + cubicCoords.ToString();
+            building.gameObject.name = "Building_" + cubicCoords.ToString();
             building.Setup(cubicCoords);
         }
     }


### PR DESCRIPTION
# WHAT

Enemy game objects are now named the same as buildings with `Building_[coords]` so that they get tidied up the same as buildings when they are destroyed