### PR TITLE
Removal of SeekerController from EnemyPrefab

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/EnemyMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/EnemyMapElement.prefab
@@ -196,7 +196,7 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 5657960569550214559}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &6585548448354940290
+--- !u!114 &2084428698437571845
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -205,97 +205,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 8730588450062426084}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 83776057e86ab48b899b2966d2092774, type: 3}
+  m_Script: {fileID: 11500000, guid: 6ac22d800d3ec4fc09d734c9ceed0b6c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   iconParent: {fileID: 8730588450661582252}
-  iconPrefab: {fileID: 4200293388350177078, guid: 87b00e9807c374871b1cd063b867ba6e,
+  iconPrefab: {fileID: 7482230774540498691, guid: 9d7d926df89fb45b09a4b5b4afb48628,
     type: 3}
-  nonPlayerIconPrefab: {fileID: 7482230774540498691, guid: 9d7d926df89fb45b09a4b5b4afb48628,
-    type: 3}
-  rend: {fileID: 0}
-  shrinkScale: 1
-  _moveCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  _jumpCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 4.2190776
-      outSlope: 4.2190776
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0.055900622
-    - serializedVersion: 3
-      time: 0.5
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 34
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: -3.8815546
-      outSlope: -3.8815546
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.055900574
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  _shrinkCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: -1.660355
-      outSlope: -1.660355
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0.054754052
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!4 &8730588450661582252 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4011681257694613555, guid: a699dfdf8ea904492a4f3bc5ea3d169d,


### PR DESCRIPTION
# What

The enemy prefab had the `SeekerController` component added to it which would throw an error on update as the enemy prefab isn't constructed in the same way. Replaced with the `MapElementController` which is the same as buildings and now it doesn't fail during render. This has the side effect of making player highlights work again

# Why

Highlighting was failing and this had something to do with the seeker controllers on the enemy objects trying to switch of a highlight that didn't exist.

<img width="216" alt="image" src="https://github.com/playmint/ds/assets/51167118/e1578302-8314-4e2d-a900-2c38a28e6080">
