### PR TITLE
Add pre combat summary

### DIFF
--- a/core/src/tile.graphql
+++ b/core/src/tile.graphql
@@ -5,6 +5,9 @@ fragment SelectedTile on Node {
     }
     building: node(match: { kinds: "Building", via: { rel: "Location", dir: IN } }) {
         ...WorldBuilding
+    }
+    seekers: nodes(match: { kinds: "Seeker", via: { rel: "Location", dir: IN, key: 1 } }) {
+        ...WorldSeeker
         bags: edges(match: { kinds: "Bag", via: { rel: "Equip" } }) {
             ...EquipmentSlot
         }

--- a/core/src/tile.ts
+++ b/core/src/tile.ts
@@ -81,8 +81,8 @@ function upgradeWorldTileToSelectedTile(t: WorldTileFragment): SelectedTileFragm
         building: t.building
             ? {
                   ...t.building,
-                  bags: [],
               }
             : null,
+        seekers: t.seekers ? t.seekers.map((s) => ({ ...s, bags: [] })) : [],
     };
 }

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -29,7 +29,6 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
     const { openModal, setModalContent, closeModal } = useModalContext();
     const player = usePlayer();
     const { seeker: selectedSeeker, selectSeeker, tiles: selectedTiles } = useSelection();
-
     const [providerAvailable, setProviderAvailable] = useState<boolean>(false);
 
     useEffect(() => {

--- a/frontend/src/plugins/combat/combat-modal/combat-modal.styles.ts
+++ b/frontend/src/plugins/combat/combat-modal/combat-modal.styles.ts
@@ -95,6 +95,7 @@ const baseStyles = (_: Partial<CombatModalProps>) => css`
         .defenders {
             flex-grow: 1;
             padding: 2.4rem 3.2rem;
+            max-width: 50%;
 
             .heading {
                 display: block;
@@ -118,6 +119,7 @@ const baseStyles = (_: Partial<CombatModalProps>) => css`
         .defenders {
             flex-grow: 1;
             padding: 2.4rem 3.2rem;
+            max-width: 50%;
 
             .participant {
                 margin-bottom: 1.8rem;

--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -67,6 +67,9 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
         }, [] as string[])
         .map((n: string) => BigInt(n))
         .slice(-4);
+
+    const isStackable = !!_stackable;
+
     const tooltip = isInvalid
         ? `Slot contains invalid ${name} item\n\nRemove item from slot to continue`
         : `${quantity} ${name}\n\nLife: ${life}\nDefense: ${defense}\nAttack: ${attack}`;
@@ -81,7 +84,7 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
         >
             {isPending && <span className="spinner" />}
             <img src={icon} alt={name} className="icon" />
-            <span className="amount">{quantity}</span>
+            {isStackable && <span className="amount">{quantity}</span>}
         </StyledBagItem>
     );
 };


### PR DESCRIPTION
## What is here
<img width="1445" alt="image" src="https://github.com/playmint/ds/assets/4235606/fc93bcbb-a8fa-4177-bd6f-69aafc2dd0a1">

## Known issues
- There are state transition issues after starting combat, the summary is removed for the first block of the combat
- The summary still uses the entity ID for building names during combat