### PR TITLE
Added area of influence pulse effect when clicking engineer

### DIFF
--- a/DawnSeekersUnity/Assets/Map/2D_Assets/RenderTextures/OutlineRenderer.renderTexture
+++ b/DawnSeekersUnity/Assets/Map/2D_Assets/RenderTextures/OutlineRenderer.renderTexture
@@ -14,8 +14,8 @@ RenderTexture:
   m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
   serializedVersion: 5
-  m_Width: 688
-  m_Height: 565
+  m_Width: 2129
+  m_Height: 1317
   m_AntiAliasing: 1
   m_MipCount: -1
   m_DepthStencilFormat: 0

--- a/DawnSeekersUnity/Assets/Map/Animations/AOIHighlight.controller
+++ b/DawnSeekersUnity/Assets/Map/Animations/AOIHighlight.controller
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1107 &-1903271286332435488
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -1687122334534404253}
+    m_Position: {x: 200, y: 0, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -1687122334534404253}
+--- !u!1102 &-1687122334534404253
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AOIPulse
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 385cc98bdfead40df85d997a7b07907d, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AOIHighlight
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -1903271286332435488}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}

--- a/DawnSeekersUnity/Assets/Map/Animations/AOIHighlight.controller.meta
+++ b/DawnSeekersUnity/Assets/Map/Animations/AOIHighlight.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df2e3a1dfd12a4bc9b3b273af1393251
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Animations/AOIPulse.anim
+++ b/DawnSeekersUnity/Assets/Map/Animations/AOIPulse.anim
@@ -23,6 +23,15 @@ AnimationClip:
       - serializedVersion: 3
         time: 0
         value: 0
+        inSlope: 2.9631395
+        outSlope: 2.9631395
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.08463279
+      - serializedVersion: 3
+        time: 0.06666667
+        value: 0.31747383
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -30,22 +39,13 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.083333336
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.33333334
+        time: 0.8333333
         value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
+        inSlope: -0.4259312
+        outSlope: -0.4259312
+        tangentMode: 0
         weightedMode: 0
-        inWeight: 0.33333334
+        inWeight: 0.06481593
         outWeight: 0.33333334
       m_PreInfinity: 2
       m_PostInfinity: 2
@@ -75,7 +75,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.33333334
+    m_StopTime: 0.8333333
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -97,6 +97,15 @@ AnimationClip:
       - serializedVersion: 3
         time: 0
         value: 0
+        inSlope: 2.9631395
+        outSlope: 2.9631395
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.08463279
+      - serializedVersion: 3
+        time: 0.06666667
+        value: 0.31747383
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -104,22 +113,13 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.083333336
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.33333334
+        time: 0.8333333
         value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
+        inSlope: -0.4259312
+        outSlope: -0.4259312
+        tangentMode: 0
         weightedMode: 0
-        inWeight: 0.33333334
+        inWeight: 0.06481593
         outWeight: 0.33333334
       m_PreInfinity: 2
       m_PostInfinity: 2

--- a/DawnSeekersUnity/Assets/Map/Animations/AOIPulse.anim
+++ b/DawnSeekersUnity/Assets/Map/Animations/AOIPulse.anim
@@ -30,8 +30,8 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.08463279
       - serializedVersion: 3
-        time: 0.06666667
-        value: 0.31747383
+        time: 0.05
+        value: 0.46033096
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -39,7 +39,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.8333333
+        time: 0.48333332
         value: 0
         inSlope: -0.4259312
         outSlope: -0.4259312
@@ -75,7 +75,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.8333333
+    m_StopTime: 0.48333332
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -104,8 +104,8 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.08463279
       - serializedVersion: 3
-        time: 0.06666667
-        value: 0.31747383
+        time: 0.05
+        value: 0.46033096
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -113,7 +113,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.8333333
+        time: 0.48333332
         value: 0
         inSlope: -0.4259312
         outSlope: -0.4259312

--- a/DawnSeekersUnity/Assets/Map/Animations/AOIPulse.anim
+++ b/DawnSeekersUnity/Assets/Map/Animations/AOIPulse.anim
@@ -1,0 +1,134 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AOIPulse
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.33333334
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Color.a
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 304273561
+      script: {fileID: 0}
+      typeID: 212
+      customType: 0
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.33333334
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.33333334
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Color.a
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/DawnSeekersUnity/Assets/Map/Animations/AOIPulse.anim.meta
+++ b/DawnSeekersUnity/Assets/Map/Animations/AOIPulse.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 385cc98bdfead40df85d997a7b07907d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Prefabs/AOIHighlight.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/AOIHighlight.prefab
@@ -75,7 +75,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 0d5b8d37019c049828d3bf799be2ef0c, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.78653437, g: 0.86787474, b: 0.9528302, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0

--- a/DawnSeekersUnity/Assets/Map/Prefabs/AOIHighlight.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/AOIHighlight.prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9133061235819889254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4332068239960712993}
+  - component: {fileID: 3319977055583762012}
+  - component: {fileID: 381342740280674260}
+  m_Layer: 0
+  m_Name: AOIHighlight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4332068239960712993
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9133061235819889254}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!212 &3319977055583762012
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9133061235819889254}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 21300000, guid: 6da8d971b2cc2f5418472bad9888d8ec, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.0039216, y: 1.0039216}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &381342740280674260
+Animator:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9133061235819889254}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: df2e3a1dfd12a4bc9b3b273af1393251, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0

--- a/DawnSeekersUnity/Assets/Map/Prefabs/AOIHighlight.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/AOIHighlight.prefab
@@ -74,7 +74,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: 6da8d971b2cc2f5418472bad9888d8ec, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 0d5b8d37019c049828d3bf799be2ef0c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/DawnSeekersUnity/Assets/Map/Prefabs/AOIHighlight.prefab.meta
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/AOIHighlight.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4b646fbdd5de34227824b5047b83b2fd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -3288,6 +3288,52 @@ MonoBehaviour:
   blendDistance: 0
   weight: 1
   sharedProfile: {fileID: 11400000, guid: 27f80fd714f3a449a85c4f3cf34f54fa, type: 2}
+--- !u!1 &2146142486
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2146142488}
+  - component: {fileID: 2146142487}
+  m_Layer: 0
+  m_Name: AOIPulseController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2146142487
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146142486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7f225b3fd24d4ee3979f24004dc06dd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  greenHighlightPrefab: {fileID: 9133061235819889254, guid: 4b646fbdd5de34227824b5047b83b2fd,
+    type: 3}
+--- !u!4 &2146142488
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146142486}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 21
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &4814635801955597106
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
@@ -33,12 +33,16 @@ public class AOIPulseController : MonoBehaviour
     private void GameStateUpdated(GameState gameState)
     {
         ClearHighlights();
-       if (gameState.Selected.Seeker != null && (_currentSeeker==null || gameState.Selected.Seeker.Id != _currentSeeker.Id) && SeekerManager.instance.IsPlayerSeeker(gameState.Selected.Seeker.Id))
+        if (
+            gameState.Selected.Seeker != null
+            && (_currentSeeker == null || gameState.Selected.Seeker.Id != _currentSeeker.Id)
+            && SeekerManager.instance.IsPlayerSeeker(gameState.Selected.Seeker.Id)
+        )
         {
             _currentSeeker = gameState.Selected.Seeker;
             ShowHighlights(TileHelper.GetTilePosCube(gameState.Selected.Seeker.NextLocation));
         }
-       else if (gameState.Selected.Seeker == null)
+        else if (gameState.Selected.Seeker == null)
         {
             _currentSeeker = null;
         }
@@ -47,24 +51,35 @@ public class AOIPulseController : MonoBehaviour
     private void ShowHighlights(Vector3Int cubePos)
     {
         Vector3Int[] positions = TileHelper.GetTileNeighbours(cubePos);
-        foreach(Vector3Int pos in positions)
+        foreach (Vector3Int pos in positions)
         {
             Transform highlight = Instantiate(greenHighlightPrefab).transform;
             highlight.position = MapManager.instance.grid.CellToWorld(
                 GridExtensions.CubeToGrid(pos)
             );
-            highlight.position = new Vector3(
-                highlight.position.x,
-                MapHeightManager.instance.GetHeightAtPosition(highlight.position),
-                highlight.position.z
-            );
+            if (TileHelper.IsDiscoveredTile(pos))
+            {
+                highlight.position = new Vector3(
+                    highlight.position.x,
+                    MapHeightManager.instance.GetHeightAtPosition(highlight.position),
+                    highlight.position.z
+                );
+            }
+            else
+            {
+                highlight.position = new Vector3(
+                    highlight.position.x,
+                    MapHeightManager.UNSCOUTED_HEIGHT,
+                    highlight.position.z
+                );
+            }
             _spawnedHighlights.Add(highlight.gameObject);
         }
     }
 
     private void ClearHighlights()
     {
-        foreach(GameObject highlight in _spawnedHighlights)
+        foreach (GameObject highlight in _spawnedHighlights)
         {
             Destroy(highlight);
         }

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cog;
+using System;
+
+public class AOIPulseController : MonoBehaviour
+{
+    [SerializeField]
+    GameObject greenHighlightPrefab;
+
+    List<GameObject> _spawnedHighlights = new List<GameObject>();
+
+    Seeker _currentSeeker;
+
+    private void Start()
+    {
+        GameStateMediator.Instance.EventStateUpdated += GameStateUpdated;
+        MapInteractionManager.instance.EventTileLeftClick += LeftClick;
+    }
+
+    private void LeftClick(Vector3Int obj)
+    {
+        ClearHighlights();
+    }
+
+    private void OnDestroy()
+    {
+        GameStateMediator.Instance.EventStateUpdated -= GameStateUpdated;
+        MapInteractionManager.instance.EventTileLeftClick -= LeftClick;
+    }
+
+    private void GameStateUpdated(GameState gameState)
+    {
+        ClearHighlights();
+       if (gameState.Selected.Seeker != null && (_currentSeeker==null || gameState.Selected.Seeker.Id != _currentSeeker.Id) && SeekerManager.instance.IsPlayerSeeker(gameState.Selected.Seeker.Id))
+        {
+            _currentSeeker = gameState.Selected.Seeker;
+            ShowHighlights(TileHelper.GetTilePosCube(gameState.Selected.Seeker.NextLocation));
+        }
+       else if (gameState.Selected.Seeker == null)
+        {
+            _currentSeeker = null;
+        }
+    }
+
+    private void ShowHighlights(Vector3Int cubePos)
+    {
+        Vector3Int[] positions = TileHelper.GetTileNeighbours(cubePos);
+        foreach(Vector3Int pos in positions)
+        {
+            Transform highlight = Instantiate(greenHighlightPrefab).transform;
+            highlight.position = MapManager.instance.grid.CellToWorld(
+                GridExtensions.CubeToGrid(pos)
+            );
+            highlight.position = new Vector3(
+                highlight.position.x,
+                MapHeightManager.instance.GetHeightAtPosition(highlight.position),
+                highlight.position.z
+            );
+            _spawnedHighlights.Add(highlight.gameObject);
+        }
+    }
+
+    private void ClearHighlights()
+    {
+        foreach(GameObject highlight in _spawnedHighlights)
+        {
+            Destroy(highlight);
+        }
+        _spawnedHighlights.Clear();
+    }
+}

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
@@ -16,23 +16,15 @@ public class AOIPulseController : MonoBehaviour
     private void Start()
     {
         GameStateMediator.Instance.EventStateUpdated += GameStateUpdated;
-        MapInteractionManager.instance.EventTileLeftClick += LeftClick;
-    }
-
-    private void LeftClick(Vector3Int obj)
-    {
-        ClearHighlights();
     }
 
     private void OnDestroy()
     {
         GameStateMediator.Instance.EventStateUpdated -= GameStateUpdated;
-        MapInteractionManager.instance.EventTileLeftClick -= LeftClick;
     }
 
     private void GameStateUpdated(GameState gameState)
     {
-        ClearHighlights();
         if (
             gameState.Selected.Seeker != null
             && (_currentSeeker == null || gameState.Selected.Seeker.Id != _currentSeeker.Id)

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs.meta
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7f225b3fd24d4ee3979f24004dc06dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/SeekerManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/SeekerManager.cs
@@ -100,6 +100,11 @@ public class SeekerManager : MonoBehaviour
         currentSelectedSeeker = state.Selected.Seeker;
     }
 
+    public bool IsPlayerSeeker(string seekerID)
+    {
+        return _playerSeekers.Any(s => s.Id == seekerID);
+    }
+
     public void RemoveAllSeekers()
     {
         var allSeekers = spawnedSeekers.ToDictionary(pair => pair.Key, pair => pair.Value);

--- a/DawnSeekersUnity/Assets/Resources/ScoutCursor.png.meta
+++ b/DawnSeekersUnity/Assets/Resources/ScoutCursor.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 12
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -20,7 +20,7 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
-  isReadable: 0
+  isReadable: 1
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
@@ -51,9 +51,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 7
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -67,7 +67,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 2048
+    maxTextureSize: 32
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1
@@ -91,6 +91,18 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
     buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1


### PR DESCRIPTION
This PR adds a subtle effect that flashes the tiles surrounding a selected engineer when you click them.
The effect plays every time you go from having no seeker selected, to selecting a seeker and should play only once.