### PR TITLE
Enemy position change

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BuildingMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BuildingMapElement.prefab
@@ -104,7 +104,7 @@ PrefabInstance:
     - target: {fileID: 4011681256154013440, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.23
+      value: -0.19
       objectReference: {fileID: 0}
     - target: {fileID: 4011681257798519416, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/EnemyMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/EnemyMapElement.prefab
@@ -111,6 +111,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 4200293388350177078, guid: 87b00e9807c374871b1cd063b867ba6e,
         type: 3}
+    - target: {fileID: 4011681256154013440, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.19
+      objectReference: {fileID: 0}
     - target: {fileID: 4011681257694613555, guid: a699dfdf8ea904492a4f3bc5ea3d169d,
         type: 3}
       propertyPath: m_LocalPosition.y
@@ -209,7 +214,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   iconParent: {fileID: 8730588450661582252}
-  iconPrefab: {fileID: 7482230774540498691, guid: 9d7d926df89fb45b09a4b5b4afb48628,
+  iconPrefab: {fileID: 2167013614747121971, guid: 58a41a29608144c348eb2c954e04eaef,
     type: 3}
 --- !u!4 &8730588450661582252 stripped
 Transform:

--- a/DawnSeekersUnity/Assets/Map/Scripts/Environment/TileController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Environment/TileController.cs
@@ -10,8 +10,7 @@ public class TileController : MonoBehaviour
     [SerializeField]
     Renderer rend;
 
-    private static int delayCount;
-    private static float delay;
+    private float delay;
 
     bool hasRisen = false;
 
@@ -20,10 +19,8 @@ public class TileController : MonoBehaviour
         if (hasRisen)
             return;
         hasRisen = true;
-        delayCount++;
-
+        delay = Mathf.Clamp(Camera.main.WorldToViewportPoint(transform.position).x, 0, 1);
         StartCoroutine(AppearFullCR());
-        delay += 0.05f;
     }
 
     IEnumerator AppearFullCR()
@@ -53,14 +50,12 @@ public class TileController : MonoBehaviour
         }
 
         rend.SetPropertyBlock(MapManager.instance.normalMatProps);
-        delayCount--;
     }
 
     public void Appear()
     {
         transform.position = new Vector3(transform.position.x, -1, transform.position.z);
-        delayCount++;
-        delay += 0.05f;
+        delay = Mathf.Clamp(Camera.main.WorldToViewportPoint(transform.position).x, 0, 1);
         rend.SetPropertyBlock(MapManager.instance.unscoutedMatProps);
         StartCoroutine(AppearCR());
     }
@@ -82,9 +77,5 @@ public class TileController : MonoBehaviour
             transform.position = Vector3.LerpUnclamped(startPos, endPos, popInCurve.Evaluate(t));
             yield return null;
         }
-
-        delayCount--;
-        if (delayCount == 0)
-            delay = 0;
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/SeekerController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/SeekerController.cs
@@ -31,7 +31,7 @@ public class SeekerController : MapElementController
     protected int _currentIndex;
     private float _currentSize;
     private Transform _meshesTrans;
-    private float _offsetRadius = 0.26f;
+    private float _offsetRadius = 0.29f;
 
     private string _seekerID;
     private Color _defaultColor;


### PR DESCRIPTION
This PR changes the position of the enemy model, so that it has the same position as the buildings; slightly to the back edge of the tile.
Tom and I also noticed that the building models were hanging over the back edge of the hex tiles, so their positions (and the enemies) were changed so that they are more flush with the tile's back edge.
As a result, the player's position when sharing a tile with a building or enemy has been moved forward slightly.

Finally, I snuck in a change to speed up the tile spawning animation so that it does a nice Mexican wave instead of random pop ins.