### PR TITLE
show enemy thumbnail

### DIFF
--- a/frontend/public/enemy.png
+++ b/frontend/public/enemy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a898546eadd446892c150d0a79a073065dac07e19282c0ebedfa1af6fbf4aea
+size 19293

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -58,6 +58,7 @@ interface KeyedThing {
 const ImageConstruct = () => <img src="/tile-construct.png" alt="" className="building-image" width="33%" />;
 const ImageAvailable = () => <img src="/tile-grass.png" alt="" className="building-image" />;
 const ImageBuilding = () => <img src="/building-with-flag.png" alt="" className="building-image" />;
+const ImageEnemy = () => <img src="/enemy.png" alt="" className="building-image" />;
 const ImageScouting = () => <img src="/tile-scouting.png" alt="" className="building-image" width="33%" />;
 const ImageSelecting = () => <img src="/tile-selecting.png" alt="" className="building-image" width="33%" />;
 
@@ -116,11 +117,13 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, showFull
         [selectIntent, selectTiles]
     );
 
+    const isEnemy = buildingKind?.model?.value === 'enemy';
+
     return (
         <StyledActionContextPanel className="action">
             <h3>{component?.title ?? building?.kind?.name?.value ?? 'Unnamed Building'}</h3>
             <span className="sub-title">{component?.summary || ''}</span>
-            <ImageBuilding />
+            {isEnemy ? <ImageEnemy /> : <ImageBuilding />}
             {component && showFull && (
                 <TileAction showTitle={false} component={component} className="action">
                     {inputs.length > 0 && inputBag && (


### PR DESCRIPTION
## what

shows an enemy thumbnail rather than a tower thumbnail when building is annotated as an enemy

![Screenshot 2023-06-21 at 15 48 21](https://github.com/playmint/ds/assets/45921/4286759f-65f1-4c4b-8fb9-ad5d52e3868a)

## related

resolves: #314 