### PR TITLE
fix map unable to select construct site tile

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementManager.cs
@@ -73,10 +73,17 @@ public class MapElementManager : MonoBehaviour
     public int IsElementAtCell(Vector3Int cubicCoords)
     {
         if (
-            _spawnedBuildings.ContainsKey(cubicCoords)
-            || _spawnedEnemies.ContainsKey(cubicCoords)
+            IsBuildingAtCell(cubicCoords) == 1
             || _spawnedIncompleteBuildings.ContainsKey(cubicCoords)
         )
+            return 1;
+        else
+            return 0;
+    }
+
+    public int IsBuildingAtCell(Vector3Int cubicCoords)
+    {
+        if (_spawnedBuildings.ContainsKey(cubicCoords) || _spawnedEnemies.ContainsKey(cubicCoords))
             return 1;
         else
             return 0;

--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/ConstructIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/ConstructIntent.cs
@@ -117,7 +117,7 @@ public class ConstructIntent : IntentHandler
             .Where(cellPosCube =>
             {
                 return MapManager.instance.IsDiscoveredTile(cellPosCube)
-                    && MapElementManager.instance.IsElementAtCell(cellPosCube) == 0;
+                    && MapElementManager.instance.IsBuildingAtCell(cellPosCube) == 0;
             })
             .ToArray();
     }


### PR DESCRIPTION
the intent logic to work out valid tile for construction was considering the existence of a construction site element to mean you can't build there which is not true

resolves: #346

review code with "hide whitespace" as this file had mixed line endings and got autoformatted 