### PR TITLE
Added 10x multiplier to Unit's health

### DIFF
--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -29,6 +29,8 @@ using Schema for State;
 uint32 constant UNIT_BASE_LIFE = 50;
 uint32 constant UNIT_BASE_DEFENCE = 23;
 uint32 constant UNIT_BASE_ATTACK = 30;
+uint32 constant UNIT_LIFE_MUL = 10;
+
 uint64 constant BLOCKS_PER_TICK = 1;
 uint8 constant MAX_ENTITIES_PER_SIDE = 100; // No higher than 256 due to there being a reward bag for each entity and edges being 8 bit indices
 uint8 constant HASH_EDGE_INDEX = 2;
@@ -671,7 +673,7 @@ contract CombatRule is Rule {
 
         if (bytes4(entityID) == Kind.Seeker.selector) {
             // Made up base stats for seeker
-            stats[ATOM_LIFE] = UNIT_BASE_LIFE;
+            stats[ATOM_LIFE] = UNIT_BASE_LIFE * UNIT_LIFE_MUL;
             stats[ATOM_DEFENSE] = UNIT_BASE_DEFENCE;
             stats[ATOM_ATTACK] = UNIT_BASE_ATTACK;
 
@@ -685,7 +687,7 @@ contract CombatRule is Rule {
                         (uint32[3] memory inputAtoms, bool isStackable) = state.getItemStructure(item);
                         if (!isStackable && balance > 0) {
                             for (uint8 k = 0; k < 3; k++) {
-                                stats[k] += inputAtoms[k];
+                                stats[k] += inputAtoms[k] * (k == ATOM_LIFE ? UNIT_LIFE_MUL : 1);
                             }
                         }
                     }

--- a/frontend/src/plugins/combat/helpers.ts
+++ b/frontend/src/plugins/combat/helpers.ts
@@ -18,6 +18,7 @@ import { CombatParticipantProps } from '@app/plugins/combat/combat-participant';
 export const UNIT_BASE_LIFE = 50;
 export const UNIT_BASE_DEFENCE = 23;
 export const UNIT_BASE_ATTACK = 30;
+export const UNIT_LIFE_MUL = 10;
 
 export const buildingIdStart = '0x34cf8a7e';
 
@@ -169,7 +170,7 @@ export const getEquipmentStats = (equipmentSlots: EquipmentSlotFragment[]) => {
                 if (slot.balance > 0) {
                     const [stackable, life, defense, attack] = getItemStats(slot.item.id);
                     if (!stackable) {
-                        stats[ATOM_LIFE] += life;
+                        stats[ATOM_LIFE] += life * UNIT_LIFE_MUL;
                         stats[ATOM_DEFENSE] += defense;
                         stats[ATOM_ATTACK] += attack;
                     }
@@ -202,8 +203,8 @@ export const unitToCombatParticipantProps = (unit: SelectedSeekerFragment, seeke
     return {
         name: `Unit #${formatUnitKey(entityID)}`,
         icon: getIcon(entityID, seekers),
-        maxHealth: stats[ATOM_LIFE] + UNIT_BASE_LIFE,
-        currentHealth: stats[ATOM_LIFE] + UNIT_BASE_LIFE,
+        maxHealth: stats[ATOM_LIFE] + UNIT_BASE_LIFE * UNIT_LIFE_MUL,
+        currentHealth: stats[ATOM_LIFE] + UNIT_BASE_LIFE * UNIT_LIFE_MUL,
         attack: stats[ATOM_ATTACK] + UNIT_BASE_ATTACK,
         defence: stats[ATOM_DEFENSE] + UNIT_BASE_DEFENCE,
         isDead: false,


### PR DESCRIPTION
# What

![image](https://github.com/playmint/ds/assets/51167118/de1681ef-a6f0-4c7d-89b6-90f188dbd4ac)

Change applied in contract logic where a Unit joins combat as well as the frontend code that does the pre combat stats calculation

# Why

To make combat last longer as per the request from @PlaymintPaul 

#320