### PR TITLE
Combat state displays correctly for first tick

### DIFF
--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -348,7 +348,7 @@ contract CombatRule is Rule {
             CombatAction memory combatAction =
                 sessionUpdates[uint16(sortedListIndexes[x])][uint16(sortedListIndexes[x] >> 16)];
 
-            if (combatAction.blockNum >= endBlockNum) {
+            if (combatAction.blockNum > endBlockNum) {
                 // Battle not finished
                 return (combatState);
             }

--- a/frontend/src/contexts/block-time-provider.tsx
+++ b/frontend/src/contexts/block-time-provider.tsx
@@ -37,7 +37,7 @@ export const BlockTimeProvider = ({ block, children }: BlockTimeContextProviderP
             const elapsed = nowTime - lastBlockTimeRef.current;
             const newBlocks = Math.floor(elapsed / BLOCK_TIME_SECS);
             estimatedBlockRef.current = block + newBlocks;
-        }, BLOCK_TIME_SECS * 1000);
+        }, 1000);
         return () => clearInterval(id);
     }, [block]);
 

--- a/frontend/src/plugins/combat/combat-modal/index.tsx
+++ b/frontend/src/plugins/combat/combat-modal/index.tsx
@@ -21,6 +21,7 @@ import {
     convertCombatActions,
     entityStateToCombatParticipantProps,
     getActions,
+    getLatestSession,
     getTileEntities,
     sumParticipants
 } from '@app/plugins/combat/helpers';
@@ -352,12 +353,7 @@ export const CombatModal: FunctionComponent<CombatModalProps> = (props: CombatMo
     const { seeker: selectedSeeker, tiles: selectedTiles = [] } = useSelection();
     const { blockNumberRef, blockTime } = useBlockTime();
     const [blockNumber, setBlockNumber] = useState<number>(blockNumberRef.current);
-    const latestSession =
-        selectedTiles.length > 0 && selectedTiles[0].sessions.length > 0
-            ? selectedTiles[0].sessions.sort((a, b) => {
-                  return a.attackTile && b.attackTile ? b.attackTile.startBlock - a.attackTile.startBlock : 0;
-              })[0]
-            : undefined;
+    const latestSession = getLatestSession(selectedTiles);
     const actions = latestSession && getActions(latestSession);
 
     const [dispatchComplete, setDispatchComplete] = useState<boolean>(false);
@@ -452,14 +448,13 @@ export const CombatModal: FunctionComponent<CombatModalProps> = (props: CombatMo
         );
     }
 
-    const entitiesEmpty = combatState.attackerStates.every((e) => e === undefined);
-    const attackers: CombatParticipantProps[] = entitiesEmpty
-        ? getTileEntities(selectedTiles[0], player)
-        : combatState.attackerStates.map((entity) => entityStateToCombatParticipantProps(entity, world, player));
+    const attackers: CombatParticipantProps[] = combatState.attackerStates.map((entity) =>
+        entityStateToCombatParticipantProps(entity, world, player)
+    );
     const [attackersMaxHealth, attackersCurrentHealth] = attackers.reduce(sumParticipants, [0, 0]);
-    const defenders: CombatParticipantProps[] = entitiesEmpty
-        ? getTileEntities(selectedTiles[1], player)
-        : combatState.defenderStates.map((entity) => entityStateToCombatParticipantProps(entity, world, player));
+    const defenders: CombatParticipantProps[] = combatState.defenderStates.map((entity) =>
+        entityStateToCombatParticipantProps(entity, world, player)
+    );
     const [defendersMaxHealth, defendersCurrentHealth] = defenders.reduce(sumParticipants, [0, 0]);
 
     // During combat

--- a/frontend/src/plugins/combat/combat.ts
+++ b/frontend/src/plugins/combat/combat.ts
@@ -89,7 +89,7 @@ export class Combat {
         for (let x = 0; x < sortedListIndexes.length; x++) {
             const combatAction = sessionUpdates[sortedListIndexes[x] & 0xffff][sortedListIndexes[x] >> 16];
 
-            if (combatAction.blockNum >= endBlockNum) {
+            if (combatAction.blockNum > endBlockNum) {
                 return combatState;
             }
 

--- a/frontend/src/plugins/combat/helpers.ts
+++ b/frontend/src/plugins/combat/helpers.ts
@@ -261,3 +261,11 @@ export const getTileEntities = (tile: SelectedTileFragment, player: ConnectedPla
     entities.push(...tile.seekers.map((unit) => unitToCombatParticipantProps(unit, player.seekers)));
     return entities;
 };
+
+export const getLatestSession = (selectedTiles: SelectedTileFragment[]) => {
+    return selectedTiles.length > 0 && selectedTiles[0].sessions.length > 0
+        ? selectedTiles[0].sessions.sort((a, b) => {
+              return a.attackTile && b.attackTile ? b.attackTile.startBlock - a.attackTile.startBlock : 0;
+          })[0]
+        : undefined;
+};


### PR DESCRIPTION
### What

The state of who has joined combat is now displayed correctly for the first block during tick 0. Also fixed the problem of frontend expecting two tiles to be selected to show state during combat which manifested itself during the playtest as only one side of the combat being displayed in the attacker column

### A bit more detail

Block time estimates/updates on the frontend now happen every second. By increasing the time we check for block time update it solves the problem where we had a block time of 0 for the first 10 seconds of play. 

Combat logic now processes actions that occur on the current block. The state calculation was exiting early if the action was occurring on `>= currentBlock`. This meant that there was no combat state displayed until the next block had been mined