### PR TITLE
don't send state without world to unity

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
@@ -224,7 +224,9 @@ public class MapInteractionManager : MonoBehaviour
         {
             selectedMarker1.gameObject.SetActive(false);
         }
-        else if (state.Selected.Tiles != null && state.Selected.Tiles.Count > 0)
+        else if (
+            state.Selected != null && state.Selected.Tiles != null && state.Selected.Tiles.Count > 0
+        )
         {
             var tile = state.Selected.Tiles.First();
             var cellPosCube = TileHelper.GetTilePosCube(tile);

--- a/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/GameStateMediator.cs
+++ b/DawnSeekersUnity/Assets/Scripts/Cog/Plugin/GameStateMediator.cs
@@ -110,16 +110,29 @@ namespace Cog
                 _hasStateUpdated = false;
                 if (EventStateUpdated != null)
                 {
-                    EventStateUpdated.Invoke(gameState);
+                    try
+                    {
+                        EventStateUpdated.Invoke(gameState);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.Log($"GameStateMediator::Update() error {e.Message}");
+                    }
                 }
             }
         }
 
         private void UpdateState(GameState state)
         {
-            gameState = state;
-            _account = state.Player.Addr as string;
-            _hasStateUpdated = true;
+            if (state != null)
+            {
+                gameState = state;
+                if (state.Player != null)
+                {
+                    _account = state.Player.Addr as string;
+                }
+                _hasStateUpdated = true;
+            }
         }
 
 #if UNITY_EDITOR
@@ -317,11 +330,10 @@ namespace Cog
         }
 
         // -- MESSAGE IN
-        private string _prevStateJson = "";
 
         public void OnState(string stateJson)
         {
-            if (_prevStateJson == stateJson)
+            if (stateJson == "")
                 return;
 
             try

--- a/frontend/src/components/organisms/unity-map/index.tsx
+++ b/frontend/src/components/organisms/unity-map/index.tsx
@@ -119,7 +119,7 @@ export const UnityMap: FunctionComponent<UnityMapProps> = ({ ...otherProps }: Un
     }, []);
 
     const newMapBlob = JSON.stringify(game);
-    if (isReady && game && globalLastBlob != newMapBlob) {
+    if (isReady && game && game.world && globalLastBlob != newMapBlob) {
         globalSender = sendMessage;
         globalLastBlob = newMapBlob;
         (window as any).globalLastBlob = globalLastBlob;


### PR DESCRIPTION
with webgl exception handling now disabled the map will crash if an exception bubbles to the surface

the map doesn't seem to like state without the "world" in it ... so dont send it without the world

add a few guards to protect from nulls