### PR TITLE
revert on invalid tile coords

### DIFF
--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -616,7 +616,7 @@ contract GameDeployer is Script {
         BuildingUtils.construct(ds, slime, "enemy", 5, 7, -12);
         BuildingUtils.construct(ds, slime, "enemy", -4, -8, 12);
         BuildingUtils.construct(ds, slime, "enemy", 9, 0, -9);
-        BuildingUtils.construct(ds, slime, "enemy", 0, 12, 12);
+        BuildingUtils.construct(ds, slime, "enemy", 0, -12, 12);
 
         BuildingUtils.construct(ds, obnoxiousBeaver, "enemy", 10, 8, -18);
         BuildingUtils.construct(ds, obnoxiousBeaver, "enemy", -3, 13, -10);

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -66,6 +66,7 @@ library Node {
     }
 
     function Tile(int16 zone, int16 q, int16 r, int16 s) internal pure returns (bytes24) {
+        require((q + r + s) == 0, "InvalidTileCoords");
         return CompoundKeyEncoder.INT16_ARRAY(Kind.Tile.selector, [zone, q, r, s]);
     }
 

--- a/contracts/test/Game.t.sol
+++ b/contracts/test/Game.t.sol
@@ -48,7 +48,7 @@ contract GameTest is Test {
                 (
                     BiomeKind.DISCOVERED,
                     1, // q
-                    1, // r
+                    -2, // r
                     1 // s
                 )
             )

--- a/contracts/test/rules/BuildingRule.t.sol
+++ b/contracts/test/rules/BuildingRule.t.sol
@@ -123,7 +123,7 @@ contract BuildingRuleTest is Test {
     }
 
     function testConstructFailSeekerNotDirect() public {
-        _testConstructFailNotAdjacent(1, -1, 1);
+        _testConstructFailNotAdjacent(1, -2, 1);
     }
 
     function testRegisterBuildingKindContract() public {

--- a/contracts/test/rules/MovementRule.t.sol
+++ b/contracts/test/rules/MovementRule.t.sol
@@ -130,7 +130,7 @@ contract MovementRuleTest is Test {
     function testNoMoveToUndiscovered() public {
         vm.startPrank(aliceAccount);
         vm.expectRevert("NoMoveToUndiscovered");
-        _tryMoveTo(0, -5, -5);
+        _tryMoveTo(0, 5, -5);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
bail if attempting to generate an invalid Tile id as it is an extremely common error.

... then fix a bunch of places where we made this mistake

fixes: #319