### PR TITLE
send state JSON to map into smaller chunks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ compose: frontend/public/ds-unity/Build/ds-unity.wasm
 contracts/out/Actions.sol/Actions.json:
 	(cd contracts && forge build)
 
+core/src/gql:
+	# noop
+
 core/dist/core.js: $(CORE_SRC)
 	(cd core && npm run build)
 

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -191,7 +191,7 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
                 </div>
             </div>
             <div className="map-container">
-                <UnityMap />
+                <UnityMap player={player} selection={selection} world={world} />
             </div>
         </StyledShell>
     );


### PR DESCRIPTION
### what

Instead of sending a single giant blob of JSON on each state update to the map, send many smaller chunks and reassemble them.

### why

deserialising json in unity-land is synchronous (and their doesn't appear to be a useful async api), and js is a single thread, which means deserialising the large blob of json blocks the event loop.

splitting up the sending of data to the map into smaller bits means that it takes significantly longer overall, but will yield cpu to the event loop in-between chunks, making things a bit more responsive.

### notes

ngl, I don't love this.... it def avoids the large blocking calls, but at the cost of a fair bit more complicated, more fragile code .... changes to the graphql may require equivilent changes to the sending code, it's quite a bit slower and increases the chances of things getting out of sync.