### PR TITLE
More performance improvements from map side

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Animations/AOIHighlight.controller
+++ b/DawnSeekersUnity/Assets/Map/Animations/AOIHighlight.controller
@@ -11,9 +11,10 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -1687122334534404253}
-    m_Position: {x: 200, y: 0, z: 0}
+    m_Position: {x: 300, y: 40, z: 0}
   m_ChildStateMachines: []
-  m_AnyStateTransitions: []
+  m_AnyStateTransitions:
+  - {fileID: 8015832047330670309}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -56,7 +57,13 @@ AnimatorController:
   m_PrefabAsset: {fileID: 0}
   m_Name: AOIHighlight
   serializedVersion: 5
-  m_AnimatorParameters: []
+  m_AnimatorParameters:
+  - m_Name: Pulse
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -70,3 +77,28 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1101 &8015832047330670309
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Pulse
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1687122334534404253}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.015482623
+  m_TransitionOffset: 0
+  m_ExitTime: 0.010634526
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 2
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BagMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BagMapElement.prefab
@@ -82,6 +82,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 1410422685, guid: a699dfdf8ea904492a4f3bc5ea3d169d, type: 3}
+      propertyPath: createIcon
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1410422685, guid: a699dfdf8ea904492a4f3bc5ea3d169d, type: 3}
       propertyPath: iconPrefab
       value: 
       objectReference: {fileID: 2167013614747121971, guid: 4854f4697b91040438550f6c31bacea1,

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BuildingMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/BuildingMapElement.prefab
@@ -97,6 +97,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 1410422685, guid: a699dfdf8ea904492a4f3bc5ea3d169d, type: 3}
+      propertyPath: createIcon
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1410422685, guid: a699dfdf8ea904492a4f3bc5ea3d169d, type: 3}
       propertyPath: iconPrefab
       value: 
       objectReference: {fileID: 2167013614747121971, guid: 58a41a29608144c348eb2c954e04eaef,

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/EnemyMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/EnemyMapElement.prefab
@@ -216,6 +216,7 @@ MonoBehaviour:
   iconParent: {fileID: 8730588450661582252}
   iconPrefab: {fileID: 2167013614747121971, guid: 58a41a29608144c348eb2c954e04eaef,
     type: 3}
+  createIcon: 0
 --- !u!4 &8730588450661582252 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4011681257694613555, guid: a699dfdf8ea904492a4f3bc5ea3d169d,

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/Icons/Icon_Other_Player.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/Icons/Icon_Other_Player.prefab
@@ -144,5 +144,20 @@ PrefabInstance:
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4748722693351174289, guid: 87b00e9807c374871b1cd063b867ba6e,
+        type: 3}
+      propertyPath: m_isRichText
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4748722693351174289, guid: 87b00e9807c374871b1cd063b867ba6e,
+        type: 3}
+      propertyPath: m_enableWordWrapping
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4748722693351174289, guid: 87b00e9807c374871b1cd063b867ba6e,
+        type: 3}
+      propertyPath: m_parseCtrlCharacters
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 87b00e9807c374871b1cd063b867ba6e, type: 3}

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/Icons/Icon_Player.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/Icons/Icon_Player.prefab
@@ -199,6 +199,21 @@ PrefabInstance:
       propertyPath: m_ConstrainProportionsScale
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7331417994891835028, guid: d0edab06a40584c3c99d39f8057dffb4,
+        type: 3}
+      propertyPath: m_isRichText
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7331417994891835028, guid: d0edab06a40584c3c99d39f8057dffb4,
+        type: 3}
+      propertyPath: m_enableWordWrapping
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7331417994891835028, guid: d0edab06a40584c3c99d39f8057dffb4,
+        type: 3}
+      propertyPath: m_parseCtrlCharacters
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7499765724257285629, guid: d0edab06a40584c3c99d39f8057dffb4,
         type: 3}
       propertyPath: m_Color.a

--- a/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/UnderConstructionMapElement.prefab
+++ b/DawnSeekersUnity/Assets/Map/Prefabs/MapElements/UnderConstructionMapElement.prefab
@@ -97,6 +97,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 1410422685, guid: a699dfdf8ea904492a4f3bc5ea3d169d, type: 3}
+      propertyPath: createIcon
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1410422685, guid: a699dfdf8ea904492a4f3bc5ea3d169d, type: 3}
       propertyPath: iconPrefab
       value: 
       objectReference: {fileID: 2167013614747121971, guid: 58a41a29608144c348eb2c954e04eaef,

--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -3590,6 +3590,21 @@ PrefabInstance:
       propertyPath: m_CullingMask.m_Bits
       value: 247
       objectReference: {fileID: 0}
+    - target: {fileID: 6518314205033195301, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_XDamping
+      value: 0.666
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314205033195301, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_YDamping
+      value: 0.666
+      objectReference: {fileID: 0}
+    - target: {fileID: 6518314205033195301, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+        type: 3}
+      propertyPath: m_ZDamping
+      value: 0.666
+      objectReference: {fileID: 0}
     - target: {fileID: 6604238751355071835, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
         type: 3}
       propertyPath: m_TargetTexture

--- a/DawnSeekersUnity/Assets/Map/Scripts/Addressables/EnvironmentLoaderManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Addressables/EnvironmentLoaderManager.cs
@@ -62,8 +62,7 @@ public class EnvironmentLoaderManager : MonoBehaviour
         AsyncOperationHandle operationHandle = Addressables.LoadAssetAsync<GameObject>(label);
         await operationHandle.Task;
         _tilePrefab = (GameObject)operationHandle.Result;
-        EnvironmentAssetsLoaded?.Invoke();
-        Debug.Log("Environment assets loaded.");
+        Invoke("DelayedInvoke", 1);
     }
 
     public TileController AddTile(Vector3 position, Vector3Int cellCubicCoords)
@@ -72,5 +71,11 @@ public class EnvironmentLoaderManager : MonoBehaviour
         tile.name = "Tile_" + cellCubicCoords.ToString();
         tile.position = new Vector3(position.x, -1, position.z);
         return tile.GetComponent<TileController>();
+    }
+
+    private void DelayedInvoke()
+    {
+        EnvironmentAssetsLoaded?.Invoke();
+        Debug.Log("Environment assets loaded.");
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
@@ -9,7 +9,7 @@ public class AOIPulseController : MonoBehaviour
     [SerializeField]
     GameObject greenHighlightPrefab;
 
-    List<GameObject> _spawnedHighlights = new List<GameObject>();
+    List<Animator> _spawnedHighlights = new List<Animator>();
 
     Seeker _currentSeeker;
 
@@ -43,37 +43,48 @@ public class AOIPulseController : MonoBehaviour
     private void ShowHighlights(Vector3Int cubePos)
     {
         Vector3Int[] positions = TileHelper.GetTileNeighbours(cubePos);
+
+        if (_spawnedHighlights.Count == 0)
+        {
+            for (int i = 0; i < positions.Length; i++)
+            {
+                Animator highlight = Instantiate(greenHighlightPrefab).GetComponent<Animator>();
+                _spawnedHighlights.Add(highlight);
+            }
+        }
+
         for (int i = 0; i < positions.Length; i++)
         {
-            Transform highlight = Instantiate(greenHighlightPrefab).transform;
-            highlight.position = MapManager.instance.grid.CellToWorld(
+            _spawnedHighlights[i].transform.position = MapManager.instance.grid.CellToWorld(
                 GridExtensions.CubeToGrid(positions[i])
             );
             if (MapManager.instance.IsDiscoveredTile(positions[i]))
             {
-                highlight.position = new Vector3(
-                    highlight.position.x,
-                    MapHeightManager.instance.GetHeightAtPosition(highlight.position),
-                    highlight.position.z
+                _spawnedHighlights[i].transform.position = new Vector3(
+                    _spawnedHighlights[i].transform.position.x,
+                    MapHeightManager.instance.GetHeightAtPosition(
+                        _spawnedHighlights[i].transform.position
+                    ),
+                    _spawnedHighlights[i].transform.position.z
                 );
             }
             else
             {
-                highlight.position = new Vector3(
-                    highlight.position.x,
+                _spawnedHighlights[i].transform.position = new Vector3(
+                    _spawnedHighlights[i].transform.position.x,
                     MapHeightManager.UNSCOUTED_HEIGHT,
-                    highlight.position.z
+                    _spawnedHighlights[i].transform.position.z
                 );
             }
-            _spawnedHighlights.Add(highlight.gameObject);
+            _spawnedHighlights[i].SetTrigger("Pulse");
         }
     }
 
     private void ClearHighlights()
     {
-        foreach (GameObject highlight in _spawnedHighlights)
+        foreach (Animator highlight in _spawnedHighlights)
         {
-            Destroy(highlight);
+            Destroy(highlight.gameObject);
         }
         _spawnedHighlights.Clear();
     }

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementController.cs
@@ -10,6 +10,9 @@ public class MapElementController : MonoBehaviour
     [SerializeField]
     protected GameObject iconPrefab;
 
+    [SerializeField]
+    private bool createIcon = true;
+
     protected IconController _icon;
     protected Vector3 _currentPosition;
 
@@ -20,13 +23,14 @@ public class MapElementController : MonoBehaviour
         _currentPosition = pos;
         _currentPosition = new Vector3(_currentPosition.x, height, _currentPosition.z);
         transform.position = _currentPosition;
-
-        _icon = MapElementManager.instance.CreateIcon(iconParent, iconPrefab);
+        if (createIcon)
+            _icon = MapElementManager.instance.CreateIcon(iconParent, iconPrefab);
     }
 
     public void DestroyMapElement()
     {
-        _icon.DestroyIcon();
+        if (createIcon)
+            _icon.DestroyIcon();
         Destroy(gameObject);
     }
 }

--- a/DawnSeekersUnity/Assets/Map/Scripts/UI/LoadingOverlay.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/UI/LoadingOverlay.cs
@@ -12,25 +12,21 @@ public class LoadingOverlay : MonoBehaviour
     {
         _group = GetComponent<CanvasGroup>();
         _hidden = false;
-        Cog.GameStateMediator.Instance.EventStateUpdated += OnStateUpdated;
+        EnvironmentLoaderManager.EnvironmentAssetsLoaded += OnStateUpdated;
     }
 
     private void OnDestroy()
     {
-        Cog.GameStateMediator.Instance.EventStateUpdated -= OnStateUpdated;
+        EnvironmentLoaderManager.EnvironmentAssetsLoaded -= OnStateUpdated;
     }
 
-    private void OnStateUpdated(GameState state)
+    private void OnStateUpdated()
     {
-        if (_hidden || state.World == null || state.World.Tiles == null)
+        if (_hidden)
             return;
-
-        if (state.World.Tiles.Count > 0)
-        {
-            _hidden = true;
-            StartCoroutine(FadeOutCR());
-            return;
-        }
+        _hidden = true;
+        StartCoroutine(FadeOutCR());
+        return;
     }
 
     IEnumerator FadeOutCR()


### PR DESCRIPTION
This PR converts the OnStateUpdated listeners in the Map and Seeker managers into coroutines, which break the task of updating tiles and seekers into more manageable chunks. So rather than processing 300 tiles in one frame, it processes 3 tiles over 100 frames. This helps to smooth out the lag spike caused whenever an update from the Shell comes though.

Also in this PR is a fix for the performance decrease over time (or rather over time spent actively playing). This was caused by a duplication glitch which would duplicate the highlights that pulse when you select your seeker and never destroy them.
The highlights are now created, pooled and reused, fixing the bug and saving garbage collection.

There's also a few minor changes to save on memory and the timing of the reveal of the map has been delayed to also make it slightly smoother.