### PR TITLE
Add action and rule for renaming owned entities

### DIFF
--- a/contracts/src/Game.sol
+++ b/contracts/src/Game.sol
@@ -20,6 +20,7 @@ import {CraftingRule} from "@ds/rules/CraftingRule.sol";
 import {PluginRule} from "@ds/rules/PluginRule.sol";
 import {NewPlayerRule} from "@ds/rules/NewPlayerRule.sol";
 import {CombatRule} from "@ds/rules/CombatRule.sol";
+import {NamingRule} from "@ds/rules/NamingRule.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 
 using Schema for StateGraph;
@@ -106,6 +107,7 @@ contract Game is BaseGame {
         dispatcher.registerRule(new PluginRule());
         dispatcher.registerRule(new NewPlayerRule(allowlist));
         dispatcher.registerRule(new CombatRule());
+        dispatcher.registerRule(new NamingRule());
         dispatcher.registerRouter(router);
 
         // update the game with this config

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -91,6 +91,8 @@ interface Actions {
         uint32[] calldata sortedListIndexes
     ) external;
 
+    function NAME_OWNED_ENTITY(bytes24 entity, string calldata name) external;
+
     // [dev/debug only] set a tile biome at any location
     function DEV_SPAWN_TILE(BiomeKind kind, int16 q, int16 r, int16 s) external;
 

--- a/contracts/src/rules/NamingRule.sol
+++ b/contracts/src/rules/NamingRule.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {State} from "cog/State.sol";
+import {Context, Rule} from "cog/Dispatcher.sol";
+import {Context, Rule} from "cog/Dispatcher.sol";
+
+import {Schema, Node, Kind, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
+import {TileUtils} from "@ds/utils/TileUtils.sol";
+import {ItemUtils} from "@ds/utils/ItemUtils.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+import {CraftingRule} from "@ds/rules/CraftingRule.sol";
+
+using Schema for State;
+
+contract NamingRule is Rule {
+    constructor() {}
+
+    function reduce(State state, bytes calldata action, Context calldata ctx) public returns (State) {
+        if (bytes4(action) == Actions.NAME_OWNED_ENTITY.selector) {
+            (bytes24 entity, string memory name) = abi.decode(action[4:], (bytes24, string));
+            _changeEntityName(state, Node.Player(ctx.sender), entity, name);
+        }
+        return state;
+    }
+
+    function _changeEntityName(State state, bytes24 player, bytes24 entity, string memory name) private {
+        bytes24 existingOwner = state.getOwner(entity);
+        if (existingOwner != 0x0 && existingOwner != player) {
+            revert("EntityNotOwnedByPlayer");
+        }
+        state.annotate(entity, "name", name);
+    }
+}

--- a/contracts/test/rules/NamingRule.t.sol
+++ b/contracts/test/rules/NamingRule.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {Game} from "cog/Game.sol";
+import {State, AnnotationKind} from "cog/State.sol";
+import {Dispatcher} from "cog/Dispatcher.sol";
+
+import {Game as Dawnseekers} from "@ds/Game.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {Schema, Node, Rel, LocationKey, BiomeKind, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
+import {ItemUtils} from "@ds/utils/ItemUtils.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+using Schema for State;
+
+contract NamingRuleTest is Test {
+    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref, string data);
+
+    Game internal game;
+    Dispatcher internal dispatcher;
+    State internal state;
+
+    // accounts
+    address aliceAccount;
+    uint64 sid;
+
+    function setUp() public {
+        // setup users
+        uint256 alicePrivateKey = 0xA11CE;
+        aliceAccount = vm.addr(alicePrivateKey);
+
+        // setup allowlist
+        address[] memory allowlist = new address[](1);
+        allowlist[0] = aliceAccount;
+
+        // setup game
+        game = new Dawnseekers(allowlist);
+        dispatcher = game.getDispatcher();
+
+        // fetch the State to play with
+        state = game.getState();
+    }
+
+    function testNameOwnedEntity() public {
+        // spawn a unit
+        vm.startPrank(aliceAccount);
+        sid++;
+        bytes24 entity = Node.Seeker(sid);
+        dispatcher.dispatch(abi.encodeCall(Actions.SPAWN_SEEKER, (entity)));
+
+        // rename the unit
+        string memory name = "Jeff";
+        dispatcher.dispatch(abi.encodeCall(Actions.NAME_OWNED_ENTITY, (entity, name)));
+
+        assertEq(state.getAnnotationRef(entity, "name"), keccak256(bytes(name)));
+    }
+}

--- a/contracts/test/rules/NamingRule.t.sol
+++ b/contracts/test/rules/NamingRule.t.sol
@@ -3,24 +3,22 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 
-import {Game} from "cog/Game.sol";
 import {State, AnnotationKind} from "cog/State.sol";
+import {StateGraph} from "cog/StateGraph.sol";
 import {Dispatcher} from "cog/Dispatcher.sol";
 
 import {Game as Dawnseekers} from "@ds/Game.sol";
 import {Actions} from "@ds/actions/Actions.sol";
-import {Schema, Node, Rel, LocationKey, BiomeKind, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
-import {ItemUtils} from "@ds/utils/ItemUtils.sol";
-import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+import {Schema, Node} from "@ds/schema/Schema.sol";
 
 using Schema for State;
 
 contract NamingRuleTest is Test {
     event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref, string data);
 
-    Game internal game;
+    Dawnseekers internal game;
     Dispatcher internal dispatcher;
-    State internal state;
+    StateGraph internal state;
 
     // accounts
     address aliceAccount;
@@ -40,7 +38,7 @@ contract NamingRuleTest is Test {
         dispatcher = game.getDispatcher();
 
         // fetch the State to play with
-        state = game.getState();
+        state = StateGraph(address(game.getState()));
     }
 
     function testNameOwnedEntity() public {

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -30,6 +30,10 @@ fragment WorldSeeker on Node {
     owner: node(match: { kinds: "Player", via: { rel: "Owner" } }) {
         id
     }
+    # owner assigned name
+    name: annotation(name: "name") {
+        value
+    }
 }
 
 fragment WorldBuilding on Node {

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -132,6 +132,20 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
         [player, selectSeeker, selectedSeeker]
     );
 
+    const nameEntity = useCallback(
+        (entityId: string | undefined) => {
+            if (!entityId) {
+                return;
+            }
+            if (!player) {
+                return;
+            }
+            const name = prompt('Enter a name:');
+            player.dispatch({ name: 'NAME_OWNED_ENTITY', args: [entityId, name] });
+        },
+        [player]
+    );
+
     const showCombatModal = (isNewSession: boolean = false) => {
         if (!player || !world) {
             return;
@@ -199,8 +213,13 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
                                             <button className="icon-button" onClick={() => selectNextSeeker(-1)}>
                                                 <img src="/icons/prev.png" alt="Previous" />
                                             </button>
-                                            <span className="label">
-                                                Unit #{formatUnitKey(selectedSeeker?.key.toString() || '')}
+                                            <span
+                                                className="label"
+                                                onDoubleClick={() => nameEntity(selectedSeeker?.id)}
+                                            >
+                                                {selectedSeeker && selectedSeeker.name?.value
+                                                    ? selectedSeeker.name.value
+                                                    : `Unit ${formatUnitKey(selectedSeeker?.key.toString() || '')}`}
                                             </span>
                                             <button className="icon-button" onClick={() => selectNextSeeker(+1)}>
                                                 <img src="/icons/next.png" alt="Next" />

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -141,6 +141,9 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
                 return;
             }
             const name = prompt('Enter a name:');
+            if (!name || name.length < 3) {
+                return;
+            }
             player.dispatch({ name: 'NAME_OWNED_ENTITY', args: [entityId, name] });
         },
         [player]

--- a/frontend/src/plugins/seeker-list/index.tsx
+++ b/frontend/src/plugins/seeker-list/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { ComponentProps } from '@app/types/component-props';
 import { styles } from './seeker-list.styles';
 import { Seeker } from '@dawnseekers/core';
+import { formatUnitKey } from '@app/helpers';
 
 export interface SeekerListProps extends ComponentProps {
     seekers: Seeker[];
@@ -22,7 +23,9 @@ export const SeekerList: FunctionComponent<SeekerListProps> = (props: SeekerList
             {seekers.map((seeker, index) => (
                 <div key={index} className="seeker">
                     <img src="/seeker-theirs.png" alt="" />
-                    Unit #{seeker.id.slice(-12)}
+                    {seeker && seeker.name?.value
+                        ? seeker.name.value
+                        : `Unit ${formatUnitKey(seeker?.key.toString() || '')}`}
                 </div>
             ))}
         </StyledSeekerList>


### PR DESCRIPTION
## what

* adds NAME_OWNED_ENTITY action that lets you name any node id that you are an owner of
* adds a hacky little easter egg for naming your Unit (double click the unit id in the selected unit panel top right)
* (hackily) resolves: https://github.com/playmint/ds/issues/351

![Screenshot 2023-06-27 at 16 19 47](https://github.com/playmint/ds/assets/45921/2253a115-7d4e-4429-8862-687f6386f60b)
