### PR TITLE
Remove move cursor

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/Intent/MoveIntent.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Intent/MoveIntent.cs
@@ -124,26 +124,6 @@ public class MoveIntent : IntentHandler
         return validPath;
     }
 
-    private void Update()
-    {
-        if (
-            GameStateMediator.Instance.gameState == null
-            || GameStateMediator.Instance.gameState.World == null
-        )
-            return;
-
-        if (
-            spawnedValidCellHighlights.ContainsKey(
-                GridExtensions.GridToCube(MapInteractionManager.CurrentMouseCell)
-            )
-        )
-        {
-            CursorController.ShowMoveCursor();
-        }
-        else
-            CursorController.ShowDefaultCursor();
-    }
-
     private void OnTileLeftClick(Vector3Int cellCubePos)
     {
         if (!isMoving)


### PR DESCRIPTION
Yep... that's what it does.

Previously when you hover over a tile, the cursor swaps to a cross arrow image to indicate that you're hovering over a valid tile. Now the cursor remains as the default pointer.