### PR TITLE
Seeker button is disabled during the spawn dispatch

### DIFF
--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -63,7 +63,7 @@ export function makeAvailablePlugins(client: Source<CogServices>) {
  * when a plugin attempts to call dispatch but there is no connected player to
  * dispatch for.
  */
-function noopDispatcher(...actions: CogAction[]) {
+async function noopDispatcher(...actions: CogAction[]) {
     console.warn('dispatch failed: attempt to dispatch without a connected player', actions);
 }
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -302,7 +302,7 @@ export interface PluginState {
 
 export type PluginSubmitProxy = (ref: string, values: PluginSubmitCallValues) => Promise<void>;
 
-export type DispatchFunc = (...actions: CogAction[]) => void;
+export type DispatchFunc = (...actions: CogAction[]) => Promise<void>;
 
 export type AvailablePlugin = AvailablePluginFragment;
 export type AvailableBuildingKind = BuildingKindFragment;

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -40,6 +40,7 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
     const { seeker: selectedSeeker, tiles: selectedTiles, selectSeeker } = selection;
     const { openModal, setModalContent, closeModal } = useModalContext();
     const [providerAvailable, setProviderAvailable] = useState<boolean>(false);
+    const [isSpawningSeeker, setIsSpawningSeeker] = useState<boolean>(false);
 
     useEffect(() => {
         const detectProvider = detectEthereumProvider();
@@ -71,8 +72,16 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
             return;
         }
         const id = CompoundKeyEncoder.encodeUint160(NodeSelectors.Seeker, BigInt(Math.floor(Math.random() * 10000)));
-        player.dispatch({ name: 'SPAWN_SEEKER', args: [id] });
-    }, [player]);
+        setIsSpawningSeeker(true);
+        player
+            .dispatch({ name: 'SPAWN_SEEKER', args: [id] })
+            .catch((e) => {
+                console.error('failed to spawn seeker:', e);
+            })
+            .finally(() => {
+                setIsSpawningSeeker(false);
+            });
+    }, [player, setIsSpawningSeeker]);
 
     const selectNextSeeker = useCallback(
         (n: number) => {
@@ -176,7 +185,9 @@ export const Shell: FunctionComponent<ShellProps> = (props: ShellProps) => {
                                             You need a mobile unit that will do your bidding out in the world. Would you
                                             like to spawn one now?
                                         </p>
-                                        <button onClick={spawnSeeker}>Spawn Unit</button>
+                                        <button onClick={spawnSeeker} disabled={isSpawningSeeker}>
+                                            Spawn Unit
+                                        </button>
                                     </div>
                                 )}
                             </div>

--- a/frontend/src/components/views/shell/shell.styles.ts
+++ b/frontend/src/components/views/shell/shell.styles.ts
@@ -186,6 +186,10 @@ const baseStyles = (_: Partial<ShellProps>) => css`
             color: #143063;
             padding: 1.2rem 2rem 0.8rem;
             font-weight: 600;
+
+            &:disabled {
+                opacity: 0.5;
+            }
         }
         > p {
             margin: 2rem 0;


### PR DESCRIPTION
## What

![image](https://github.com/playmint/ds/assets/51167118/99d4e641-6467-43ea-a093-e001fa403ec6)

Spawn button disabled whilst dispatch taking place

## Why

To prevent the player from spawning multiple seekers

## How

- Updated the dispatch function return type to be `promise<void>` to reflect the changes to the update function. With the correct type it can be awaited
- Disabling the button during the dispatch and reenabling after the promise either fulfils or errors

## Problems

There is a moment where the promise is fulfilled and the button renabled before the newly spawned seeker has been fetched which leaves a window of opportunity to press it again. The dispatch errors are being caught by core so I can't renable solely on error and as the dispatch returns void, I don't know if the dispatch was a success or not. A work around could be just to not renable the button at all after the dispatch but if there was an error then the player would have to reload the game. 