### PR TITLE
Hide story buildings and enemies from construction list

### DIFF
--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -700,7 +700,7 @@ contract GameDeployer is Script {
             })
         );
 
-        BuildingUtils.construct(ds, theUltimateGoal, "building", -1, 2, -1);
+        BuildingUtils.construct(ds, theUltimateGoal, "story-building", -1, 2, -1);
     }
 
     function _badmintonGear(Game ds, bytes24 goldCoin) private {

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -309,6 +309,13 @@ const Construct: FunctionComponent<ConstructProps> = ({ selectedTiles, seeker, p
         ? 'Select the type of building you&apos;d like to construct'
         : 'Choose an adjacent tile to build on';
 
+    // temp excluding of any building annotated with a non-building model this
+    // is only expected to be used during Blueprint to exlcuding "story
+    // buildings" or until we have a nicer solution to avoiding a giant list
+    const constructableKinds = availableKinds.filter(
+        (kind) => !kind.model || !kind.model.value || kind.model.value === 'building'
+    );
+
     return (
         <StyledActionContextPanel className="action">
             <h3>Constructing</h3>
@@ -322,7 +329,7 @@ const Construct: FunctionComponent<ConstructProps> = ({ selectedTiles, seeker, p
                         onChange={onChangeSelectedKind}
                         value={selectedKind?.id}
                     >
-                        {availableKinds.map((k) => (
+                        {constructableKinds.map((k) => (
                             <option key={k.id} value={k.id}>
                                 {k.name?.value || '<unnamed>'}
                             </option>


### PR DESCRIPTION
### what

hide any BuildingKinds from the construction list that have a "model" annotation that is not "building".

this allows paul to annotate any buildings he doesn't want visible in the list as "story-building" or something like that.

this is a temporary patch for Blueprint or until we have a proper solution for the constructable list

resolves: #302 

### example

This god mode `construct` call will cause `theUltimateGoal` building kind to be hidden from construct list

```
        BuildingUtils.construct(ds, theUltimateGoal, "story-building", -1, 2, -1);
```

So would this:

```
        BuildingUtils.construct(ds, theUltimateGoal, "enemy", -1, 2, -1);
```

This would keep it visible for all in the list

```
        BuildingUtils.construct(ds, theUltimateGoal, "building", -1, 2, -1);
```