### PR TITLE
disallow non-stackable items as construction materials

### DIFF
--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -107,11 +107,8 @@ contract BuildingRule is Rule {
                 require(state.getOwner(materialItem[i]) != 0x0, "input item must be registered before use in recipe");
                 // get atomic structure
                 (uint32[3] memory inputAtoms, bool inputStackable) = state.getItemStructure(materialItem[i]);
-                if (inputStackable) {
-                    require(materialQty[i] > 0 && materialQty[i] <= 100, "stackable input item must be qty 0-100");
-                } else {
-                    require(materialQty[i] == 1, "equipable input item must have qty=1");
-                }
+                require(inputStackable, "non-stackable items not allowed as construction materials");
+                require(materialQty[i] > 0 && materialQty[i] <= 100, "stackable input item must be qty 0-100");
                 availableInputAtoms[0] = availableInputAtoms[0] + (inputAtoms[0] * uint32(materialQty[i]));
                 availableInputAtoms[1] = availableInputAtoms[1] + (inputAtoms[1] * uint32(materialQty[i]));
                 availableInputAtoms[2] = availableInputAtoms[2] + (inputAtoms[2] * uint32(materialQty[i]));

--- a/contracts/test/rules/BuildingRule.t.sol
+++ b/contracts/test/rules/BuildingRule.t.sol
@@ -118,6 +118,20 @@ contract BuildingRuleTest is Test {
         vm.stopPrank();
     }
 
+    function testConstructFailStackableMaterial() public {
+        vm.startPrank(aliceAccount);
+        // register building with a a non-stackable construction material
+        uint64[4] memory qtys;
+        qtys[0] = 1;
+        bytes24[4] memory materials;
+        materials[0] = Node.Item("non-stackable-ball", [uint32(20), uint32(20), uint32(20)], false);
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (materials[0], "non-stackable-ball", "00-00")));
+        bytes24 buildingKind = Node.BuildingKind(25);
+        vm.expectRevert("non-stackable items not allowed as construction materials");
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_BUILDING_KIND, (buildingKind, "hut", materials, qtys)));
+        vm.stopPrank();
+    }
+
     function testConstructFailSeekerTooFarAway() public {
         _testConstructFailNotAdjacent(2, -2, 0);
     }


### PR DESCRIPTION
we dont have good support for distributing non-stackable materials during combat so for now we are disallowing their use in construction materials to simply things

* resolves: #354 