### PR TITLE
Bags show up on defeated tiles if the player has a reward

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/Environment/MapManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Environment/MapManager.cs
@@ -145,8 +145,9 @@ public class MapManager : MonoBehaviour
         {
             var hasResource = TileHelper.HasResource(tile);
             var cellPosCube = TileHelper.GetTilePosCube(tile);
+            var hasReward = TileHelper.HasReward(tile, state.Player.Seekers);
 
-            if (hasResource)
+            if (hasResource || hasReward)
                 MapElementManager.instance.CreateBag(cellPosCube);
             else
                 MapElementManager.instance.CheckBagIconRemoved(cellPosCube);


### PR DESCRIPTION
## What
![image](https://github.com/playmint/ds/assets/51167118/f341385f-7b65-4eec-8862-66d7f6e50ab8)

Showing a bag on a combat tile if there are rewards belonging to the player


## How

We check if the tile has a session and if the player has any rewards associated with that session. 

## Issues

Known issue is that we don't know without calculating the full combat state which side won so for now I'm going to assume that if there are rewards that it would have been the defenders that had lost. Bags belong to the session not the tile so in reality the bag could be shown on either tile