### PR TITLE
MapElements now stick to tile (including spawned bags)

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/Environment/MapManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Environment/MapManager.cs
@@ -59,7 +59,7 @@ public class MapManager : MonoBehaviour
         }
     }
 
-    public void AddTile(Vector3Int cellCubicCoords, Tiles2 tile)
+    public TileController AddTile(Vector3Int cellCubicCoords, Tiles2 tile)
     {
         if (!IsTileAtPosition(cellCubicCoords))
         {
@@ -76,6 +76,8 @@ public class MapManager : MonoBehaviour
                 tc.AppearFull();
             else
                 tc.Appear();
+
+            return tc;
         }
         else
         {
@@ -87,9 +89,11 @@ public class MapManager : MonoBehaviour
                 {
                     TileController tileController = tileGO.GetComponent<TileController>();
                     tileController.AppearFull();
+                    return tileController;
                 }
             }
         }
+        return null;
     }
 
     public bool IsDiscoveredTile(Vector3Int cellPosCube)
@@ -147,20 +151,22 @@ public class MapManager : MonoBehaviour
             var cellPosCube = TileHelper.GetTilePosCube(tile);
             var hasReward = TileHelper.HasReward(tile, state.Player.Seekers);
 
+            Transform tileTransform = AddTile(cellPosCube, tile)?.transform;
+
             if (hasResource || hasReward)
-                MapElementManager.instance.CreateBag(cellPosCube);
+                MapElementManager.instance.CreateBag(cellPosCube, tileTransform);
             else
                 MapElementManager.instance.CheckBagIconRemoved(cellPosCube);
 
             if (TileHelper.HasEnemy(tile))
-                MapElementManager.instance.CreateEnemy(cellPosCube);
+                MapElementManager.instance.CreateEnemy(cellPosCube, tileTransform);
             else if (tile.Building != null)
             {
-                MapElementManager.instance.CreateBuilding(cellPosCube);
+                MapElementManager.instance.CreateBuilding(cellPosCube, tileTransform);
                 MapElementManager.instance.CheckIncompleteBuildingIconRemoved(cellPosCube);
             }
             else if (incompleteBuildings.Contains(tile.Id.Substring(10)))
-                MapElementManager.instance.CreateIncompleteBuilding(cellPosCube);
+                MapElementManager.instance.CreateIncompleteBuilding(cellPosCube, tileTransform);
             else
             {
                 MapElementManager.instance.CheckBuildingIconRemoved(cellPosCube);
@@ -168,7 +174,6 @@ public class MapManager : MonoBehaviour
                 MapElementManager.instance.CheckIncompleteBuildingIconRemoved(cellPosCube);
             }
 
-            AddTile(cellPosCube, tile);
             counter++;
             if (counter % tileChunks == 0)
                 yield return null;

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementController.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementController.cs
@@ -16,13 +16,19 @@ public class MapElementController : MonoBehaviour
     protected IconController _icon;
     protected Vector3 _currentPosition;
 
-    public void Setup(Vector3Int cell)
+    public void Setup(Vector3Int cell, Transform parent = null)
     {
         Vector3 pos = MapManager.instance.grid.CellToWorld(GridExtensions.CubeToGrid(cell));
         float height = MapHeightManager.instance.GetHeightAtPosition(pos);
+        if (parent != null)
+            height = parent.position.y;
         _currentPosition = pos;
         _currentPosition = new Vector3(_currentPosition.x, height, _currentPosition.z);
         transform.position = _currentPosition;
+        if (parent != null)
+        {
+            transform.SetParent(parent, true);
+        }
         if (createIcon)
             _icon = MapElementManager.instance.CreateIcon(iconParent, iconPrefab);
     }

--- a/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/GameplayElements/MapElementManager.cs
@@ -26,47 +26,47 @@ public class MapElementManager : MonoBehaviour
         instance = this;
     }
 
-    public void CreateBuilding(Vector3Int cubicCoords)
+    public void CreateBuilding(Vector3Int cubicCoords, Transform tileTransform)
     {
         if (!_spawnedBuildings.ContainsKey(cubicCoords))
         {
             MapElementController building = Instantiate(buildingPrefab, transform, true)
                 .GetComponent<MapElementController>();
             _spawnedBuildings.Add(cubicCoords, building);
-            building.Setup(cubicCoords);
+            building.Setup(cubicCoords, tileTransform);
         }
     }
 
-    public void CreateIncompleteBuilding(Vector3Int cubicCoords)
+    public void CreateIncompleteBuilding(Vector3Int cubicCoords, Transform tileTransform)
     {
         if (!_spawnedIncompleteBuildings.ContainsKey(cubicCoords))
         {
             MapElementController building = Instantiate(incompleteBuildingPrefab, transform, true)
                 .GetComponent<MapElementController>();
             _spawnedIncompleteBuildings.Add(cubicCoords, building);
-            building.Setup(cubicCoords);
+            building.Setup(cubicCoords, tileTransform);
         }
     }
 
-    public void CreateEnemy(Vector3Int cubicCoords)
+    public void CreateEnemy(Vector3Int cubicCoords, Transform tileTransform)
     {
         if (!_spawnedEnemies.ContainsKey(cubicCoords))
         {
             MapElementController enemy = Instantiate(enemyPrefab, transform, true)
                 .GetComponent<MapElementController>();
             _spawnedEnemies.Add(cubicCoords, enemy);
-            enemy.Setup(cubicCoords);
+            enemy.Setup(cubicCoords, tileTransform);
         }
     }
 
-    public void CreateBag(Vector3Int cubicCoords)
+    public void CreateBag(Vector3Int cubicCoords, Transform tileTransform)
     {
         if (!_spawnedBags.ContainsKey(cubicCoords))
         {
             MapElementController bag = Instantiate(bagPrefab, transform, true)
                 .GetComponent<MapElementController>();
             _spawnedBags.Add(cubicCoords, bag);
-            bag.Setup(cubicCoords);
+            bag.Setup(cubicCoords, tileTransform);
         }
     }
 


### PR DESCRIPTION
This PR makes all map elements stick to the tiles that they're on so that they move with the tile animation.
So all buildings, enemies, etc will bounce in when the map first loads up.
Discovered bags will bounce in with their revealed tiles.