### PR TITLE
Docs graphql link text fix - creating-new-items

### DIFF
--- a/docs/how-to-create-docs/creating-new-items.md
+++ b/docs/how-to-create-docs/creating-new-items.md
@@ -34,7 +34,7 @@ As a general rule, stackable items are “resources” whilst equipable items ar
 
 ## Item IDs
 
-When you set the crafting items you need to reference their IDs. The easiest way to find these is to go to [https://services-ds-main.dev.playmint.com/](https://services-ds-test.dev.playmint.com/) and run this query: 
+When you set the crafting items you need to reference their IDs. The easiest way to find these is to go to [https://services-ds-test.dev.playmint.com/](https://services-ds-test.dev.playmint.com/) and run this query: 
 
 ```jsx
 {


### PR DESCRIPTION
graphql browser link had wrong text - now updated to use https://services-ds-test.dev.playmint.com/ as text so it matches the link