### PR TITLE
fudge: give the plugin sandbox more memory

### DIFF
--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -282,7 +282,7 @@ export function loadPlugin(
 
     // const qjs = await getQuickJS();
     // const runtime = qjs.newRuntime();
-    runtime.setMemoryLimit(1024 * 640);
+    runtime.setMemoryLimit(1024 * 640 * 10);
     runtime.setMaxStackSize(1024 * 320);
     // Interrupt computation after 1024 calls to the interrupt handler
     // let interruptCycles = 0;


### PR DESCRIPTION
we hit the memory limit of the sandbox due to the large size of the state. increasing this number is not a realistic solution long term, but it'll buy us a bit more time while we sort out the state size problem