### PR TITLE
Added chance of spawning multiple resources on one tile

### DIFF
--- a/contracts/src/rules/ScoutRule.sol
+++ b/contracts/src/rules/ScoutRule.sol
@@ -56,10 +56,21 @@ contract ScoutRule is Rule {
 
     function _tempSpawnResourceBag(State state, bytes24 targetTile, int16[3] memory coords) private {
         uint64 bagID = uint64(uint256(keccak256(abi.encode(coords))));
+        uint8 itemSlot = 0;
         if (uint8(bagID) < 128) {
             bytes24 bag = Node.Bag(bagID);
+            state.setItemSlot(bag, itemSlot, _tempRandomResource(), 100);
 
-            state.setItemSlot(bag, 0, _tempRandomResource(), 100);
+            if (uint8(bagID >> 8) < 128) {
+                itemSlot++;
+                state.setItemSlot(bag, itemSlot, _tempRandomResource(), 100);
+            }
+
+            if (uint8(bagID >> 16) < 64) {
+                itemSlot++;
+                state.setItemSlot(bag, itemSlot, _tempRandomResource(), 100);
+            }
+
             state.setEquipSlot(targetTile, 0, bag);
         }
     }


### PR DESCRIPTION
## What

I have added two extra rolls to spawn resources on a tile. There is a 50% chance of spawning the next resource and then a 25% chance of spawning yet another. 

<img width="493" alt="image" src="https://github.com/playmint/ds/assets/51167118/7f832d58-7012-4760-b7de-3fa99d13f937">

Seperate rolls as in the 2nd roll happens even if the 1st was unsuccessful.

## Why

To speed up progression in the game by having more resources on the map