### PR TITLE
Outline appears over UI

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
+++ b/DawnSeekersUnity/Assets/Map/Scenes/MapScene.unity
@@ -942,9 +942,9 @@ Canvas:
   m_GameObject: {fileID: 527441469}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 0
+  m_RenderMode: 1
   m_Camera: {fileID: 1911231969}
-  m_PlaneDistance: 100
+  m_PlaneDistance: 1
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
   m_OverrideSorting: 0


### PR DESCRIPTION
This PR fixes the issue which caused the Mobile Unit outline to appear over the shield UI icons.