### PR TITLE
prevent map capturing all keyboard events

### DIFF
--- a/DawnSeekersUnity/Assets/Map/Scripts/Environment/MapManager.cs
+++ b/DawnSeekersUnity/Assets/Map/Scripts/Environment/MapManager.cs
@@ -34,6 +34,10 @@ public class MapManager : MonoBehaviour
 
     private void Awake()
     {
+#if !UNITY_EDITOR && UNITY_WEBGL
+        // disable WebGLInput.captureAllKeyboardInput so elements in web page can handle keyboard inputs
+        WebGLInput.captureAllKeyboardInput = false;
+#endif
         dynamicMatProps = new MaterialPropertyBlock();
         unscoutedMatProps = new MaterialPropertyBlock();
         normalMatProps = new MaterialPropertyBlock();


### PR DESCRIPTION
we want to be able to use keyboard events from the shell (browser) so stop capturing them all into the map

note: this will impact the current implementation of panning camera with arrows/WASD, we will fix with future work to either trigger events from shell or proxy events through

fixes: #424 

