### PR TITLE
Added @downstream to the reference list

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -34,6 +34,7 @@
       "@app/*": [
         "*"
       ],
+      "@downstream/*": ["../../*"],
       "*": ["../node_modules/*"]
     },
     "skipLibCheck": true,
@@ -51,9 +52,5 @@
   ],
   "exclude": [
     "node_modules"
-  ],
-  "references": [
-      { "path": "../core" }
   ]
-
 }


### PR DESCRIPTION
## What

Added `@downstream` to the reference list in `tsconfig.json`

## Why

![image](https://github.com/playmint/ds/assets/51167118/6423f3cf-d94c-4b0b-a9e8-ca8a4f5cc209)

Without the reference listed in `tsconfig.json` vsCode was unable to figure out references to anything imported from `@downstream/core` therefore static analysis wasn't working and we were getting a lot of objects typed to `any` which would then throw up a lot of errors in the code window