### PR TITLE
drop up to the stack limit onto partial stacks

### DIFF
--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -56,7 +56,7 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
 
     const isPickable = !isPickedUpItemVisible;
 
-    const [_stackable, greenGoo, blueGoo, redGoo] = [...itemId]
+    const [stackable, greenGoo, blueGoo, redGoo] = [...itemId]
         .slice(2)
         .reduce((bs, b, idx) => {
             if (idx % 8 === 0) {
@@ -68,7 +68,7 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
         .map((n: string) => BigInt(n))
         .slice(-4);
 
-    const isStackable = !!_stackable;
+    const isStackable = !!stackable;
 
     const tooltip = isInvalid
         ? `Slot contains invalid ${name} item\n\nRemove item from slot to continue`

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -89,12 +89,30 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
         handleDrop(quantity);
     };
 
-    // if we have a picked up item in hand and the slot is empty
-    // and if there is a placeholder make sure the placeholder matches
-    const isDroppable =
+    const [isStackableItem] = item
+        ? [...item.itemId]
+              .slice(2)
+              .reduce((bs, b, idx) => {
+                  if (idx % 8 === 0) {
+                      bs.push('0x');
+                  }
+                  bs[bs.length - 1] += b;
+                  return bs;
+              }, [] as string[])
+              .map((n: string) => BigInt(n))
+              .slice(-4)
+        : [false];
+
+    const isCompatiblePlaceholder =
+        pickedUpItem && ((placeholder && placeholder.item.id === pickedUpItem.transferInfo.itemId) || !placeholder);
+    const isStackableSlot =
         pickedUpItem &&
-        !item &&
-        ((placeholder && placeholder.item.id === pickedUpItem.transferInfo.itemId) || !placeholder);
+        item &&
+        pickedUpItem.transferInfo.itemId == item.itemId &&
+        (isStackableItem ? itemSlotBalance < 100 : itemSlotBalance == 0);
+
+    // if we have a picked up item in hand and the slot is compatible/stackable
+    const isDroppable = pickedUpItem && ((!item && isCompatiblePlaceholder) || (item && isStackableSlot));
 
     // it's possible for a slot to contain an item that doesn't match the slot's
     // recipe/placeholder, try to detect this invalid state

--- a/frontend/src/plugins/inventory/inventory-provider.tsx
+++ b/frontend/src/plugins/inventory/inventory-provider.tsx
@@ -120,8 +120,22 @@ export const InventoryProvider = ({ children }: InventoryContextProviderProps): 
         // don't attempt to drop more than we are holding
         transferQuantity = Math.min(transferQuantity, pickedUpItemRef.current.quantity);
 
+        // don't attempt to drop more than a slot can hold
+        transferQuantity =
+            targetCurrentBalance + transferQuantity >= 100 ? 100 - targetCurrentBalance : transferQuantity;
+
+        const source = pickedUpItemRef.current.transferInfo;
+        if (source.id == target.id && source.equipIndex == target.equipIndex && source.slotKey == target.slotKey) {
+            clearPickedUpItem();
+            return;
+        }
+
+        if (transferQuantity == 0) {
+            return;
+        }
+
         transferItem(
-            pickedUpItemRef.current.transferInfo,
+            source,
             {
                 id: target.id,
                 equipIndex: target.equipIndex,


### PR DESCRIPTION
* dropping a stack of 100 onto a slot containing 50 of the same item will now drop 50 into the slot and leave you with 50 in your hand.
* highlights for where you can drop reflect being able to drop onto partial stacks.
* skips attempting transfer to same slot or when qty==0
* resolves: #384 