### PR TITLE
add priorityClassName to deployment pods

### DIFF
--- a/.github/workflows/build-exp.yml
+++ b/.github/workflows/build-exp.yml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       DEPLOYMENT_ENVIRONMENT: exp
+      DEPLOYMENT_PRIORITY: default
       FRONTEND_IMAGE_NAME: playmint/ds-shell
       CONTRACTS_IMAGE_NAME: playmint/ds-contracts
       SERVICES_IMAGE_NAME: playmint/ds-services

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       DEPLOYMENT_ENVIRONMENT: main
+      DEPLOYMENT_PRIORITY: default
       FRONTEND_IMAGE_NAME: playmint/ds-shell
       CONTRACTS_IMAGE_NAME: playmint/ds-contracts
       SERVICES_IMAGE_NAME: playmint/ds-services

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       DEPLOYMENT_ENVIRONMENT: test
+      DEPLOYMENT_PRIORITY: production
       FRONTEND_IMAGE_NAME: playmint/ds-shell
       CONTRACTS_IMAGE_NAME: playmint/ds-contracts
       SERVICES_IMAGE_NAME: playmint/ds-services

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,10 @@ on:
         description: Name of environment main/prod/test to deploy to
         required: true
         type: string
+      DEPLOYMENT_PRIORITY:
+        description: priorityClassName for pods
+        required: true
+        type: string
       FRONTEND_REPLICAS:
         description: Number of instances of frontend server
         default: 1
@@ -312,6 +316,7 @@ jobs:
           cluster:
             domain: dev.playmint.com
           version: ${{ github.sha }}
+          priorityClassName: ${{ inputs.DEPLOYMENT_PRIORITY }}
       run: |
         echo "${CHART_VALUES}" > /tmp/values.yaml
         helm upgrade --timeout "30m" --history-max 5 --install --wait ${CHART_NAMESPACE} ./chart --values /tmp/values.yaml --create-namespace -n "${CHART_NAMESPACE}"

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         gitsha: {{ $.Values.version | quote }}
     spec:
+      priorityClassName: {{ $.Values.priorityClassName | quote }}
       containers:
         - name: services
           image: {{ printf "ghcr.io/playmint/ds-services:%s-%s" $.Release.Name $.Values.version }}
@@ -127,6 +128,7 @@ spec:
       annotations:
         gitsha: {{ $.Values.version | quote }}
     spec:
+      priorityClassName: {{ $.Values.priorityClassName | quote }}
       containers:
         - name: frontend
           image: {{ printf "ghcr.io/playmint/ds-shell:%s-%s" $.Release.Name $.Values.version }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,5 @@
 version: dev
+priorityClassName: default
 cluster:
   domain: dev.playmint.com
 


### PR DESCRIPTION
#### what

deploy the production-like environment with the "production" priority class and the others with the "default" class

#### why 
to give higher priority to the production deployments when the cluster is under resource pressure and feeling a little bit evicty ... meaning that it will prefer to kill the ds-main or ds-exp deployment than the ds-test deployment