### PR TITLE
New BagRule introduced

### DIFF
--- a/contracts/src/Game.sol
+++ b/contracts/src/Game.sol
@@ -21,6 +21,7 @@ import {PluginRule} from "@ds/rules/PluginRule.sol";
 import {NewPlayerRule} from "@ds/rules/NewPlayerRule.sol";
 import {CombatRule} from "@ds/rules/CombatRule.sol";
 import {NamingRule} from "@ds/rules/NamingRule.sol";
+import {BagRule} from "@ds/rules/BagRule.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 
 using Schema for StateGraph;
@@ -113,6 +114,7 @@ contract Game is BaseGame {
         dispatcher.registerRule(playerRule);
         dispatcher.registerRule(new CombatRule());
         dispatcher.registerRule(new NamingRule());
+        dispatcher.registerRule(new BagRule());
         dispatcher.registerRouter(router);
 
         // update the game with this config

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -97,6 +97,12 @@ interface Actions {
 
     function NAME_OWNED_ENTITY(bytes24 entity, string calldata name) external;
 
+    function TRANSFER_BAG_OWNERSHIP(bytes24 bag, bytes24 toEntity) external;
+
+    function TRANSFER_BAG(bytes24 bag, bytes24 fromEntity, bytes24 toEntity) external;
+
+    function SPAWN_EMPTY_BAG(bytes24 equipee) external;
+
     // [dev/debug only] set a tile biome at any location
     function DEV_SPAWN_TILE(BiomeKind kind, int16 q, int16 r, int16 s) external;
 

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -99,9 +99,9 @@ interface Actions {
 
     function TRANSFER_BAG_OWNERSHIP(bytes24 bag, bytes24 toEntity) external;
 
-    function TRANSFER_BAG(bytes24 bag, bytes24 fromEntity, bytes24 toEntity) external;
+    function TRANSFER_BAG(bytes24 bag, bytes24 fromEntity, bytes24 toEntity, uint8 toEquipSlot) external;
 
-    function SPAWN_EMPTY_BAG(bytes24 equipee) external;
+    function SPAWN_EMPTY_BAG(bytes24 equipee, uint8 equipSlot) external;
 
     // [dev/debug only] set a tile biome at any location
     function DEV_SPAWN_TILE(BiomeKind kind, int16 q, int16 r, int16 s) external;

--- a/contracts/src/rules/BagRule.sol
+++ b/contracts/src/rules/BagRule.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {State} from "cog/State.sol";
+import {Context, Rule} from "cog/Dispatcher.sol";
+
+import {Schema, Node, BiomeKind, Kind} from "@ds/schema/Schema.sol";
+import {TileUtils} from "@ds/utils/TileUtils.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BagUtils} from "@ds/utils/BagUtils.sol";
+
+using Schema for State;
+
+uint8 constant MAX_EQUIP_SLOT_INDEX = 254; // There appears to be a problem with state.getEquipSlot if used with 255
+
+contract BagRule is Rule {
+    function reduce(State state, bytes calldata action, Context calldata ctx) public returns (State) {
+        if (bytes4(action) == Actions.SPAWN_EMPTY_BAG.selector) {
+            // decode the action
+            (bytes24 equipee) = abi.decode(action[4:], (bytes24));
+
+            _spawnEmptyBag(state, ctx.sender, ctx.clock, equipee);
+        }
+
+        if (bytes4(action) == Actions.TRANSFER_BAG_OWNERSHIP.selector) {
+            // decode the action
+            (bytes24 bag, bytes24 toEntity) = abi.decode(action[4:], (bytes24, bytes24));
+
+            _transferBagOwnership(state, ctx.sender, bag, toEntity);
+        }
+
+        if (bytes4(action) == Actions.TRANSFER_BAG.selector) {
+            // decode the action
+            (bytes24 bag, bytes24 fromEntity, bytes24 toEntity) = abi.decode(action[4:], (bytes24, bytes24, bytes24));
+
+            _transferBag(state, ctx, bag, fromEntity, toEntity);
+        }
+
+        return state;
+    }
+
+    function _spawnEmptyBag(State state, address sender, uint32 clock, bytes24 equipee) private {
+        require(
+            _isSenderOwnerOfEntity(state, sender, equipee),
+            "BagRule::spawnEmptyBag: Owner of equipee doesn't match sender of action"
+        );
+
+        bytes24 bag;
+        uint256 inc;
+        while (bag == bytes24(0)) {
+            bag = Node.Bag(uint64(uint256(keccak256(abi.encode(sender, equipee, clock, inc)))));
+            if (state.getOwner(bag) != bytes24(0)) {
+                bag = bytes24(0);
+                inc++;
+            }
+        }
+
+        _setOwner(state, bag, equipee);
+
+        (uint8 equipSlot, bool slotFound) = _getNextAvailableEquipSlot(state, equipee);
+
+        require(slotFound, "BagRule::spawnEmptyBag: No more available slots on equipee");
+
+        state.setEquipSlot(equipee, equipSlot, bag);
+    }
+
+    function _transferBagOwnership(State state, address sender, bytes24 bag, bytes24 toEntity) private {
+        _requireSenderIsOwner(state, sender, bag);
+
+        _setOwner(state, bag, toEntity);
+    }
+
+    function _setOwner(State state, bytes24 bag, bytes24 owner) private {
+        // Building kinds are directly set as owners whereas with MobileUnits we use the Unit's owner which is a Player
+        if (bytes4(owner) == Kind.Building.selector) {
+            state.setOwner(bag, owner);
+        } else {
+            state.setOwner(bag, state.getOwner(owner));
+        }
+    }
+
+    function _transferBag(State state, Context calldata ctx, bytes24 bag, bytes24 fromEntity, bytes24 toEntity)
+        private
+    {
+        (uint8 equipSlot, bool found) = _getEquipSlotForEquipment(state, fromEntity, bag);
+        require(found, "BagRule::_transferBag: Bag is neither equipped to entity or owned by the entity");
+
+        _transferBagAtSlot(state, ctx, equipSlot, fromEntity, toEntity);
+    }
+
+    function _transferBagAtSlot(
+        State state,
+        Context calldata ctx,
+        uint8 equipSlot,
+        bytes24 fromEntity,
+        bytes24 toEntity
+    ) private {
+        // Check if entity at equipSlot is a bag
+        bytes24 bag = state.getEquipSlot(fromEntity, equipSlot);
+        require(bytes4(bag) == Kind.Bag.selector, "BagRule::_transferBagAtSlot: Entity at equipSlot not Bag");
+
+        // Allow if either sender is owner of the bag or if sender is owner of the equipee
+        require(
+            _isSenderOwnerOfEntity(state, ctx.sender, bag) || _isSenderOwnerOfEntity(state, ctx.sender, fromEntity),
+            "BagRule::_transferBagAtSlot: Neither sender is owner of the bag or is owner of the equipee"
+        );
+
+        BagUtils.requireSameOrAdjacentLocation(state, fromEntity, toEntity, ctx.clock);
+
+        // Unequip from entity
+        state.setEquipSlot(fromEntity, equipSlot, bytes24(0));
+
+        _equipToNextAvailableSlot(state, toEntity, bag);
+    }
+
+    function _getNextAvailableEquipSlot(State state, bytes24 equipee) private view returns (uint8, bool) {
+        for (uint8 i = 0; i <= MAX_EQUIP_SLOT_INDEX; i++) {
+            bytes24 heldEquipment = state.getEquipSlot(equipee, i);
+            if (heldEquipment == bytes24(0)) {
+                return (i, true);
+            }
+        }
+
+        return (0, false);
+    }
+
+    function _equipToNextAvailableSlot(State state, bytes24 equipee, bytes24 equipment) private returns (uint8) {
+        (uint8 equipSlot, bool slotFound) = _getNextAvailableEquipSlot(state, equipee);
+        require(slotFound, "BagRule::_equipToNextAvailableSlot: No more available slots on equipee");
+
+        state.setEquipSlot(equipee, equipSlot, equipment);
+
+        return equipSlot;
+    }
+
+    function _getEquipSlotForEquipment(State state, bytes24 equipee, bytes24 equipment)
+        private
+        view
+        returns (uint8 equipSlot, bool found)
+    {
+        for (uint8 i = 0; i <= MAX_EQUIP_SLOT_INDEX; i++) {
+            if (state.getEquipSlot(equipee, i) == equipment) {
+                return (i, true);
+            }
+        }
+
+        return (0, false);
+    }
+
+    // TODO: We can probably get rid of this and just use _isSenderOwnerOfEntity. I found it handy during debugging
+    //       as I could see where in the validation it was failing
+    function _requireSenderIsOwner(State state, address sender, bytes24 entity) private view {
+        // The mess here is that if we are checking what owns a buildingInstance, we say it owns itself
+        bytes24 owner = bytes4(entity) == Kind.Building.selector ? entity : state.getOwner(entity);
+
+        // If the owner is a building instance then verify that the sender matches the implementation of the building kind
+        if (bytes4(owner) == Kind.Building.selector) {
+            bytes24 buildingKind = state.getBuildingKind(owner);
+            require(buildingKind != 0x0, "BagRule::_requireSenderIsOwner: no building kind for building id");
+
+            // check sender is the contract that implements the building kind
+            address implementation = state.getImplementation(buildingKind);
+            require(implementation != address(0), "BagRule::_requireSenderIsOwner: no implementation for building kind");
+            require(
+                sender == implementation, "BagRule::_requireSenderIsOwner: sender must be BuildingKind implementation"
+            );
+        } else {
+            // If owner isn't a building then assume it is a player
+            require(
+                Node.Player(sender) == owner, "BagRule::_requireSenderIsOwner: sender isn't the owner of the entity"
+            );
+        }
+    }
+
+    function _isSenderOwnerOfEntity(State state, address sender, bytes24 entity) private view returns (bool) {
+        // The mess here is that if we are checking what owns a buildingInstance, we say it owns itself
+        bytes24 owner = bytes4(entity) == Kind.Building.selector ? entity : state.getOwner(entity);
+
+        // If the owner is a building instance then verify that the sender matches the implementation of the building kind
+        if (bytes4(owner) == Kind.Building.selector) {
+            bytes24 buildingKind = state.getBuildingKind(owner);
+            if (buildingKind == 0x0) return false;
+            // check sender is the contract that implements the building kind
+            address implementation = state.getImplementation(buildingKind);
+            if (implementation == address(0)) return false;
+            return sender == implementation;
+        } else {
+            // If owner isn't a building then assume it is a player
+            return Node.Player(sender) == owner;
+        }
+    }
+}

--- a/contracts/src/rules/BagRule.sol
+++ b/contracts/src/rules/BagRule.sol
@@ -17,9 +17,9 @@ contract BagRule is Rule {
     function reduce(State state, bytes calldata action, Context calldata ctx) public returns (State) {
         if (bytes4(action) == Actions.SPAWN_EMPTY_BAG.selector) {
             // decode the action
-            (bytes24 equipee) = abi.decode(action[4:], (bytes24));
+            (bytes24 equipee, uint8 equipSlot) = abi.decode(action[4:], (bytes24, uint8));
 
-            _spawnEmptyBag(state, ctx.sender, ctx.clock, equipee);
+            _spawnEmptyBag(state, ctx.sender, ctx.clock, equipee, equipSlot);
         }
 
         if (bytes4(action) == Actions.TRANSFER_BAG_OWNERSHIP.selector) {
@@ -31,19 +31,17 @@ contract BagRule is Rule {
 
         if (bytes4(action) == Actions.TRANSFER_BAG.selector) {
             // decode the action
-            (bytes24 bag, bytes24 fromEntity, bytes24 toEntity) = abi.decode(action[4:], (bytes24, bytes24, bytes24));
+            (bytes24 bag, bytes24 fromEntity, bytes24 toEntity, uint8 toEquipSlot) =
+                abi.decode(action[4:], (bytes24, bytes24, bytes24, uint8));
 
-            _transferBag(state, ctx, bag, fromEntity, toEntity);
+            _transferBag(state, ctx, bag, fromEntity, toEntity, toEquipSlot);
         }
 
         return state;
     }
 
-    function _spawnEmptyBag(State state, address sender, uint32 clock, bytes24 equipee) private {
-        require(
-            _isSenderOwnerOfEntity(state, sender, equipee),
-            "BagRule::spawnEmptyBag: Owner of equipee doesn't match sender of action"
-        );
+    function _spawnEmptyBag(State state, address sender, uint32 clock, bytes24 equipee, uint8 equipSlot) private {
+        require(_isSenderOwnerOfEntity(state, sender, equipee), "Owner of equipee doesn't match sender of action");
 
         bytes24 bag;
         uint256 inc;
@@ -56,81 +54,77 @@ contract BagRule is Rule {
         }
 
         _setOwner(state, bag, equipee);
-
-        (uint8 equipSlot, bool slotFound) = _getNextAvailableEquipSlot(state, equipee);
-
-        require(slotFound, "BagRule::spawnEmptyBag: No more available slots on equipee");
+        _equipToEntity(state, equipee, equipSlot, bag);
 
         state.setEquipSlot(equipee, equipSlot, bag);
     }
 
     function _transferBagOwnership(State state, address sender, bytes24 bag, bytes24 toEntity) private {
+        require(bytes4(bag) == Kind.Bag.selector, "Entity not a Bag");
+
         _requireSenderIsOwner(state, sender, bag);
 
         _setOwner(state, bag, toEntity);
     }
 
-    function _setOwner(State state, bytes24 bag, bytes24 owner) private {
-        // Building kinds are directly set as owners whereas with MobileUnits we use the Unit's owner which is a Player
-        if (bytes4(owner) == Kind.Building.selector) {
-            state.setOwner(bag, owner);
+    function _setOwner(State state, bytes24 bag, bytes24 entity) private {
+        if (entity == bytes24(0)) {
+            // Public (non owned) bags
+            state.setOwner(bag, entity);
+        } else if (bytes4(entity) == Kind.Building.selector) {
+            // Building kinds are directly set as owners
+            state.setOwner(bag, entity);
         } else {
-            state.setOwner(bag, state.getOwner(owner));
+            // Default is to set the owner to the same as the owner of the entity. This is applicable to MobileUnits
+            state.setOwner(bag, state.getOwner(entity));
         }
     }
 
-    function _transferBag(State state, Context calldata ctx, bytes24 bag, bytes24 fromEntity, bytes24 toEntity)
-        private
-    {
-        (uint8 equipSlot, bool found) = _getEquipSlotForEquipment(state, fromEntity, bag);
-        require(found, "BagRule::_transferBag: Bag is neither equipped to entity or owned by the entity");
+    function _transferBag(
+        State state,
+        Context calldata ctx,
+        bytes24 bag,
+        bytes24 fromEntity,
+        bytes24 toEntity,
+        uint8 toEquipSlot
+    ) private {
+        (uint8 fromEquipSlot, bool found) = _getEquipSlotForEquipment(state, fromEntity, bag);
+        require(found, "Bag is neither equipped to entity or owned by the entity");
 
-        _transferBagAtSlot(state, ctx, equipSlot, fromEntity, toEntity);
+        _transferBagAtSlot(state, ctx, fromEntity, fromEquipSlot, toEntity, toEquipSlot);
     }
 
     function _transferBagAtSlot(
         State state,
         Context calldata ctx,
-        uint8 equipSlot,
         bytes24 fromEntity,
-        bytes24 toEntity
+        uint8 fromEquipSlot,
+        bytes24 toEntity,
+        uint8 toEquipSlot
     ) private {
         // Check if entity at equipSlot is a bag
-        bytes24 bag = state.getEquipSlot(fromEntity, equipSlot);
-        require(bytes4(bag) == Kind.Bag.selector, "BagRule::_transferBagAtSlot: Entity at equipSlot not Bag");
+        bytes24 bag = state.getEquipSlot(fromEntity, fromEquipSlot);
+        require(bytes4(bag) == Kind.Bag.selector, "Entity at equipSlot not Bag");
 
         // Allow if either sender is owner of the bag or if sender is owner of the equipee
         require(
             _isSenderOwnerOfEntity(state, ctx.sender, bag) || _isSenderOwnerOfEntity(state, ctx.sender, fromEntity),
-            "BagRule::_transferBagAtSlot: Neither sender is owner of the bag or is owner of the equipee"
+            "Neither sender is owner of the bag or is owner of the equipee"
         );
 
         BagUtils.requireSameOrAdjacentLocation(state, fromEntity, toEntity, ctx.clock);
 
         // Unequip from entity
-        state.setEquipSlot(fromEntity, equipSlot, bytes24(0));
+        state.setEquipSlot(fromEntity, fromEquipSlot, bytes24(0));
 
-        _equipToNextAvailableSlot(state, toEntity, bag);
+        _equipToEntity(state, toEntity, toEquipSlot, bag);
     }
 
-    function _getNextAvailableEquipSlot(State state, bytes24 equipee) private view returns (uint8, bool) {
-        for (uint8 i = 0; i <= MAX_EQUIP_SLOT_INDEX; i++) {
-            bytes24 heldEquipment = state.getEquipSlot(equipee, i);
-            if (heldEquipment == bytes24(0)) {
-                return (i, true);
-            }
-        }
+    function _equipToEntity(State state, bytes24 toEntity, uint8 toEquipSlot, bytes24 bag) private {
+        bytes24 equippedEntity = state.getEquipSlot(toEntity, toEquipSlot);
+        require(equippedEntity == bytes24(0), "Entity already equipped to destination slot");
 
-        return (0, false);
-    }
-
-    function _equipToNextAvailableSlot(State state, bytes24 equipee, bytes24 equipment) private returns (uint8) {
-        (uint8 equipSlot, bool slotFound) = _getNextAvailableEquipSlot(state, equipee);
-        require(slotFound, "BagRule::_equipToNextAvailableSlot: No more available slots on equipee");
-
-        state.setEquipSlot(equipee, equipSlot, equipment);
-
-        return equipSlot;
+        state.setEquipSlot(toEntity, toEquipSlot, bag);
     }
 
     function _getEquipSlotForEquipment(State state, bytes24 equipee, bytes24 equipment)
@@ -156,19 +150,15 @@ contract BagRule is Rule {
         // If the owner is a building instance then verify that the sender matches the implementation of the building kind
         if (bytes4(owner) == Kind.Building.selector) {
             bytes24 buildingKind = state.getBuildingKind(owner);
-            require(buildingKind != 0x0, "BagRule::_requireSenderIsOwner: no building kind for building id");
+            require(buildingKind != 0x0, "no building kind for building id");
 
             // check sender is the contract that implements the building kind
             address implementation = state.getImplementation(buildingKind);
-            require(implementation != address(0), "BagRule::_requireSenderIsOwner: no implementation for building kind");
-            require(
-                sender == implementation, "BagRule::_requireSenderIsOwner: sender must be BuildingKind implementation"
-            );
+            require(implementation != address(0), "no implementation for building kind");
+            require(sender == implementation, "sender must be BuildingKind implementation");
         } else {
             // If owner isn't a building then assume it is a player
-            require(
-                Node.Player(sender) == owner, "BagRule::_requireSenderIsOwner: sender isn't the owner of the entity"
-            );
+            require(Node.Player(sender) == owner, "sender isn't the owner of the entity");
         }
     }
 

--- a/contracts/test/rules/BagRule.t.sol
+++ b/contracts/test/rules/BagRule.t.sol
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {Game} from "cog/Game.sol";
+import {State, AnnotationKind} from "cog/State.sol";
+import {Dispatcher} from "cog/Dispatcher.sol";
+
+import {Game as Downstream} from "@ds/Game.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {Schema, Node, Rel, LocationKey, Kind, BiomeKind, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
+import {ItemUtils} from "@ds/utils/ItemUtils.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+using Schema for State;
+
+contract BuildingRuleTest is Test {
+    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref, string data);
+
+    Game internal game;
+    Dispatcher internal dispatcher;
+    State internal state;
+
+    // accounts
+    address aliceAccount;
+    address bobAccount;
+    uint64 sid;
+
+    bytes24[4] defaultMaterialItem;
+    uint64[4] defaultMaterialQty;
+
+    bytes24 _buildingInstance;
+    MockBuildingKind _buildingImplementation;
+
+    bytes24 _mobileUnitAlice;
+    bytes24 _mobileUnitBob;
+
+    function setUp() public {
+        // setup users
+        uint256 alicePrivateKey = 0xA11CE;
+        aliceAccount = vm.addr(alicePrivateKey);
+        uint256 bobPrivateKey = 0xB0b;
+        bobAccount = vm.addr(bobPrivateKey);
+
+        // setup allowlist
+        address[] memory allowlist = new address[](2);
+        allowlist[0] = aliceAccount;
+        allowlist[1] = bobAccount;
+
+        // setup game
+        game = new Downstream(allowlist);
+        dispatcher = game.getDispatcher();
+
+        // fetch the State to play with
+        state = game.getState();
+
+        // setup default material construction costs
+        defaultMaterialItem[0] = ItemUtils.GlassGreenGoo();
+        defaultMaterialItem[1] = ItemUtils.BeakerBlueGoo();
+        defaultMaterialItem[2] = ItemUtils.FlaskRedGoo();
+        defaultMaterialQty[0] = 25;
+        defaultMaterialQty[1] = 25;
+        defaultMaterialQty[2] = 25;
+
+        vm.startPrank(aliceAccount);
+        _mobileUnitAlice = _spawnMobileUnitWithResources();
+        vm.stopPrank();
+
+        vm.startPrank(bobAccount);
+        _mobileUnitBob = _spawnMobileUnitWithResources();
+        vm.stopPrank();
+
+        _buildingInstance = _constructBuilding(bobAccount, _mobileUnitBob);
+    }
+
+    function testTransferToAndFromMobileUnits() public {
+        bytes24 bag = state.getEquipSlot(_mobileUnitAlice, 0);
+        assertEq(bytes4(bag), Kind.Bag.selector, "Entity at equip slot 0 isn't a bag");
+
+        // -- Transfer from Alice to Bob
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG, (bag, _mobileUnitAlice, _mobileUnitBob)));
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG_OWNERSHIP, (bag, _mobileUnitBob)));
+        vm.stopPrank();
+
+        assertEq(state.getEquipSlot(_mobileUnitAlice, 0), bytes24(0), "Expected bag not to be equipped to Alice");
+        assertEq(state.getOwner(bag), Node.Player(bobAccount), "Expected the bag to be owned by bobAccount");
+
+        // Mobile units are spawned with two bags at slots 0 and 1. Expecting the transferred bag to be at the next available slot
+        assertEq(state.getEquipSlot(_mobileUnitBob, 2), bag, "Expected bag to be equipped to Bob at slot 2");
+
+        // -- Transfer back to Alice
+
+        vm.startPrank(bobAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG, (bag, _mobileUnitBob, _mobileUnitAlice)));
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG_OWNERSHIP, (bag, _mobileUnitAlice)));
+        vm.stopPrank();
+
+        assertEq(state.getEquipSlot(_mobileUnitBob, 2), bytes24(0), "Expected bag not to be equipped to Bob");
+        assertEq(state.getOwner(bag), Node.Player(aliceAccount), "Expected the bag to be owned by aliceAccount");
+
+        // Bag should end up back at slot 0 for Alice as it was empty
+        assertEq(state.getEquipSlot(_mobileUnitAlice, 0), bag, "Expected bag to be equipped to Alice at slot 0");
+    }
+
+    function testTransferToAndFromBuilding() public {
+        bytes24 bag = state.getEquipSlot(_mobileUnitAlice, 0);
+        assertEq(bytes4(bag), Kind.Bag.selector, "Entity at equip slot 0 isn't a bag");
+
+        // -- Transfer from Alice to building
+
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG, (bag, _mobileUnitAlice, _buildingInstance)));
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG_OWNERSHIP, (bag, _buildingInstance)));
+        vm.stopPrank();
+
+        assertEq(state.getEquipSlot(_mobileUnitAlice, 0), bytes24(0), "Expected bag not to be equipped to Alice");
+        assertEq(state.getOwner(bag), _buildingInstance, "Expected the bag to be owned by _buildingInstance");
+
+        // -- Transfer from building back to Alice
+
+        // Buildings are constructed with two bags at slots 0 and 1. Expecting the transferred bag to be at the next available slot
+        assertEq(state.getEquipSlot(_buildingInstance, 2), bag, "Expected bag to be equipped to Bob at slot 2");
+
+        vm.startPrank(address(_buildingImplementation));
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG, (bag, _buildingInstance, _mobileUnitAlice)));
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG_OWNERSHIP, (bag, _mobileUnitAlice)));
+        vm.stopPrank();
+
+        assertEq(state.getEquipSlot(_buildingInstance, 2), bytes24(0), "Expected bag not to be equipped to building");
+        assertEq(state.getOwner(bag), Node.Player(aliceAccount), "Expected the bag to be owned by aliceAccount");
+
+        // Bag should end up back at slot 0 for Alice as it was empty
+        assertEq(state.getEquipSlot(_mobileUnitAlice, 0), bag, "Expected bag to be equipped to Alice at slot 0");
+    }
+
+    function testUnitEquipeeAllowedToTransfer() public {
+        bytes24 bag = state.getEquipSlot(_mobileUnitAlice, 0);
+        assertEq(bytes4(bag), Kind.Bag.selector, "Entity at equip slot 0 isn't a bag");
+
+        // -- Transfer from Alice to Bob (NOT INCLUDING OWNERSHIP)
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG, (bag, _mobileUnitAlice, _mobileUnitBob)));
+        vm.stopPrank();
+
+        assertEq(state.getEquipSlot(_mobileUnitAlice, 0), bytes24(0), "Expected bag not to be equipped to Alice");
+        assertEq(state.getOwner(bag), Node.Player(aliceAccount), "Expected the bag to be owned by alice");
+
+        // -- Transfer back to Alice
+
+        vm.startPrank(bobAccount);
+        vm.expectRevert();
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG_OWNERSHIP, (bag, _mobileUnitBob)));
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG, (bag, _mobileUnitBob, _mobileUnitAlice)));
+        vm.stopPrank();
+
+        assertEq(state.getEquipSlot(_mobileUnitBob, 2), bytes24(0), "Expected bag not to be equipped to Bob");
+        assertEq(state.getOwner(bag), Node.Player(aliceAccount), "Expected the bag to be owned by aliceAccount");
+        assertEq(state.getEquipSlot(_mobileUnitAlice, 0), bag, "Expected bag to be equipped to Alice at slot 0");
+    }
+
+    function testBuildingEquipeeAllowedToTransfer() public {
+        bytes24 bag = state.getEquipSlot(_mobileUnitAlice, 0);
+        assertEq(bytes4(bag), Kind.Bag.selector, "Entity at equip slot 0 isn't a bag");
+
+        // -- Transfer from Alice to building (NOT INCLUDING OWNERSHIP)
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG, (bag, _mobileUnitAlice, _buildingInstance)));
+        vm.stopPrank();
+
+        assertEq(state.getEquipSlot(_mobileUnitAlice, 0), bytes24(0), "Expected bag not to be equipped to Alice");
+        assertEq(state.getOwner(bag), Node.Player(aliceAccount), "Expected the bag to be owned by alice");
+
+        // -- Transfer back to Alice
+
+        vm.startPrank(address(_buildingImplementation));
+        vm.expectRevert();
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG_OWNERSHIP, (bag, _buildingInstance)));
+        dispatcher.dispatch(abi.encodeCall(Actions.TRANSFER_BAG, (bag, _buildingInstance, _mobileUnitAlice)));
+        vm.stopPrank();
+
+        assertEq(state.getEquipSlot(_buildingInstance, 2), bytes24(0), "Expected bag not to be equipped to building");
+        assertEq(state.getOwner(bag), Node.Player(aliceAccount), "Expected the bag to be owned by aliceAccount");
+        assertEq(state.getEquipSlot(_mobileUnitAlice, 0), bag, "Expected bag to be equipped to Alice at slot 0");
+    }
+
+    function testSpawnEmptyBagOnUnit() public {
+        bytes24 bag = state.getEquipSlot(_mobileUnitAlice, 2);
+        assertEq(bag, bytes24(0), "Expected no entity to be equipped to alice at slot 2");
+
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.SPAWN_EMPTY_BAG, (_mobileUnitAlice)));
+        vm.stopPrank();
+
+        bag = state.getEquipSlot(_mobileUnitAlice, 2);
+        assertEq(bytes4(bag), Kind.Bag.selector, "Expected alice to be equipped with new bag at slot 2");
+        assertEq(state.getOwner(bag), Node.Player(aliceAccount), "Expected the bag to be owned by aliceAccount");
+    }
+
+    function testSpawnEmptyBagOnBuilding() public {
+        bytes24 bag = state.getEquipSlot(_buildingInstance, 2);
+        assertEq(bag, bytes24(0), "Expected no entity to be equipped to building at slot 2");
+
+        vm.startPrank(address(_buildingImplementation));
+        dispatcher.dispatch(abi.encodeCall(Actions.SPAWN_EMPTY_BAG, (_buildingInstance)));
+        vm.stopPrank();
+
+        bag = state.getEquipSlot(_buildingInstance, 2);
+        assertEq(bytes4(bag), Kind.Bag.selector, "Expected building to be equipped with new bag at slot 2");
+        assertEq(state.getOwner(bag), _buildingInstance, "Expected the bag to be owned by building");
+    }
+
+    function testFailSpawnEmptyBagOnNonOwnedEntity() public {
+        vm.startPrank(aliceAccount);
+        dispatcher.dispatch(abi.encodeCall(Actions.SPAWN_EMPTY_BAG, (_buildingInstance)));
+        vm.stopPrank();
+    }
+
+    // ------------------------------------------------------------------------------------------- //
+
+    function _constructBuilding(address builderAccount, bytes24 mobileUnit) private returns (bytes24) {
+        // register a building kind
+        bytes24 buildingKind = Node.BuildingKind(20);
+        string memory buildingName = "hut";
+        vm.expectEmit(true, true, true, true, address(state));
+        emit AnnotationSet(buildingKind, AnnotationKind.CALLDATA, "name", keccak256(bytes(buildingName)), buildingName);
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.REGISTER_BUILDING_KIND, (buildingKind, "hut", defaultMaterialItem, defaultMaterialQty)
+            )
+        );
+        // register a mock implementation for the building
+        _buildingImplementation = new MockBuildingKind();
+        dispatcher.dispatch(
+            abi.encodeCall(Actions.REGISTER_KIND_IMPLEMENTATION, (buildingKind, address(_buildingImplementation)))
+        );
+
+        // spawn a mobileUnit
+        vm.startPrank(builderAccount);
+        // discover an adjacent tile for our building site
+        (int16 q, int16 r, int16 s) = (1, -1, 0);
+        _discover(q, r, s);
+        // get our building and give it the resources to construct
+        bytes24 buildingInstance = Node.Building(DEFAULT_ZONE, q, r, s);
+        // construct our building
+        _transferFromMobileUnit(mobileUnit, 0, 25, buildingInstance);
+        _transferFromMobileUnit(mobileUnit, 1, 25, buildingInstance);
+        _transferFromMobileUnit(mobileUnit, 2, 25, buildingInstance);
+        dispatcher.dispatch(abi.encodeCall(Actions.CONSTRUCT_BUILDING_MOBILE_UNIT, (mobileUnit, buildingKind, q, r, s)));
+        vm.stopPrank();
+        // check the building has a location at q/r/s
+        assertEq(
+            state.getFixedLocation(buildingInstance),
+            Node.Tile(DEFAULT_ZONE, q, r, s),
+            "expected building to have location"
+        );
+        // check building has owner
+        assertEq(
+            state.getOwner(buildingInstance),
+            Node.Player(builderAccount),
+            "expected building to be owned by builder acccount"
+        );
+        // check building has kind
+        assertEq(state.getBuildingKind(buildingInstance), buildingKind, "expected building to have kind");
+        // check building has a bag equip
+        assertTrue(state.getEquipSlot(buildingInstance, 0) != 0x0, "expected building to have a bag equip");
+
+        return buildingInstance;
+    }
+
+    // _spawnMobileUnitWithResources spawns a mobileUnit for the current sender at
+    // 0,0,0 with 100 of each resource in an equiped bag
+    function _spawnMobileUnitWithResources() private returns (bytes24) {
+        sid++;
+        bytes24 mobileUnit = Node.MobileUnit(sid);
+        _discover(0, 0, 0);
+        dispatcher.dispatch(abi.encodeCall(Actions.SPAWN_MOBILE_UNIT, (mobileUnit)));
+        bytes24[] memory items = new bytes24[](3);
+        items[0] = ItemUtils.GlassGreenGoo();
+        items[1] = ItemUtils.BeakerBlueGoo();
+        items[2] = ItemUtils.FlaskRedGoo();
+
+        uint64[] memory balances = new uint64[](3);
+        balances[0] = 100;
+        balances[1] = 100;
+        balances[2] = 100;
+
+        uint64 mobileUnitBag = uint64(uint256(keccak256(abi.encode(mobileUnit))));
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.DEV_SPAWN_BAG,
+                (mobileUnitBag, state.getOwnerAddress(mobileUnit), mobileUnit, 0, items, balances)
+            )
+        );
+
+        return mobileUnit;
+    }
+
+    function _transferFromMobileUnit(bytes24 mobileUnit, uint8 slot, uint64 qty, bytes24 toBuilding) private {
+        bytes24 buildingBag = Node.Bag(uint64(uint256(keccak256(abi.encode(toBuilding)))));
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.TRANSFER_ITEM_MOBILE_UNIT,
+                (mobileUnit, [mobileUnit, toBuilding], [0, 0], [slot, slot], buildingBag, qty)
+            )
+        );
+    }
+
+    function _discover(int16 q, int16 r, int16 s) private {
+        dispatcher.dispatch(
+            abi.encodeCall(
+                Actions.DEV_SPAWN_TILE,
+                (
+                    BiomeKind.DISCOVERED,
+                    q, // q
+                    r, // r
+                    s // s
+                )
+            )
+        );
+    }
+}
+
+contract MockBuildingKind is BuildingKind {
+    struct UseArgs {
+        Game game;
+        bytes24 building;
+        bytes24 mobileUnit;
+        uint256 payloadLen;
+    }
+
+    UseArgs[] public useCalls;
+
+    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) public {
+        UseArgs storage call = useCalls.push();
+        call.game = game;
+        call.building = building;
+        call.mobileUnit = mobileUnit;
+        call.payloadLen = payload.length;
+    }
+
+    function getUseCallCount() public view returns (uint256) {
+        return useCalls.length;
+    }
+}


### PR DESCRIPTION
## What

A new game rule named `BagRule` which implements bag actions.

```
    function TRANSFER_BAG_OWNERSHIP(bytes24 bag, bytes24 fromEntity, bytes24 toEntity) external;

    function TRANSFER_BAG(bytes24 bag, bytes24 fromEntity, bytes24 toEntity) external;

    function SPAWN_EMPTY_BAG(bytes24 equipee) external;
```
## Why

Transferring of bags and ownership was done by directly manipulating the game state. For building implementation code this will be illegal therefore basic rules for bags needed to be made to expose this functionality

## Summary of the rules

- An owner of a bag can transfer a bag onto another `MobileUnit` or a `BuildingInstance`
  - Transferring a bag onto another entity does NOT inherently transfer ownership. This means it is possible to transfer a bag onto another entity and its use would be restricted from the point of view of that entity i.e. they cannot move items out of that bag nor transfer ownship
- Equipees of a bag that doesn't belong to them are allowed to transfer the bag onto another `MobileUnit` or a `BuildingInstance`
- An owner of a bag can transfer ownership of a bag to another `MobileUnit` or a `BuildingInstance` 
- Bags cannot be transferred directly to or from tiles.

## Problems encountered

The code that checks if a bag belongs to the `sender` of a action is a little tricky because of the way that bags are owned by `Player` nodes when equipped to `MobileUnits` but are owned by `Building` nodes (Instances of buildings) when equipped to a building. 

Trouble with validating that the sender was the owner of the bag when called from building contract