### PR TITLE
Filter constructable buildings list to owned-by-player

### DIFF
--- a/core/src/kinds.graphql
+++ b/core/src/kinds.graphql
@@ -20,6 +20,10 @@ fragment BuildingKind on Node {
     outputs: edges(match: { kinds: ["Item"], via: { rel: "Output" } }) {
         ...ItemSlot
     }
+    # who deployed this building kind
+    owner: node(match: { kinds: "Player", via: { rel: "Owner" } }) {
+        id
+    }
 }
 
 query GetAvailableBuildingKinds($gameID: ID!) {

--- a/frontend/src/plugins/action-context-panel/action-context-panel.styles.ts
+++ b/frontend/src/plugins/action-context-panel/action-context-panel.styles.ts
@@ -63,7 +63,8 @@ const baseStyles = (_: Partial<ActionContextPanelProps>) => css`
         overflow: hidden;
         text-overflow: ellipsis;
         display: inline-block;
-        margin: 0rem 0.1rem 0.5rem 0;
+        margin: 2rem 0.1rem 0rem 0;
+        opacity: 0.4;
     }
 `;
 

--- a/frontend/src/plugins/action-context-panel/action-context-panel.styles.ts
+++ b/frontend/src/plugins/action-context-panel/action-context-panel.styles.ts
@@ -56,18 +56,14 @@ const baseStyles = (_: Partial<ActionContextPanelProps>) => css`
     }
 
     .label {
-        width: 60%;
+        width: 12rem;
         height: 1.7rem;
         white-space: nowrap;
         font-size: 1.4rem;
         overflow: hidden;
         text-overflow: ellipsis;
-        display: block;
-        margin: 0.5rem 0;
-        > strong {
-            display: inline-block;
-            width: 6rem;
-        }
+        display: inline-block;
+        margin: 0rem 0.1rem 0.5rem 0;
     }
 `;
 

--- a/frontend/src/plugins/action-context-panel/action-context-panel.styles.ts
+++ b/frontend/src/plugins/action-context-panel/action-context-panel.styles.ts
@@ -54,6 +54,21 @@ const baseStyles = (_: Partial<ActionContextPanelProps>) => css`
     .secondary-action-button {
         margin: 0 auto;
     }
+
+    .label {
+        width: 60%;
+        height: 1.7rem;
+        white-space: nowrap;
+        font-size: 1.4rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: block;
+        margin: 0.5rem 0;
+        > strong {
+            display: inline-block;
+            width: 6rem;
+        }
+    }
 `;
 
 /**

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -1,8 +1,16 @@
 /** @format */
 import { TileAction } from '@app/components/organisms/tile-action';
+import { getCoords, getNeighbours, getTileDistance } from '@app/helpers/tile';
+import { Bag } from '@app/plugins/inventory/bag';
+import { BuildingInventory } from '@app/plugins/inventory/building-inventory';
+import { getBuildingEquipSlot, getBuildingId } from '@app/plugins/inventory/helpers';
+import { useInventory } from '@app/plugins/inventory/inventory-provider';
+import { TileInventory } from '@app/plugins/inventory/tile-inventory';
+import { MobileUnitList } from '@app/plugins/mobile-unit-list';
 import { ComponentProps } from '@app/types/component-props';
 import {
     BiomeKind,
+    BuildingKindFragment,
     CogAction,
     ConnectedPlayer,
     SelectedMobileUnitFragment,
@@ -13,22 +21,13 @@ import {
     usePluginState,
     useSelection,
     useWorld,
+    World,
     WorldBuildingFragment,
-    BuildingKindFragment,
-    WorldTileFragment,
-    World
+    WorldTileFragment
 } from '@downstream/core';
 import React, { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { useInventory } from '@app/plugins/inventory/inventory-provider';
-import { getCoords, getTileDistance, getNeighbours } from '@app/helpers/tile';
-import { BuildingInventory } from '@app/plugins/inventory/building-inventory';
-import { getBuildingEquipSlot, getBuildingId } from '@app/plugins/inventory/helpers';
-import { MobileUnitList } from '@app/plugins/mobile-unit-list';
-import { TileInventory } from '@app/plugins/inventory/tile-inventory';
-import { Bag } from '@app/plugins/inventory/bag';
 import { styles } from './action-context-panel.styles';
-import { formatNameOrId } from '@app/helpers';
 
 export interface ActionContextPanelProps extends ComponentProps {
     onShowCombatModal?: (isNewSession: boolean) => void;

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -316,31 +316,35 @@ const Construct: FunctionComponent<ConstructProps> = ({ selectedTiles, mobileUni
             <span className="sub-title">{help}</span>
             <ImageConstruct />
             <form onSubmit={handleConstruct}>
-                <div className="select">
-                    <select
-                        name="kind"
-                        placeholder="select kind"
-                        onChange={onChangeSelectedKind}
-                        value={selectedKind?.id}
-                    >
-                        {constructableKinds.map((k) => (
-                            <option key={k.id} value={k.id}>
-                                {k.name?.value || '<unnamed>'}
-                            </option>
-                        ))}
-                    </select>
-                </div>
-                {buildingId && (
-                    <div ref={slotsRef} className="ingredients">
-                        <BuildingInventory buildingId={buildingId} recipe={recipe} />
-                    </div>
+                {constructableTile && (
+                    <>
+                        <div className="select">
+                            <select
+                                name="kind"
+                                placeholder="select kind"
+                                onChange={onChangeSelectedKind}
+                                value={selectedKind?.id}
+                            >
+                                {constructableKinds.map((k) => (
+                                    <option key={k.id} value={k.id}>
+                                        {k.name?.value || '<unnamed>'}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        {buildingId && (
+                            <div ref={slotsRef} className="ingredients">
+                                <BuildingInventory buildingId={buildingId} recipe={recipe} />
+                            </div>
+                        )}
+                        <button className="action-button" type="submit" disabled={!canConstruct}>
+                            Confirm Construction
+                        </button>
+                        <button className="secondary-action-button" onClick={clearIntent}>
+                            Cancel Construction
+                        </button>
+                    </>
                 )}
-                <button className="action-button" type="submit" disabled={!canConstruct}>
-                    Confirm Construction
-                </button>
-                <button className="secondary-action-button" onClick={clearIntent}>
-                    Cancel Construction
-                </button>
             </form>
         </StyledActionContextPanel>
     );

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -15,7 +15,8 @@ import {
     useWorld,
     WorldBuildingFragment,
     BuildingKindFragment,
-    WorldTileFragment
+    WorldTileFragment,
+    World
 } from '@downstream/core';
 import React, { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -27,6 +28,7 @@ import { MobileUnitList } from '@app/plugins/mobile-unit-list';
 import { TileInventory } from '@app/plugins/inventory/tile-inventory';
 import { Bag } from '@app/plugins/inventory/bag';
 import { styles } from './action-context-panel.styles';
+import { formatNameOrId } from '@app/helpers';
 
 export interface ActionContextPanelProps extends ComponentProps {
     onShowCombatModal?: (isNewSession: boolean) => void;
@@ -73,11 +75,12 @@ const byKey = (a: KeyedThing, b: KeyedThing) => {
 interface TileBuildingProps {
     player?: ConnectedPlayer;
     building: WorldBuildingFragment;
+    world?: World;
     showFull: boolean;
     selectIntent: Selector<string | undefined>;
     selectTiles: Selector<string[] | undefined>;
 }
-const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, showFull, player }) => {
+const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, showFull, player, world }) => {
     const { tiles: selectedTiles } = useSelection();
     const selectedTile = selectedTiles?.[0];
     const tileMobileUnits = selectedTile?.mobileUnits ?? [];
@@ -109,10 +112,23 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, showFull
 
     const isEnemy = buildingKind?.model?.value === 'enemy';
 
+    const author = world?.players.find((p) => p.id === building?.kind?.owner?.id);
+    const owner = world?.players.find((p) => p.id === building?.owner?.id);
+
     return (
         <StyledActionContextPanel className="action">
             <h3>{component?.title ?? building?.kind?.name?.value ?? 'Unnamed Building'}</h3>
             <span className="sub-title">{component?.summary || ''}</span>
+            {author && (
+                <span className="label">
+                    <strong>AUTHOR:</strong> {author.addr}
+                </span>
+            )}
+            {owner && (
+                <span className="label">
+                    <strong>OWNER:</strong> {owner.addr}
+                </span>
+            )}
             {isEnemy ? <ImageEnemy /> : <ImageBuilding />}
             {component && showFull && (
                 <Fragment>
@@ -667,6 +683,7 @@ export const ActionContextPanel: FunctionComponent<ActionContextPanelProps> = ({
                     return (
                         <TileBuilding
                             building={selectedTile.building}
+                            world={world}
                             showFull={false}
                             selectIntent={selectIntent}
                             selectTiles={selectTiles}
@@ -677,6 +694,7 @@ export const ActionContextPanel: FunctionComponent<ActionContextPanelProps> = ({
                         <TileBuilding
                             player={player}
                             building={selectedTile.building}
+                            world={world}
                             showFull={true}
                             selectIntent={selectIntent}
                             selectTiles={selectTiles}

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -118,16 +118,6 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, showFull
         <StyledActionContextPanel className="action">
             <h3>{component?.title ?? building?.kind?.name?.value ?? 'Unnamed Building'}</h3>
             <span className="sub-title">{component?.summary || ''}</span>
-            {author && (
-                <span className="label">
-                    <strong>AUTHOR:</strong> {author.addr}
-                </span>
-            )}
-            {owner && (
-                <span className="label">
-                    <strong>OWNER:</strong> {owner.addr}
-                </span>
-            )}
             {isEnemy ? <ImageEnemy /> : <ImageBuilding />}
             {component && showFull && (
                 <Fragment>
@@ -174,6 +164,16 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, showFull
                 <MobileUnitList mobileUnits={tileMobileUnits} player={player} />
             )}
             {!showFull && selectedTile && <TileInventory tile={selectedTile} />}
+            {author && (
+                <span className="label">
+                    <strong>AUTHOR:</strong> {author.addr}
+                </span>
+            )}
+            {owner && (
+                <span className="label">
+                    <strong>OWNER:</strong> {owner.addr}
+                </span>
+            )}
         </StyledActionContextPanel>
     );
 };


### PR DESCRIPTION
* changes the default behaviour of the construction list to only show building kinds deployed by the player with option to "show all" (resolves: #488 )
* include BuildingKind author and Building instance owner in building info (resolves: #129 )

here's me with my one owned buildingkind

![Screenshot 2023-08-09 at 13 57 17](https://github.com/playmint/ds/assets/45921/34e22c73-c84e-47b4-b12a-bcadbf00f980)

.... and here's someone with no buildingkinds of their own but show-all enabled
 
![Screenshot 2023-08-09 at 12 43 15](https://github.com/playmint/ds/assets/45921/a27c6fa7-7c5e-4746-b3b8-2b2c1d43d7b3)


here's building panel showing author and owner addresses

![Screenshot 2023-08-09 at 14 55 20](https://github.com/playmint/ds/assets/45921/4a27b431-babd-4f17-8f48-fb13eef4133b)

