### PR TITLE
Removal of category from Building spec

### DIFF
--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -113,7 +113,6 @@ export const BuildingKind = z.object({
 
 export const BuildingSpec = z.object({
     name: Name,
-    category: BuildingCategoryEnum,
     location: Coords,
 });
 

--- a/contracts/src/fixtures/extractors/map.yaml
+++ b/contracts/src/fixtures/extractors/map.yaml
@@ -2,19 +2,16 @@
 kind: Building
 spec:
   name: Green Goo Extractor
-  category: extractor
   location: [-1, 0, 1]
 
 ---
 kind: Building
 spec:
   name: Blue Goo Extractor
-  category: extractor
   location: [-1, 1, 0]
 
 ---
 kind: Building
 spec:
   name: Red Goo Extractor
-  category: extractor
   location: [-3, 0, 3]

--- a/contracts/src/fixtures/the-great-cleanup/map.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/map.yaml
@@ -2,231 +2,198 @@
 kind: Building
 spec:
   name: Mecha-Kaiju
-  category: blocker
   location: [10, -21, 11]
 
 ---
 kind: Building
 spec:
   name: All Things Rubber
-  category: factory
   location: [-10, 0, 10]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [1, 5, -6]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [0, -12, 12]
 
 ---
 kind: Building
 spec:
   name: Kwik Tyre
-  category: factory
   location: [-4, 3, 1]
 
 ---
 kind: Building
 spec:
   name: Green Goo Fusion
-  category: factory
   location: [-20, 0, 20]
 
 ---
 kind: Building
 spec:
   name: Foul Fiends
-  category: factory
   location: [3, -3, 0]
 
 ---
 kind: Building
 spec:
   name: Non-compliant Unit
-  category: blocker
   location: [10, 2, -12]
 
 ---
 kind: Building
 spec:
   name: Non-compliant Unit
-  category: blocker
   location: [10, -7, -3]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [-1, -4, 5]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [-4, -8, 12]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [-4, 8, -4]
 
 ---
 kind: Building
 spec:
   name: The Great Cleanup
-  category: factory
   location: [-1, 2, -1]
 
 ---
 kind: Building
 spec:
   name: Non-compliant Unit
-  category: blocker
   location: [-3, 13, -10]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [6, -5, -1]
 
 ---
 kind: Building
 spec:
   name: Mecha-Kaiju
-  category: blocker
   location: [-14, -7, 21]
 
 ---
 kind: Building
 spec:
   name: Green Goo Fission
-  category: factory
   location: [-10, -15, 25]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [-6, -4, 10]
 
 ---
 kind: Building
 spec:
   name: Mecha-Kaiju
-  category: blocker
   location: [-5, 20, -15]
 
 ---
 kind: Building
 spec:
   name: Non-compliant Unit
-  category: blocker
   location: [-13, -4, 17]
 
 ---
 kind: Building
 spec:
   name: Paperclip Maximiser
-  category: blocker
   location: [-15, 27, -12]
 
 ---
 kind: Building
 spec:
   name: Mecha-Kaiju
-  category: blocker
   location: [15, 6, -21]
 
 ---
 kind: Building
 spec:
   name: Non-compliant Unit
-  category: blocker
   location: [10, 8, -18]
 
 ---
 kind: Building
 spec:
   name: Prime Evil
-  category: blocker
   location: [12, -25, 13]
 
 ---
 kind: Building
 spec:
   name: Non-compliant Unit
-  category: blocker
   location: [-18, 8, 10]
 
 ---
 kind: Building
 spec:
   name: Cocktail Hut
-  category: factory
   location: [5, 13, -18]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [9, 0, -9]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [5, 7, -12]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [3, -7, 4]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [8, -12, 4]
 
 ---
 kind: Building
 spec:
   name: Crazy Hermit
-  category: factory
   location: [7, 7, -14]
 
 ---
 kind: Building
 spec:
   name: Prime Evil
-  category: blocker
   location: [-26, 18, 8]
 
 ---
 kind: Building
 spec:
   name: Slime
-  category: blocker
   location: [-8, 9, -1]
 
 ---

--- a/frontend/src/pages/tile-fabricator.tsx
+++ b/frontend/src/pages/tile-fabricator.tsx
@@ -261,7 +261,6 @@ export const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                             kind: 'Building',
                             spec: {
                                 name: buildingKind.spec.name,
-                                category: buildingKind.spec.category, // TODO: remove this as category is deprecated on kind=Building
                                 location: t.location,
                             },
                         },


### PR DESCRIPTION
#What

Removal of the category field from the Building spec. We are able to look up the BuildingKind to get at the ID so no need to specify the category when defining a building

#Why

Having to define the category when describing an instance of a building was superfluous 