### PR TITLE
Prevent clashing of BuildingKind contract address 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ Thumbs.db
 
 /node_modules
 *.tsbuildinfo
+
+# dev script
+.livestartup.js

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ clean:
 	rm -rf cli/node_modules
 	rm -f  contracts/lib/cog/services/bin/ds-node
 	rm -rf contracts/out
+	rm -rf contracts/broadcast
+	rm -rf contracts/cache
 	rm -rf core/dist
 	rm -rf core/src/gql
 	rm -rf core/src/abi

--- a/contracts/src/fixtures/the-great-cleanup/TheGreatCleanup.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/TheGreatCleanup.yaml
@@ -4,6 +4,10 @@ spec:
   name: The Great Cleanup
   category: factory
   model: 01-02
+  contract:
+    file: ./TheGreatCleanup.sol
+  plugin:
+    file: ./TheGreatCleanup.js
   materials:
   - name: L33t Bricks
     quantity: 100


### PR DESCRIPTION
## What

* contracts: Salts the BuildingKind contract addresses with the `state` and `kind` ids to avoid clashing with previous deployment
* make: clean now cleans contract cache

## Why

On the "real" deployments, BuildingKind contract addresses would clash, and the game would think they are already deployed (but they were deployed for a previous version of the game) ... by salting with the `state` the contract deployments become per-deployment

fixes: #527 
fixes: #524 