### PR TITLE
Goo extraction curve

### DIFF
--- a/contracts/src/fixtures/extractors/BlueExtractor.yaml
+++ b/contracts/src/fixtures/extractors/BlueExtractor.yaml
@@ -17,4 +17,4 @@ spec:
       quantity: 25
   outputs:
     - name: Beaker of Blue Goo
-      quantity: 10
+      quantity: 1

--- a/contracts/src/fixtures/extractors/GenericExtractor.js
+++ b/contracts/src/fixtures/extractors/GenericExtractor.js
@@ -83,11 +83,11 @@ export default function update({ selected, world }) {
 
     const gooIndex = outItemAtomVals.findIndex((gooVal) => gooVal > 0n);
     // const gooCost = Number(BigInt(out0.balance) * outItemAtomVals[gooIndex]);
-    // const numberOfItems = Math.floor(
-    //     extractedGoo[gooIndex] / Number(outItemAtomVals[gooIndex])
-    // );
+    const numberOfItems = Math.floor(
+        extractedGoo[gooIndex] / Number(outItemAtomVals[gooIndex])
+    );
 
-    const canExtract = extractedGoo[gooIndex] >= 1;
+    const canExtract = numberOfItems >= 1;
 
     const extract = () => {
         if (!selectedEngineer) {
@@ -139,7 +139,9 @@ export default function update({ selected, world }) {
                             )}% full</p>
                             <p>Extracted ${
                                 extractedGoo[gooIndex]
-                            } ${getGooColor(gooIndex)} Goo</p>
+                            } ${getGooColor(
+                            gooIndex
+                        )} Goo (${numberOfItems} items)</p>
                         </p>
                         `,
                     },

--- a/contracts/src/fixtures/extractors/GreenExtractor.yaml
+++ b/contracts/src/fixtures/extractors/GreenExtractor.yaml
@@ -17,4 +17,4 @@ spec:
       quantity: 25
   outputs:
     - name: Glass of Green Goo
-      quantity: 10
+      quantity: 1

--- a/contracts/src/fixtures/extractors/RedExtractor.yaml
+++ b/contracts/src/fixtures/extractors/RedExtractor.yaml
@@ -17,4 +17,4 @@ spec:
       quantity: 25
   outputs:
     - name: Flask of Red Goo
-      quantity: 10
+      quantity: 1

--- a/contracts/src/rules/ExtractionRule.sol
+++ b/contracts/src/rules/ExtractionRule.sol
@@ -69,53 +69,60 @@ contract ExtractionRule is Rule {
         }
 
         // Get output item and qty
-        (bytes24 outputItemID, uint64 qty) = state.getOutput(buildingKind, 0);
+        // NOTE: No longer care about the quanity. We just check if we can make at least 1
+        (bytes24 outputItemID, /*uint64 qty*/ ) = state.getOutput(buildingKind, 0);
+
+        // Output bag is at slot 1 same as crafting building.
+        bytes24 outBag = state.getEquipSlot(buildingInstance, 1);
+        _requireIsBag(outBag);
+        (bytes24 bagItem, uint64 bagBal) = state.getItemSlot(outBag, 0);
+        if (bagItem != bytes24(0)) {
+            require(bagItem == outputItemID, "Item at slot 0 doesn't match extractor output item");
+            require(bagBal < 100, "Not enough space in slot to put output item");
+        }
+
+        uint64 qty;
 
         // Calculate extracted atoms (goo) and check if we have sufficient to create a batch of output items
         {
             uint64[3] memory reservoirAtoms = state.getBuildingReservoirAtoms(buildingInstance);
             uint64[3] memory extractedAtoms = _calcExtractedGoo(state, ctx, buildingInstance);
 
-            reservoirAtoms[GOO_GREEN] =
-                uint64(min(reservoirAtoms[GOO_GREEN] + extractedAtoms[GOO_GREEN], GOO_RESERVOIR_MAX));
-            reservoirAtoms[GOO_BLUE] =
-                uint64(min(reservoirAtoms[GOO_BLUE] + extractedAtoms[GOO_BLUE], GOO_RESERVOIR_MAX));
-            reservoirAtoms[GOO_RED] = uint64(min(reservoirAtoms[GOO_RED] + extractedAtoms[GOO_RED], GOO_RESERVOIR_MAX));
+            for (uint256 i = 0; i < 3; i++) {
+                reservoirAtoms[i] = uint64(min(reservoirAtoms[i] + extractedAtoms[i], GOO_RESERVOIR_MAX));
+            }
 
             (uint32[3] memory outputItemAtoms, /*bool isStackable*/ ) = state.getItemStructure(outputItemID);
 
             // Check we have enough atoms (goo) in the reservoir to make
             require(
-                outputItemAtoms[GOO_GREEN] * qty <= reservoirAtoms[GOO_GREEN],
-                "not enough green goo extracted to make item"
+                outputItemAtoms[GOO_GREEN] <= reservoirAtoms[GOO_GREEN], "not enough green goo extracted to make item"
             );
-            require(
-                outputItemAtoms[GOO_BLUE] * qty <= reservoirAtoms[GOO_BLUE],
-                "not enough blue goo extracted to make item"
-            );
-            require(
-                outputItemAtoms[GOO_RED] * qty <= reservoirAtoms[GOO_RED], "not enough red goo extracted to make item"
-            );
+            require(outputItemAtoms[GOO_BLUE] <= reservoirAtoms[GOO_BLUE], "not enough blue goo extracted to make item");
+            require(outputItemAtoms[GOO_RED] <= reservoirAtoms[GOO_RED], "not enough red goo extracted to make item");
 
-            reservoirAtoms[GOO_GREEN] -= outputItemAtoms[GOO_GREEN] * qty;
-            reservoirAtoms[GOO_BLUE] -= outputItemAtoms[GOO_BLUE] * qty;
-            reservoirAtoms[GOO_RED] -= outputItemAtoms[GOO_RED] * qty;
+            // How many items can I make with the extracted goo (We pick the lowest mulitple above zero)
+            for (uint256 i = 0; i < 3; i++) {
+                if (outputItemAtoms[i] > 0) {
+                    uint64 numItems = reservoirAtoms[i] / outputItemAtoms[i];
+                    if (qty == 0 || numItems < qty) {
+                        qty = numItems;
+                    }
+                }
+            }
+
+            // Can only fit 100 items in a slot so set the qty to the difference
+            if (bagBal + qty > 100) {
+                qty = 100 - bagBal;
+            }
+
+            // Spend the extracted atoms
+            for (uint256 i = 0; i < 3; i++) {
+                reservoirAtoms[i] -= outputItemAtoms[i] * qty;
+            }
 
             state.setBuildingReservoirAtoms(buildingInstance, reservoirAtoms);
             state.setBlockNum(buildingInstance, 0, ctx.clock);
-        }
-
-        // Output bag is at slot 1 same as crafting building.
-        bytes24 outBag = state.getEquipSlot(buildingInstance, 1);
-        _requireIsBag(outBag);
-
-        (bytes24 bagItem, uint64 bagBal) = state.getItemSlot(outBag, 0);
-
-        if (bagItem != bytes24(0)) {
-            require(bagItem == outputItemID, "Item at slot 0 doesn't match extractor output item");
-
-            // TODO: Should we be filling up the other slots?
-            require(bagBal + qty <= 100, "Not enough space in slot to put output item");
         }
 
         state.setItemSlot(outBag, 0, outputItemID, bagBal + qty);

--- a/contracts/test/rules/ExtractionRule.t.sol
+++ b/contracts/test/rules/ExtractionRule.t.sol
@@ -111,10 +111,10 @@ contract ExtractionRuleTest is Test, GameTest {
 
         // check that output item now exists in outputBag slot 1
         bytes24 outputBag = state.getEquipSlot(buildingInstance, 1);
-        (bytes24 expItem, uint64 expBalance) = state.getOutput(mockBuildingKind, 0);
+        (bytes24 expItem, /*uint64 expBalance*/ ) = state.getOutput(mockBuildingKind, 0);
         (bytes24 gotItem, uint64 gotBalance) = state.getItemSlot(outputBag, 0);
         assertEq(gotItem, expItem, "expected output slot to contain expected output item");
-        assertEq(gotBalance, expBalance, "expected output balance match");
+        assertEq(gotBalance, 100, "expected output balance to be a full stack of 100");
 
         // expect reservoir to be minus the cost of the item batch
         uint64[3] memory reservoirAtoms = state.getBuildingReservoirAtoms(buildingInstance);
@@ -122,7 +122,7 @@ contract ExtractionRuleTest is Test, GameTest {
 
         assertEq(
             reservoirAtoms[GOO_GREEN],
-            GOO_RESERVOIR_MAX - outputItemAtoms[GOO_GREEN] * expBalance,
+            GOO_RESERVOIR_MAX - outputItemAtoms[GOO_GREEN] * 100,
             "expected total atomic value of output items to be taken from reservoir"
         );
     }

--- a/frontend/src/plugins/tile-coords/index.tsx
+++ b/frontend/src/plugins/tile-coords/index.tsx
@@ -15,15 +15,58 @@ const StyledTileCoords = styled('div')`
     ${styles}
 `;
 
+const GOO_GREEN = 0;
+const GOO_BLUE = 1;
+const GOO_RED = 2;
+
+// https://www.notion.so/playmint/Extraction-6b36dcb3f95e4ab8a57cb6b99d24bb8f#cb8cc764f9ef436e9847e631ef12b157
+
+const getSecsPerGoo = (atomVal: number) => {
+    if (atomVal < 10) return 0;
+
+    const x = atomVal - 32;
+    const baseSecsPerGoo = 120 * Math.pow(0.98, x);
+
+    if (atomVal >= 200) return baseSecsPerGoo / 4;
+    else if (atomVal >= 170) return baseSecsPerGoo / 2;
+    else return baseSecsPerGoo;
+};
+
+const getGooPerSec = (atomVal: number) => {
+    const secsPerGoo = getSecsPerGoo(atomVal);
+    return secsPerGoo > 0 ? 1 / secsPerGoo : 0;
+};
+
+const getGooName = (index: number) => {
+    switch (index) {
+        case GOO_GREEN:
+            return 'Green';
+        case GOO_BLUE:
+            return 'Blue';
+        case GOO_RED:
+            return 'Red';
+    }
+
+    return 'Unknown';
+};
 export const TileCoords: FunctionComponent<TileCoordsProps> = (props: TileCoordsProps) => {
     const { selectedTiles, ...otherProps } = props;
     const lastTile = selectedTiles[selectedTiles.length - 1];
     const [_, q, r, s] = lastTile.coords.map((elm) => ethers.fromTwos(elm, 16));
 
-    const [green, blue, red] =
+    const gooRates =
         lastTile.atoms && lastTile.atoms.length > 0
-            ? lastTile.atoms.sort((a, b) => a.key - b.key).map((elm) => elm.weight)
-            : [0, 0, 0];
+            ? lastTile.atoms
+                  .sort((a, b) => b.weight - a.weight)
+                  .map((elm) => {
+                      return {
+                          index: elm.key,
+                          name: getGooName(elm.key),
+                          gooPerSec: getGooPerSec(elm.weight),
+                      };
+                  })
+            : [];
+
     const [showingIllustration, setShowingIllustration] = useState(false);
     // const [__, qHex, rHex, sHex] = lastTile.coords;
 
@@ -33,6 +76,13 @@ export const TileCoords: FunctionComponent<TileCoordsProps> = (props: TileCoords
 
     return (
         <StyledTileCoords {...otherProps}>
+            {gooRates.length > 0 && (
+                <div className="gooRating">
+                    <h3>{gooRates[0].name} Goo Tile</h3>
+                    <strong>GOO PER SECOND: </strong>
+                    <span>{Math.floor(gooRates[0].gooPerSec * 100) / 100}</span>
+                </div>
+            )}
             {showingIllustration && (
                 <div className="tile-container" style={{ marginBottom: '1rem' }}>
                     <img src="empty-tile.png" alt="" width={80} />
@@ -47,18 +97,6 @@ export const TileCoords: FunctionComponent<TileCoordsProps> = (props: TileCoords
             <div className="coordinates" onClick={handleCoordinatesClick}>
                 <strong>COORDINATES:</strong> {`${q}, ${r}, ${s}`}
             </div>
-            <div className="gooRating">
-                <span>
-                    <strong>RED:</strong> {red}
-                </span>
-                <span>
-                    <strong>GREEN:</strong> {green}
-                </span>
-                <span>
-                    <strong>BLUE:</strong> {blue}
-                </span>
-            </div>
-            {/* <div className="coordinates">{`Q:${qHex} R:${rHex} S:${sHex}`}</div> */}
         </StyledTileCoords>
     );
 };


### PR DESCRIPTION
# What

Implemented the extraction curve as per notion doc:
https://www.notion.so/playmint/Extraction-6b36dcb3f95e4ab8a57cb6b99d24bb8f#cb8cc764f9ef436e9847e631ef12b157

![image](https://github.com/playmint/ds/assets/51167118/30912153-8935-4c7a-8d3c-0c2ae4aecc1f)
Frontend now shows the extraction rate for the goo in both the tile info and the extrator building UI

<img width="265" alt="image" src="https://github.com/playmint/ds/assets/51167118/03d4e008-b930-4631-acf9-48cbf662e3d2">

- The tile info only shows the highest rated goo however for now all three goo values still exist on the tile

<img width="255" alt="image" src="https://github.com/playmint/ds/assets/51167118/301f417a-1f5f-49fe-b54c-b22cf3df4d2b">
<img width="251" alt="image" src="https://github.com/playmint/ds/assets/51167118/c2b07bc8-8690-44c0-bf3a-71b67d17dd7c">

- Clicking extract will now extract as many items as possible with the goo that has been extracted. 

<img width="239" alt="image" src="https://github.com/playmint/ds/assets/51167118/00f5e957-2abe-4ec2-a030-42208920a377">
<img width="246" alt="image" src="https://github.com/playmint/ds/assets/51167118/babf9749-264e-4694-b337-a692da2ddce6">

- The output slot is capped at 100 and also works if there are items already in the output slot