### PR TITLE
disable simulation node

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -15,20 +15,14 @@ const DEPLOYER_PRIVATE_KEY = "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff
 const commands = [
     {
         name: 'networks',
-        command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --code-size-limit 9999999999999 --gas-limit 9999999999999999 --silent",
-        prefixColor: 'black',
-    },
-
-    {
-        name: 'sim',
-        command: "anvil --code-size-limit 9999999999999 --gas-limit 9999999999999999 --port 8546 --fork-url http://localhost:8545 --no-mining --no-rate-limit --no-storage-caching --silent",
+        command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --code-size-limit 9999999999999  --block-time 2 --silent",
         prefixColor: 'black',
     },
 
     {
         name: 'contract',
         command: `./lib/cog/services/bin/wait-for -it localhost:8545 -t 300 \
-            && forge script script/Deploy.sol:GameDeployer --broadcast --rpc-url "http://localhost:8545" \
+            && forge script script/Deploy.sol:GameDeployer --broadcast --rpc-url "http://localhost:8545" --slow \
             && ./lib/cog/services/bin/wait-for -it localhost:8080 -t 300 \
             && sleep 2 \
             && ds -k ${DEPLOYER_PRIVATE_KEY} -n local apply -R -f ./src/fixtures/ --slow\
@@ -42,15 +36,13 @@ const commands = [
 
     {
         name: 'services',
-        command: './bin/wait-for -it localhost:8545 -t 300 && ./bin/wait-for -it localhost:8546 -t 300 && ./bin/ds-node',
+        command: './bin/wait-for -it localhost:8545 -t 300 && ./bin/ds-node',
         env: {
             PORT: "8181",
             CHAIN_ID: "1337",
             SEQUENCER_PRIVATE_KEY,
             SEQUENCER_PROVIDER_URL_HTTP: "http://localhost:8545",
             SEQUENCER_PROVIDER_URL_WS: "ws://localhost:8545",
-            SIMULATION_PROVIDER_URL_HTTP: "http://localhost:8546",
-            SIMULATION_PROVIDER_URL_WS: "ws://localhost:8546",
             INDEXER_WATCH_PENDING: "false",
             INDEXER_PROVIDER_URL_HTTP: "http://localhost:8545",
             INDEXER_PROVIDER_URL_WS: "ws://localhost:8545",

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -41,10 +41,6 @@ spec:
               value: {{ $.Values.sequencer.providerUrlWs | quote }}
             - name: SEQUENCER_MINE_EMPTY
               value: {{ $.Values.sequencer.mineEmpty | quote }}
-            - name: SIMULATION_PROVIDER_URL_HTTP
-              value: "http://localhost:8546"
-            - name: SIMULATION_PROVIDER_URL_WS
-              value: "ws://localhost:8546"
             - name: INDEXER_WATCH_PENDING
               value: {{ $.Values.indexer.watchPending | quote }}
             - name: INDEXER_PROVIDER_URL_HTTP
@@ -95,33 +91,8 @@ spec:
           - mountPath: "/root/.foundry/anvil/tmp"
             name: contracts-scratch
         {{ end -}}
-        - name: sim
-          image: {{ printf "ghcr.io/playmint/ds-contracts:%s" $.Values.version }}
-          imagePullPolicy: Always
-          command: ["/bin/bash"]
-          args:
-          - -eu
-          - -c
-          - |
-            anvil --port 8546 --fork-url {{ $.Values.sequencer.providerUrlHttp | quote }} --no-mining --no-rate-limit
-          ports:
-            - name: network
-              containerPort: 8546
-              protocol: TCP
-          volumeMounts:
-          - mountPath: "/root/.foundry/anvil/tmp"
-            name: sim-scratch
-      volumes:
-      - name: sim-scratch
-        ephemeral:
-          volumeClaimTemplate:
-            spec:
-              accessModes: [ "ReadWriteOnce" ]
-              storageClassName: default
-              resources:
-                requests:
-                  storage: 5Gi
       {{ if $.Values.anvil.enabled }}
+      volumes:
       - name: contracts-scratch
         ephemeral:
           volumeClaimTemplate:

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -24,10 +24,10 @@ echo "+-------------------+"
 echo "| starting evm node |"
 echo "+-------------------+"
 anvil \
+    --block-time 2 \
 	--host 0.0.0.0 \
 	-m "${ACCOUNT_MNEMONIC}" \
     --code-size-limit 9999999999999 \
-    --gas-limit 9999999999999999 \
 	&
 
 
@@ -38,7 +38,7 @@ while ! curl -sf -X POST --data '{"jsonrpc":"2.0","method":"eth_blockNumber","pa
 	echo "waiting for evm node to respond..."
 	sleep 1
 done
-forge script script/Deploy.sol:GameDeployer --broadcast --rpc-url "http://localhost:8545"
+forge script script/Deploy.sol:GameDeployer --broadcast --rpc-url "http://localhost:8545" --slow
 
 echo "+---------------------+"
 echo "| deploying fixtures  |"

--- a/contracts/src/fixtures/extractors/GenericExtractor.js
+++ b/contracts/src/fixtures/extractors/GenericExtractor.js
@@ -6,7 +6,7 @@ const GOO_RED = 2;
 
 const GOO_RESERVOIR_MAX = 500;
 // const TILE_ATOM_MAX = 255;
-const BLOCK_TIME_SECS = 10;
+const BLOCK_TIME_SECS = 2;
 
 function getGooColor(gooIndex) {
     switch (gooIndex) {

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -37,7 +37,7 @@ interface Kind {
     function BlockNum() external;
 }
 
-uint64 constant BLOCK_TIME_SECS = 10;
+uint64 constant BLOCK_TIME_SECS = 2;
 
 uint8 constant GOO_GREEN = 0;
 uint8 constant GOO_BLUE = 1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,22 +14,6 @@ services:
       SERVICES_URL_HTTP: "http://cog:8080/query"
       SERVICES_URL_WS: "ws://cog:8080/query"
 
-  sim:
-    build:
-      context: .
-      dockerfile: ./contracts/Dockerfile
-    image: playmint/ds-contracts:local
-    ports:
-      - 8546:8546
-    entrypoint:
-    - /bin/bash
-    - -eu
-    - -c
-    - |
-      anvil --host 0.0.0.0 --port 8546 --fork-url http://contracts:8545 --no-mining --no-rate-limit
-    depends_on:
-      - contracts
-
   frontend:
     build:
       context: .
@@ -50,8 +34,6 @@ services:
     - |
       echo "waiting contracts"
       /wait-for -it contracts:8545 -t 300
-      echo "waiting sim"
-      /wait-for -it sim:8546 -t 30
       echo "starting"
       exec /ds-node
     environment:
@@ -59,8 +41,6 @@ services:
       SEQUENCER_PRIVATE_KEY: "095a37ef5b5d87db7fe50551725cb64804c8c554868d3d729c0dd17f0e664c87"
       SEQUENCER_PROVIDER_URL_HTTP: "http://contracts:8545"
       SEQUENCER_PROVIDER_URL_WS: "ws://contracts:8545"
-      SIMULATION_PROVIDER_URL_HTTP: "http://sim:8546"
-      SIMULATION_PROVIDER_URL_WS: "ws://sim:8546"
       INDEXER_WATCH_PENDING: "false"
       INDEXER_PROVIDER_URL_HTTP: "http://contracts:8545"
       INDEXER_PROVIDER_URL_WS: "ws://contracts:8545"
@@ -68,6 +48,5 @@ services:
       - 8080:8080
     depends_on:
       - contracts
-      - sim
 
 

--- a/frontend/src/contexts/block-time-provider.tsx
+++ b/frontend/src/contexts/block-time-provider.tsx
@@ -16,7 +16,7 @@ export const BlockTimeContext = createContext<BlockTimeContextStore>({} as Block
 
 export const useBlockTime = () => useContext(BlockTimeContext);
 
-const BLOCK_TIME_SECS = 10;
+const BLOCK_TIME_SECS = 2;
 
 export const BlockTimeProvider = ({ block, children }: BlockTimeContextProviderProps) => {
     const lastBlockRef = useRef<number>(0);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -161,7 +161,7 @@ async function main({
                 `--ws-endpoint ${servicesWS}/query`,
                 `--http-endpoint ${servicesURL}/query`,
                 `-k ${deployerPrivateKey}`,
-                `apply -R -f ./contracts/src/fixtures --slow`
+                `apply -R -f ./contracts/src/fixtures`
             ].join(' '), {
                 stdio: 'inherit'
             })


### PR DESCRIPTION
## what

* pins to version of cog that doesn't use action simulation
* updates deployment config to disable simulation
* brings local dev inline with 2s block time so it is representative of testnet
* fixes issues with `ds apply` so that it correctly applies manifests in order without --slow or --batch=1
* sends separate calls of `player.dispatch(...)` in parallel to avoid blocking (await still waits for commit as before)

## why

* The simulation feature was designed to work with a slower block time than the bundling time (ie to make a 10-15s commit time feel like a 1s commit time). We are now running on a 2s commit time, and the simulation stuff as currently designed is not playing nicely and making things unstable.
* There appears to be an issue where the websocket connection fails frequently when forked off the L2 chain... reconnecting and recovering from this failure takes extra time and when occurs means everything stalls to stay in sync ... this is probably a result of network connectivity to the L2 node, ideally we would run a follower node in the same place as the indexer... but that is out of scope so this is quite a hard blocker on fixing this right now

## impact

* 😞 Things are gonna feel a little slower again (response time in the ~2-4s range rather than ~1-2s)
* 😃 Things should be stable again
* 😃 That annoyingly long wait after login is gone
* 😃 fixes: #528 