### PR TITLE
Base item rename

### DIFF
--- a/cli/test/examples/manifest.yaml
+++ b/cli/test/examples/manifest.yaml
@@ -19,18 +19,18 @@ spec:
   plugin:
     file: ./Building.js
   materials:
-  - name: Glass of Green Goo
+  - name: Green Goo
     quantity: 25
-  - name: Flask of Red Goo
+  - name: Red Goo
     quantity: 25
-  - name: Beaker of Blue Goo
+  - name: Blue Goo
     quantity: 25
   inputs:
-  - name: Glass of Green Goo
+  - name: Green Goo
     quantity: 2
-  - name: Beaker of Blue Goo
+  - name: Blue Goo
     quantity: 2
-  - name: Flask of Red Goo
+  - name: Red Goo
     quantity: 2
   outputs:
   outputs:

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -128,15 +128,9 @@ contract DownstreamGame is BaseGame {
         _registerDispatcher(dispatcher);
 
         // register base resources used by temp scouting
-        dispatcher.dispatch(
-            abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.GlassGreenGoo(), "Glass of Green Goo", "22-27"))
-        );
-        dispatcher.dispatch(
-            abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.BeakerBlueGoo(), "Beaker of Blue Goo", "22-142"))
-        );
-        dispatcher.dispatch(
-            abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.FlaskRedGoo(), "Flask of Red Goo", "22-24"))
-        );
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.GreenGoo(), "Green Goo", "22-27")));
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.BlueGoo(), "Blue Goo", "22-142")));
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.RedGoo(), "Red Goo", "22-24")));
     }
 
     function allow(address addr) public {

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -128,9 +128,9 @@ contract DownstreamGame is BaseGame {
         _registerDispatcher(dispatcher);
 
         // register base resources used by temp scouting
-        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.GreenGoo(), "Green Goo", "22-27")));
-        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.BlueGoo(), "Blue Goo", "22-142")));
-        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.RedGoo(), "Red Goo", "22-24")));
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.GreenGoo(), "Green Goo", "15-185")));
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.BlueGoo(), "Blue Goo", "32-96")));
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.RedGoo(), "Red Goo", "22-256")));
     }
 
     function allow(address addr) public {

--- a/contracts/src/fixtures/cocktails/manifest.yaml
+++ b/contracts/src/fixtures/cocktails/manifest.yaml
@@ -28,9 +28,9 @@ spec:
       quantity: 25
   inputs:
     - name: Blue Goo
-      quantity: 2
+      quantity: 4
     - name: Red Goo
-      quantity: 2
+      quantity: 4
   outputs:
     - name: Cocktail
       quantity: 1

--- a/contracts/src/fixtures/cocktails/manifest.yaml
+++ b/contracts/src/fixtures/cocktails/manifest.yaml
@@ -20,17 +20,17 @@ spec:
   plugin:
     file: ./CocktailHut.js
   materials:
-  - name: Glass of Green Goo
-    quantity: 25
-  - name: Beaker of Blue Goo
-    quantity: 25
-  - name: Flask of Red Goo
-    quantity: 25
+    - name: Green Goo
+      quantity: 25
+    - name: Blue Goo
+      quantity: 25
+    - name: Red Goo
+      quantity: 25
   inputs:
-  - name: Beaker of Blue Goo
-    quantity: 2
-  - name: Flask of Red Goo
-    quantity: 2
+    - name: Blue Goo
+      quantity: 2
+    - name: Red Goo
+      quantity: 2
   outputs:
-  - name: Cocktail
-    quantity: 1
+    - name: Cocktail
+      quantity: 1

--- a/contracts/src/fixtures/extractors/BlueExtractor.yaml
+++ b/contracts/src/fixtures/extractors/BlueExtractor.yaml
@@ -9,12 +9,12 @@ spec:
   plugin:
     file: ./GenericExtractor.js
   materials:
-    - name: Glass of Green Goo
+    - name: Green Goo
       quantity: 25
-    - name: Beaker of Blue Goo
+    - name: Blue Goo
       quantity: 25
-    - name: Flask of Red Goo
+    - name: Red Goo
       quantity: 25
   outputs:
-    - name: Beaker of Blue Goo
+    - name: Blue Goo
       quantity: 1

--- a/contracts/src/fixtures/extractors/GreenExtractor.yaml
+++ b/contracts/src/fixtures/extractors/GreenExtractor.yaml
@@ -9,12 +9,12 @@ spec:
   plugin:
     file: ./GenericExtractor.js
   materials:
-    - name: Glass of Green Goo
+    - name: Green Goo
       quantity: 25
-    - name: Beaker of Blue Goo
+    - name: Blue Goo
       quantity: 25
-    - name: Flask of Red Goo
+    - name: Red Goo
       quantity: 25
   outputs:
-    - name: Glass of Green Goo
+    - name: Green Goo
       quantity: 1

--- a/contracts/src/fixtures/extractors/RedExtractor.yaml
+++ b/contracts/src/fixtures/extractors/RedExtractor.yaml
@@ -9,12 +9,12 @@ spec:
   plugin:
     file: ./GenericExtractor.js
   materials:
-    - name: Glass of Green Goo
+    - name: Green Goo
       quantity: 25
-    - name: Beaker of Blue Goo
+    - name: Blue Goo
       quantity: 25
-    - name: Flask of Red Goo
+    - name: Red Goo
       quantity: 25
   outputs:
-    - name: Flask of Red Goo
+    - name: Red Goo
       quantity: 1

--- a/contracts/src/fixtures/the-great-cleanup/BadmintonArmour.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/BadmintonArmour.yaml
@@ -9,21 +9,21 @@ spec:
   plugin:
     file: ./BadmintonArmour.js
   materials:
-  - name: Gold Coin
-    quantity: 5
-  - name: Glass of Green Goo
-    quantity: 50
-  - name: Beaker of Blue Goo
-    quantity: 50
-  - name: Flask of Red Goo
-    quantity: 50
+    - name: Gold Coin
+      quantity: 5
+    - name: Green Goo
+      quantity: 50
+    - name: Blue Goo
+      quantity: 50
+    - name: Red Goo
+      quantity: 50
   inputs:
-  - name: Gold Coin
-    quantity: 2
-  - name: Beaker of Blue Goo
-    quantity: 100
-  - name: Beaker of Blue Goo
-    quantity: 100
+    - name: Gold Coin
+      quantity: 2
+    - name: Blue Goo
+      quantity: 100
+    - name: Blue Goo
+      quantity: 100
   outputs:
-  - name: Racket
-    quantity: 1
+    - name: Racket
+      quantity: 1

--- a/contracts/src/fixtures/the-great-cleanup/BadmintonArmour.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/BadmintonArmour.yaml
@@ -11,18 +11,18 @@ spec:
   materials:
     - name: Gold Coin
       quantity: 5
-    - name: Green Goo
+    - name: Glass of Green Goo
       quantity: 50
-    - name: Blue Goo
+    - name: Beaker of Blue Goo
       quantity: 50
-    - name: Red Goo
+    - name: Flask of Red Goo
       quantity: 50
   inputs:
     - name: Gold Coin
       quantity: 2
-    - name: Blue Goo
+    - name: Beaker of Blue Goo
       quantity: 100
-    - name: Blue Goo
+    - name: Beaker of Blue Goo
       quantity: 100
   outputs:
     - name: Racket

--- a/contracts/src/fixtures/the-great-cleanup/BadmintonWeapons.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/BadmintonWeapons.yaml
@@ -11,18 +11,18 @@ spec:
   materials:
     - name: Gold Coin
       quantity: 5
-    - name: Green Goo
+    - name: Glass of Green Goo
       quantity: 50
-    - name: Blue Goo
+    - name: Beaker of Blue Goo
       quantity: 50
-    - name: Red Goo
+    - name: Flask of Red Goo
       quantity: 50
   inputs:
     - name: Gold Coin
       quantity: 2
-    - name: Red Goo
+    - name: Flask of Red Goo
       quantity: 100
-    - name: Red Goo
+    - name: Flask of Red Goo
       quantity: 100
   outputs:
     - name: Shuttlecock

--- a/contracts/src/fixtures/the-great-cleanup/BadmintonWeapons.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/BadmintonWeapons.yaml
@@ -9,21 +9,21 @@ spec:
   plugin:
     file: ./BadmintonWeapons.js
   materials:
-  - name: Gold Coin
-    quantity: 5
-  - name: Glass of Green Goo
-    quantity: 50
-  - name: Beaker of Blue Goo
-    quantity: 50
-  - name: Flask of Red Goo
-    quantity: 50
+    - name: Gold Coin
+      quantity: 5
+    - name: Green Goo
+      quantity: 50
+    - name: Blue Goo
+      quantity: 50
+    - name: Red Goo
+      quantity: 50
   inputs:
-  - name: Gold Coin
-    quantity: 2
-  - name: Flask of Red Goo
-    quantity: 100
-  - name: Flask of Red Goo
-    quantity: 100
+    - name: Gold Coin
+      quantity: 2
+    - name: Red Goo
+      quantity: 100
+    - name: Red Goo
+      quantity: 100
   outputs:
-  - name: Shuttlecock
-    quantity: 1
+    - name: Shuttlecock
+      quantity: 1

--- a/contracts/src/fixtures/the-great-cleanup/Bottler.js
+++ b/contracts/src/fixtures/the-great-cleanup/Bottler.js
@@ -1,0 +1,69 @@
+import ds from "downstream";
+
+export default function update({ selected, world }) {
+    const { tiles, mobileUnit } = selected || {};
+    const selectedTile = tiles && tiles.length === 1 ? tiles[0] : undefined;
+    const selectedBuilding = selectedTile?.building;
+    const selectedEngineer = mobileUnit;
+
+    // fetch the expected inputs item kinds
+    const requiredInputs = selectedBuilding?.kind?.inputs || [];
+    const want0 = requiredInputs.find((inp) => inp.key == 0);
+
+    // fetch what is currently in the input slots
+    const inputSlots =
+        selectedBuilding?.bags.find((b) => b.key == 0).bag?.slots || [];
+    const got0 = inputSlots?.find((slot) => slot.key == 0);
+
+    // fetch our output item details
+    const expectedOutputs = selectedBuilding?.kind?.outputs || [];
+    const out0 = expectedOutputs?.find((slot) => slot.key == 0);
+
+    // try to detect if the input slots contain enough stuff to craft
+    const canCraft =
+        selectedEngineer && want0 && got0 && want0.balance == got0.balance;
+
+    const craft = () => {
+        if (!selectedEngineer) {
+            ds.log("no selected engineer");
+            return;
+        }
+        if (!selectedBuilding) {
+            ds.log("no selected building");
+            return;
+        }
+
+        ds.dispatch({
+            name: "BUILDING_USE",
+            args: [selectedBuilding.id, selectedEngineer.id, []],
+        });
+
+        ds.log("A prescient rubber item manufacturer.");
+    };
+
+    return {
+        version: 1,
+        components: [
+            {
+                type: "building",
+                id: "foul-fiends",
+                title: `${want0.item.name.value} Bottler`,
+                summary: `We can take your ${want0.item.name.value} and bottle it`,
+                content: [
+                    {
+                        id: "default",
+                        type: "inline",
+                        buttons: [
+                            {
+                                text: "Bottle it",
+                                type: "action",
+                                action: craft,
+                                disabled: !canCraft,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/contracts/src/fixtures/the-great-cleanup/BottlerBlue.sol
+++ b/contracts/src/fixtures/the-great-cleanup/BottlerBlue.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+contract BottlerBlue is BuildingKind {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }
+}

--- a/contracts/src/fixtures/the-great-cleanup/BottlerGreen.sol
+++ b/contracts/src/fixtures/the-great-cleanup/BottlerGreen.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+contract BottlerGreen is BuildingKind {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }
+}

--- a/contracts/src/fixtures/the-great-cleanup/BottlerRed.sol
+++ b/contracts/src/fixtures/the-great-cleanup/BottlerRed.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+contract BottlerRed is BuildingKind {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }
+}

--- a/contracts/src/fixtures/the-great-cleanup/Bottlers.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/Bottlers.yaml
@@ -1,0 +1,71 @@
+---
+kind: BuildingKind
+spec:
+  name: Green Goo Bottler
+  category: factory
+  model: 01-00
+  contract:
+    file: ./BottlerGreen.sol
+  plugin:
+    file: ./Bottler.js
+  materials:
+    - name: Green Goo
+      quantity: 25
+    - name: Blue Goo
+      quantity: 25
+    - name: Red Goo
+      quantity: 25
+  inputs:
+    - name: Green Goo
+      quantity: 100
+  outputs:
+    - name: Glass of Green Goo
+      quantity: 25
+
+---
+kind: BuildingKind
+spec:
+  name: Blue Goo Bottler
+  category: factory
+  model: 01-01
+  contract:
+    file: ./BottlerBlue.sol
+  plugin:
+    file: ./Bottler.js
+  materials:
+    - name: Green Goo
+      quantity: 25
+    - name: Blue Goo
+      quantity: 25
+    - name: Red Goo
+      quantity: 25
+  inputs:
+    - name: Blue Goo
+      quantity: 100
+  outputs:
+    - name: Beaker of Blue Goo
+      quantity: 25
+
+---
+kind: BuildingKind
+spec:
+  name: Red Goo Bottler
+  category: factory
+  model: 01-02
+  contract:
+    file: ./BottlerRed.sol
+  plugin:
+    file: ./Bottler.js
+  materials:
+    - name: Green Goo
+      quantity: 25
+    - name: Blue Goo
+      quantity: 25
+    - name: Red Goo
+      quantity: 25
+  inputs:
+    - name: Red Goo
+      quantity: 100
+  outputs:
+    - name: Flask of Red Goo
+      quantity: 25

--- a/contracts/src/fixtures/the-great-cleanup/CrazyHermit.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/CrazyHermit.yaml
@@ -14,7 +14,7 @@ spec:
   inputs:
     - name: Really Green Goo
       quantity: 1
-    - name: Green Goo
+    - name: Glass of Green Goo
       quantity: 1
     - name: Vibrant Green Goo
       quantity: 1

--- a/contracts/src/fixtures/the-great-cleanup/CrazyHermit.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/CrazyHermit.yaml
@@ -9,16 +9,15 @@ spec:
   plugin:
     file: ./CrazyHermit.js
   materials:
-  - name: L33t Bricks
-    quantity: 100
+    - name: L33t Bricks
+      quantity: 100
   inputs:
-  - name: Really Green Goo
-    quantity: 1
-  - name: Glass of Green Goo
-    quantity: 1
-  - name: Vibrant Green Goo
-    quantity: 1
+    - name: Really Green Goo
+      quantity: 1
+    - name: Green Goo
+      quantity: 1
+    - name: Vibrant Green Goo
+      quantity: 1
   outputs:
-  - name: Dismembered Hand
-    quantity: 1
-
+    - name: Dismembered Hand
+      quantity: 1

--- a/contracts/src/fixtures/the-great-cleanup/FoulFiends.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/FoulFiends.yaml
@@ -9,12 +9,11 @@ spec:
   plugin:
     file: ./FoulFiends.js
   materials:
-  - name: L33t Bricks
-    quantity: 100
+    - name: L33t Bricks
+      quantity: 100
   inputs:
-  - name: Flask of Red Goo
-    quantity: 100
+    - name: Red Goo
+      quantity: 100
   outputs:
-  - name: Smelly Duck
-    quantity: 1
-
+    - name: Smelly Duck
+      quantity: 1

--- a/contracts/src/fixtures/the-great-cleanup/FoulFiends.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/FoulFiends.yaml
@@ -12,7 +12,7 @@ spec:
     - name: L33t Bricks
       quantity: 100
   inputs:
-    - name: Red Goo
+    - name: Flask of Red Goo
       quantity: 100
   outputs:
     - name: Smelly Duck

--- a/contracts/src/fixtures/the-great-cleanup/GreenGooFission.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/GreenGooFission.yaml
@@ -12,7 +12,7 @@ spec:
     - name: L33t Bricks
       quantity: 100
   inputs:
-    - name: Green Goo
+    - name: Glass of Green Goo
       quantity: 100
   outputs:
     - name: Vibrant Green Goo

--- a/contracts/src/fixtures/the-great-cleanup/GreenGooFission.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/GreenGooFission.yaml
@@ -9,12 +9,11 @@ spec:
   plugin:
     file: ./GreenGooFission.js
   materials:
-  - name: L33t Bricks
-    quantity: 100
+    - name: L33t Bricks
+      quantity: 100
   inputs:
-  - name: Glass of Green Goo
-    quantity: 100
+    - name: Green Goo
+      quantity: 100
   outputs:
-  - name: Vibrant Green Goo
-    quantity: 5
-
+    - name: Vibrant Green Goo
+      quantity: 5

--- a/contracts/src/fixtures/the-great-cleanup/KwikTyre.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/KwikTyre.yaml
@@ -9,13 +9,13 @@ spec:
   plugin:
     file: ./KwikTyre.js
   materials:
-  - name: L33t Bricks
-    quantity: 100
+    - name: L33t Bricks
+      quantity: 100
   inputs:
-  - name: Glass of Green Goo
-    quantity: 100
-  - name: Beaker of Blue Goo
-    quantity: 100
+    - name: Green Goo
+      quantity: 100
+    - name: Blue Goo
+      quantity: 100
   outputs:
-  - name: Budget Tyre
-    quantity: 1
+    - name: Budget Tyre
+      quantity: 1

--- a/contracts/src/fixtures/the-great-cleanup/KwikTyre.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/KwikTyre.yaml
@@ -12,9 +12,9 @@ spec:
     - name: L33t Bricks
       quantity: 100
   inputs:
-    - name: Green Goo
+    - name: Glass of Green Goo
       quantity: 100
-    - name: Blue Goo
+    - name: Beaker of Blue Goo
       quantity: 100
   outputs:
     - name: Budget Tyre

--- a/contracts/src/fixtures/the-great-cleanup/items.yaml
+++ b/contracts/src/fixtures/the-great-cleanup/items.yaml
@@ -1,6 +1,39 @@
 ---
 kind: Item
 spec:
+  name: Glass of Green Goo
+  icon: 22-27
+  goo:
+    red: 0
+    green: 2
+    blue: 0
+  stackable: true
+
+---
+kind: Item
+spec:
+  name: Beaker of Blue Goo
+  icon: 22-142
+  goo:
+    red: 0
+    green: 0
+    blue: 2
+  stackable: true
+
+---
+kind: Item
+spec:
+  name: Flask of Red Goo
+  icon: 22-24
+  goo:
+    red: 2
+    green: 0
+    blue: 0
+  stackable: true
+
+---
+kind: Item
+spec:
   name: L33t Bricks
   icon: 07-191
   goo:

--- a/contracts/src/rules/ScoutRule.sol
+++ b/contracts/src/rules/ScoutRule.sol
@@ -162,11 +162,11 @@ contract ScoutRule is Rule {
         _resourceSpawnCount++;
         uint256 n = _resourceSpawnCount % 3;
         if (n == 0) {
-            return ItemUtils.GlassGreenGoo();
+            return ItemUtils.GreenGoo();
         } else if (n == 1) {
-            return ItemUtils.BeakerBlueGoo();
+            return ItemUtils.BlueGoo();
         } else {
-            return ItemUtils.FlaskRedGoo();
+            return ItemUtils.RedGoo();
         }
     }
 }

--- a/contracts/src/utils/ItemUtils.sol
+++ b/contracts/src/utils/ItemUtils.sol
@@ -23,16 +23,16 @@ library ItemUtils {
     // these should not really be special, they are simply
     // how we seed the world with atoms at the moment by
     // dropping these per-atom resources in bags during scout
-    function GlassGreenGoo() internal pure returns (bytes24) {
-        return Node.Item("Glass of Green Goo", [uint32(2), uint32(0), uint32(0)], true);
+    function GreenGoo() internal pure returns (bytes24) {
+        return Node.Item("Green Goo", [uint32(1), uint32(0), uint32(0)], true);
     }
 
-    function BeakerBlueGoo() internal pure returns (bytes24) {
-        return Node.Item("Beaker of Blue Goo", [uint32(0), uint32(2), uint32(0)], true);
+    function BlueGoo() internal pure returns (bytes24) {
+        return Node.Item("Blue Goo", [uint32(0), uint32(1), uint32(0)], true);
     }
 
-    function FlaskRedGoo() internal pure returns (bytes24) {
-        return Node.Item("Flask of Red Goo", [uint32(0), uint32(0), uint32(2)], true);
+    function RedGoo() internal pure returns (bytes24) {
+        return Node.Item("Red Goo", [uint32(0), uint32(0), uint32(1)], true);
     }
 
     // register is a helper to declare a new kind of item

--- a/contracts/test/helpers/GameTest.sol
+++ b/contracts/test/helpers/GameTest.sol
@@ -38,9 +38,9 @@ contract Dev {
 
     function spawnFullBag(address owner, bytes24 equipNode, uint8 equipSlot) public returns (bytes24) {
         bytes24[] memory items = new bytes24[](3);
-        items[0] = ItemUtils.GlassGreenGoo();
-        items[1] = ItemUtils.BeakerBlueGoo();
-        items[2] = ItemUtils.FlaskRedGoo();
+        items[0] = ItemUtils.GreenGoo();
+        items[1] = ItemUtils.BlueGoo();
+        items[2] = ItemUtils.RedGoo();
 
         uint64[] memory balances = new uint64[](3);
         balances[0] = 100;

--- a/contracts/test/rules/BagRule.t.sol
+++ b/contracts/test/rules/BagRule.t.sol
@@ -25,9 +25,9 @@ contract BagRuleTest is Test, GameTest {
         dev.spawnTile(0, 0, 0);
         dev.spawnTile(1, -1, 0);
         // setup default material construction costs
-        defaultMaterialItem[0] = ItemUtils.GlassGreenGoo();
-        defaultMaterialItem[1] = ItemUtils.BeakerBlueGoo();
-        defaultMaterialItem[2] = ItemUtils.FlaskRedGoo();
+        defaultMaterialItem[0] = ItemUtils.GreenGoo();
+        defaultMaterialItem[1] = ItemUtils.BlueGoo();
+        defaultMaterialItem[2] = ItemUtils.RedGoo();
         defaultMaterialQty[0] = 25;
         defaultMaterialQty[1] = 25;
         defaultMaterialQty[2] = 25;

--- a/contracts/test/rules/BuildingRule.t.sol
+++ b/contracts/test/rules/BuildingRule.t.sol
@@ -16,9 +16,9 @@ contract BuildingRuleTest is Test, GameTest {
 
     function setUp() public {
         // setup default material construction costs
-        defaultMaterialItem[0] = ItemUtils.GlassGreenGoo();
-        defaultMaterialItem[1] = ItemUtils.BeakerBlueGoo();
-        defaultMaterialItem[2] = ItemUtils.FlaskRedGoo();
+        defaultMaterialItem[0] = ItemUtils.GreenGoo();
+        defaultMaterialItem[1] = ItemUtils.BlueGoo();
+        defaultMaterialItem[2] = ItemUtils.RedGoo();
         defaultMaterialQty[0] = 25;
         defaultMaterialQty[1] = 25;
         defaultMaterialQty[2] = 25;
@@ -291,9 +291,9 @@ contract BuildingRuleTest is Test, GameTest {
         bytes24 buildingInstance = Node.Building(DEFAULT_ZONE, q, r, s);
         bytes24 buildingBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance)))));
         state.setEquipSlot(buildingInstance, 0, buildingBag);
-        state.setItemSlot(buildingBag, 0, ItemUtils.GlassGreenGoo(), 100);
-        state.setItemSlot(buildingBag, 1, ItemUtils.BeakerBlueGoo(), 100);
-        state.setItemSlot(buildingBag, 2, ItemUtils.FlaskRedGoo(), 100);
+        state.setItemSlot(buildingBag, 0, ItemUtils.GreenGoo(), 100);
+        state.setItemSlot(buildingBag, 1, ItemUtils.BlueGoo(), 100);
+        state.setItemSlot(buildingBag, 2, ItemUtils.RedGoo(), 100);
         // construct our building
         vm.expectRevert("BuildingMustBeAdjacentToMobileUnit"); // expect fail as q/r/s not adjacent
         dispatcher.dispatch(abi.encodeCall(Actions.CONSTRUCT_BUILDING_MOBILE_UNIT, (mobileUnit, buildingKind, q, r, s)));

--- a/contracts/test/rules/CombatRule.t.sol
+++ b/contracts/test/rules/CombatRule.t.sol
@@ -44,9 +44,9 @@ contract CombatRuleTest is Test, GameTest {
         vm.stopPrank();
 
         // setup default material construction costs
-        defaultMaterialItem[0] = ItemUtils.GlassGreenGoo();
-        defaultMaterialItem[1] = ItemUtils.BeakerBlueGoo();
-        defaultMaterialItem[2] = ItemUtils.FlaskRedGoo();
+        defaultMaterialItem[0] = ItemUtils.GreenGoo();
+        defaultMaterialItem[1] = ItemUtils.BlueGoo();
+        defaultMaterialItem[2] = ItemUtils.RedGoo();
         defaultMaterialQty[0] = 25;
         defaultMaterialQty[1] = 25;
         defaultMaterialQty[2] = 25;

--- a/contracts/test/rules/CraftingRule.t.sol
+++ b/contracts/test/rules/CraftingRule.t.sol
@@ -39,9 +39,9 @@ contract CraftingRuleTest is Test, GameTest {
     }
 
     function testResources() public {
-        assertEq(state.getAtoms(ItemUtils.GlassGreenGoo())[GOO_GREEN], 2);
-        assertEq(state.getAtoms(ItemUtils.BeakerBlueGoo())[GOO_BLUE], 2);
-        assertEq(state.getAtoms(ItemUtils.FlaskRedGoo())[GOO_RED], 2);
+        assertEq(state.getAtoms(ItemUtils.GreenGoo())[GOO_GREEN], 1);
+        assertEq(state.getAtoms(ItemUtils.BlueGoo())[GOO_BLUE], 1);
+        assertEq(state.getAtoms(ItemUtils.RedGoo())[GOO_RED], 1);
     }
 
     function testGetAtoms() public {
@@ -240,9 +240,9 @@ contract CraftingRuleTest is Test, GameTest {
         )
     {
         // Input
-        inputItemIDs[0] = ItemUtils.GlassGreenGoo();
-        inputItemIDs[1] = ItemUtils.BeakerBlueGoo();
-        inputItemIDs[2] = ItemUtils.FlaskRedGoo();
+        inputItemIDs[0] = ItemUtils.GreenGoo();
+        inputItemIDs[1] = ItemUtils.BlueGoo();
+        inputItemIDs[2] = ItemUtils.RedGoo();
         inputQtys[0] = 2;
         inputQtys[1] = 2;
         inputQtys[2] = 2;
@@ -255,9 +255,9 @@ contract CraftingRuleTest is Test, GameTest {
 
     function _registerBuildingKind(uint32 uid, address buildingContract) private returns (bytes24) {
         bytes24[4] memory defaultMaterialItem;
-        defaultMaterialItem[0] = ItemUtils.GlassGreenGoo();
-        defaultMaterialItem[1] = ItemUtils.BeakerBlueGoo();
-        defaultMaterialItem[2] = ItemUtils.FlaskRedGoo();
+        defaultMaterialItem[0] = ItemUtils.GreenGoo();
+        defaultMaterialItem[1] = ItemUtils.BlueGoo();
+        defaultMaterialItem[2] = ItemUtils.RedGoo();
         uint64[4] memory defaultMaterialQty;
         defaultMaterialQty[0] = 25;
         defaultMaterialQty[1] = 25;
@@ -308,9 +308,9 @@ contract CraftingRuleTest is Test, GameTest {
         // magic 100 items into the construct slot
         bytes24 inputBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance)))));
         state.setEquipSlot(buildingInstance, 0, inputBag);
-        state.setItemSlot(inputBag, 0, ItemUtils.GlassGreenGoo(), 25);
-        state.setItemSlot(inputBag, 1, ItemUtils.BeakerBlueGoo(), 25);
-        state.setItemSlot(inputBag, 2, ItemUtils.FlaskRedGoo(), 25);
+        state.setItemSlot(inputBag, 0, ItemUtils.GreenGoo(), 25);
+        state.setItemSlot(inputBag, 1, ItemUtils.BlueGoo(), 25);
+        state.setItemSlot(inputBag, 2, ItemUtils.RedGoo(), 25);
         // construct our building
         dispatcher.dispatch(abi.encodeCall(Actions.CONSTRUCT_BUILDING_MOBILE_UNIT, (mobileUnit, buildingKind, q, r, s)));
         return buildingInstance;

--- a/contracts/test/rules/ExtractionRule.t.sol
+++ b/contracts/test/rules/ExtractionRule.t.sol
@@ -129,9 +129,9 @@ contract ExtractionRuleTest is Test, GameTest {
 
     function _registerBuildingKind(uint32 uid, address buildingContract) private returns (bytes24) {
         bytes24[4] memory defaultMaterialItem;
-        defaultMaterialItem[0] = ItemUtils.GlassGreenGoo();
-        defaultMaterialItem[1] = ItemUtils.BeakerBlueGoo();
-        defaultMaterialItem[2] = ItemUtils.FlaskRedGoo();
+        defaultMaterialItem[0] = ItemUtils.GreenGoo();
+        defaultMaterialItem[1] = ItemUtils.BlueGoo();
+        defaultMaterialItem[2] = ItemUtils.RedGoo();
         uint64[4] memory defaultMaterialQty;
         defaultMaterialQty[0] = 25;
         defaultMaterialQty[1] = 25;
@@ -141,7 +141,7 @@ contract ExtractionRuleTest is Test, GameTest {
 
         bytes24[MAX_CRAFT_INPUT_ITEMS] memory inputItemIDs;
         uint64[MAX_CRAFT_INPUT_ITEMS] memory inputQtys;
-        bytes24 outputItem = ItemUtils.GlassGreenGoo();
+        bytes24 outputItem = ItemUtils.GreenGoo();
         uint64 outputQty = 10; // How many we can make in one extraction
 
         dispatcher.dispatch(
@@ -175,9 +175,9 @@ contract ExtractionRuleTest is Test, GameTest {
         // magic 100 items into the construct slot
         bytes24 inputBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance)))));
         state.setEquipSlot(buildingInstance, 0, inputBag);
-        state.setItemSlot(inputBag, 0, ItemUtils.GlassGreenGoo(), 25);
-        state.setItemSlot(inputBag, 1, ItemUtils.BeakerBlueGoo(), 25);
-        state.setItemSlot(inputBag, 2, ItemUtils.FlaskRedGoo(), 25);
+        state.setItemSlot(inputBag, 0, ItemUtils.GreenGoo(), 25);
+        state.setItemSlot(inputBag, 1, ItemUtils.BlueGoo(), 25);
+        state.setItemSlot(inputBag, 2, ItemUtils.RedGoo(), 25);
         // construct our building
         dispatcher.dispatch(abi.encodeCall(Actions.CONSTRUCT_BUILDING_MOBILE_UNIT, (mobileUnit, buildingKind, q, r, s)));
         return buildingInstance;

--- a/contracts/test/rules/InventoryRule.t.sol
+++ b/contracts/test/rules/InventoryRule.t.sol
@@ -222,7 +222,7 @@ contract InventoryRuleTest is Test, GameTest {
         (bytes24 toResourceBefore, uint64 toBalanceBefore) = state.getItemSlot(toBag, ITEM_SLOT_0);
         assertEq(
             fromResourceBefore,
-            ItemUtils.GlassGreenGoo(),
+            ItemUtils.GreenGoo(),
             "expected mobileUnit1-equip0-bag-item0 (from) resource to be wood before xfer"
         );
         assertEq(toResourceBefore, 0x0, "expected mobileUnit1-equip1-bag-item0 (to) resource to be unset before xfer");
@@ -262,7 +262,7 @@ contract InventoryRuleTest is Test, GameTest {
         (bytes24 toResourceBefore, uint64 toBalanceBefore) = state.getItemSlot(toBag, ITEM_SLOT_0);
         assertEq(
             fromResourceBefore,
-            ItemUtils.GlassGreenGoo(),
+            ItemUtils.GreenGoo(),
             "expected mobileUnit1-equip0-bag-item0 (from) resource to be wood before xfer"
         );
         assertEq(toResourceBefore, 0x0, "expected mobileUnit1-equip1-bag-item0 (to) resource to be unset before xfer");
@@ -287,12 +287,12 @@ contract InventoryRuleTest is Test, GameTest {
         (bytes24 toResourceAfter, uint64 toBalanceAfter) = state.getItemSlot(toBag, itemSlots[1]);
         assertEq(
             fromResourceAfter,
-            ItemUtils.GlassGreenGoo(),
+            ItemUtils.GreenGoo(),
             "expected mobileUnit1-equip0-bag-item0 resource to be wood after xfer"
         );
         assertEq(
             toResourceAfter,
-            ItemUtils.GlassGreenGoo(),
+            ItemUtils.GreenGoo(),
             "expected mobileUnit1-equip1-bag-item0 resource to be wood after xfer"
         );
         assertEq(fromBalanceAfter, 50, "expected mobileUnit1-equip1-bag-item0 balance to decrease to 50 after xfer");
@@ -316,7 +316,7 @@ contract InventoryRuleTest is Test, GameTest {
         (bytes24 toResourceBefore, uint64 toBalanceBefore) = state.getItemSlot(toBag, ITEM_SLOT_0);
         assertEq(
             fromResourceBefore,
-            ItemUtils.GlassGreenGoo(),
+            ItemUtils.GreenGoo(),
             "expected mobileUnit1-equip0-bag-item0 (from) resource to be wood before xfer"
         );
         assertEq(toResourceBefore, 0x0, "expected mobileUnit1-equip1-bag-item0 (to) resource to be unset before xfer");
@@ -342,12 +342,12 @@ contract InventoryRuleTest is Test, GameTest {
         (bytes24 toResourceAfter, uint64 toBalanceAfter) = state.getItemSlot(toBag, itemSlots[1]);
         assertEq(
             fromResourceAfter,
-            ItemUtils.GlassGreenGoo(),
+            ItemUtils.GreenGoo(),
             "expected mobileUnit1-equip0-bag-item0 resource to be wood after xfer"
         );
         assertEq(
             toResourceAfter,
-            ItemUtils.GlassGreenGoo(),
+            ItemUtils.GreenGoo(),
             "expected mobileUnit1-equip1-bag-item0 resource to be wood after xfer"
         );
         assertEq(fromBalanceAfter, 50, "expected mobileUnit1-equip1-bag-item0 balance to decrease to 50 after xfer");
@@ -356,7 +356,7 @@ contract InventoryRuleTest is Test, GameTest {
 
     function _spawnBagWithWood(address owner, bytes24 equipNode, uint8 equipSlot) private returns (bytes24) {
         bytes24[] memory items = new bytes24[](1);
-        items[0] = ItemUtils.GlassGreenGoo();
+        items[0] = ItemUtils.GreenGoo();
         uint64[] memory balances = new uint64[](1);
         balances[0] = 100;
         return dev.spawnBag(owner, equipNode, equipSlot, items, balances);
@@ -364,7 +364,7 @@ contract InventoryRuleTest is Test, GameTest {
 
     function _spawnBagWithStone(address owner, bytes24 equipNode, uint8 equipSlot) private returns (bytes24) {
         bytes24[] memory items = new bytes24[](1);
-        items[0] = ItemUtils.BeakerBlueGoo();
+        items[0] = ItemUtils.BlueGoo();
         uint64[] memory balances = new uint64[](1);
         balances[0] = 100;
         return dev.spawnBag(owner, equipNode, equipSlot, items, balances);

--- a/contracts/test/rules/PluginRule.t.sol
+++ b/contracts/test/rules/PluginRule.t.sol
@@ -31,9 +31,9 @@ contract PluginRuleTest is Test, GameTest {
         // register a building kind
         vm.startPrank(players[0].addr);
         bytes24[4] memory defaultMaterialItem;
-        defaultMaterialItem[0] = ItemUtils.GlassGreenGoo();
-        defaultMaterialItem[1] = ItemUtils.BeakerBlueGoo();
-        defaultMaterialItem[2] = ItemUtils.FlaskRedGoo();
+        defaultMaterialItem[0] = ItemUtils.GreenGoo();
+        defaultMaterialItem[1] = ItemUtils.BlueGoo();
+        defaultMaterialItem[2] = ItemUtils.RedGoo();
         uint64[4] memory defaultMaterialQty;
         defaultMaterialQty[0] = 25;
         defaultMaterialQty[1] = 25;
@@ -91,9 +91,9 @@ contract PluginRuleTest is Test, GameTest {
         vm.startPrank(players[0].addr);
         bytes24 buildingKind = Node.BuildingKind(30);
         bytes24[4] memory defaultMaterialItem;
-        defaultMaterialItem[0] = ItemUtils.GlassGreenGoo();
-        defaultMaterialItem[1] = ItemUtils.BeakerBlueGoo();
-        defaultMaterialItem[2] = ItemUtils.FlaskRedGoo();
+        defaultMaterialItem[0] = ItemUtils.GreenGoo();
+        defaultMaterialItem[1] = ItemUtils.BlueGoo();
+        defaultMaterialItem[2] = ItemUtils.RedGoo();
         uint64[4] memory defaultMaterialQty;
         defaultMaterialQty[0] = 25;
         defaultMaterialQty[1] = 25;

--- a/docs/content/how-to-create-docs/creating-new-items.md
+++ b/docs/content/how-to-create-docs/creating-new-items.md
@@ -4,9 +4,9 @@
 
 All items in Downstream contain goo. There are 3 types of goo:
 
-- Green Goo
-- Blue Goo
-- Red Goo
+-   Green Goo
+-   Blue Goo
+-   Red Goo
 
 When a new item is registered you state its Goo composition. However, these numbers can only by at most half the value of the goo in its input items.
 For example, if its INPUT ingredients contain a total of 10 RED goo and 5 BLUE goo the maximum goo the new item can have is: 5 RED, 2 BLUE, 0 GREEN.
@@ -14,31 +14,32 @@ You are able to register the item with lower values than these, but if you try t
 
 The easiest way to see how many atoms an item has is to hover over it in the inventory. The base resources found in the game contain:
 
-- Glass of Green Goo = 2 GREEN goo
-- Beaker of Blue Goo = 2 BLUE goo
-- Flask of Red Goo = 2 RED goo
+-   Green Goo = 2 GREEN goo
+-   Blue Goo = 2 BLUE goo
+-   Red Goo = 2 RED goo
 
 Creators can choose to use goo however they wish. Downstream uses the goo values in combat where:
-- Green Goo = Life
-- Blue Goo = Defense
-- Red Goo = Attack
+
+-   Green Goo = Life
+-   Blue Goo = Defense
+-   Red Goo = Attack
 
 ## Stackable / Equipable
 
-Items are always one of these. Either they are *********stackable********* or they are **********equipable.**********
+Items are always one of these. Either they are \***\*\*\*\***stackable\***\*\*\*\*** or they are \***\*\*\*\*\***equipable.\***\*\*\*\*\***
 
-- Stackable items can be stacked, so that up to 100 fit into 1 inventory slot. However, although they have atoms these are not taken into account when calculating combat stats
-- Equipable items can not be stacked. Only 1 will fit into 1 slot. These items DO have their atoms taken into account during combat.
+-   Stackable items can be stacked, so that up to 100 fit into 1 inventory slot. However, although they have atoms these are not taken into account when calculating combat stats
+-   Equipable items can not be stacked. Only 1 will fit into 1 slot. These items DO have their atoms taken into account during combat.
 
-As a general rule, stackable items are “resources” whilst equipable items are “gear”. 
+As a general rule, stackable items are “resources” whilst equipable items are “gear”.
 
 ## Item IDs
 
-When you set the crafting items you need to reference their IDs. The easiest way to find these is to go to [https://services-ds-test.dev.playmint.com/](https://services-ds-test.dev.playmint.com/) and run this query: 
+When you set the crafting items you need to reference their IDs. The easiest way to find these is to go to [https://services-ds-test.dev.playmint.com/](https://services-ds-test.dev.playmint.com/) and run this query:
 
 ```jsx
 {
-  game(id: "DOWNSTREAM"){    
+  game(id: "DOWNSTREAM"){
     state {
       items: nodes(match: {kinds: "Item"}) {
         id
@@ -57,4 +58,4 @@ This will show all registered items by ID and name. Note - multiple items can ha
 
 You can choose your item’s icon from a large collection. These are displayed here: [https://assets.downstream.game/icons/sheet.html](https://playmintglobal.z16.web.core.windows.net/icons/sheet.html)
 
-Just put the the “xx-xx” number as the ****icon**** variable.
+Just put the the “xx-xx” number as the \***\*icon\*\*** variable.

--- a/docs/content/how-to-create-docs/creating-new-items.md
+++ b/docs/content/how-to-create-docs/creating-new-items.md
@@ -14,9 +14,9 @@ You are able to register the item with lower values than these, but if you try t
 
 The easiest way to see how many atoms an item has is to hover over it in the inventory. The base resources found in the game contain:
 
--   Green Goo = 2 GREEN goo
--   Blue Goo = 2 BLUE goo
--   Red Goo = 2 RED goo
+-   Green Goo = 1 GREEN goo
+-   Blue Goo = 1 BLUE goo
+-   Red Goo = 1 RED goo
 
 Creators can choose to use goo however they wish. Downstream uses the goo values in combat where:
 

--- a/docs/content/how-to-create-docs/developing-a-new-building.md
+++ b/docs/content/how-to-create-docs/developing-a-new-building.md
@@ -1,15 +1,15 @@
 # Developing a New Building
 
-**Windows users will need to enable WSL for this process** (*[https://learn.microsoft.com/en-us/windows/wsl/install](https://learn.microsoft.com/en-us/windows/wsl/install)*)
+**Windows users will need to enable WSL for this process** (_[https://learn.microsoft.com/en-us/windows/wsl/install](https://learn.microsoft.com/en-us/windows/wsl/install)_)
 
 ## Getting Set Up
 
 1. Install [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) if you don't have it.
 2. Clone this repository: [https://github.com/playmint/ds-hammer-factory](https://github.com/playmint/ds-hammer-factory) with recursive submodules
     > `git clone --recurse-submodules https://github.com/playmint/ds-hammer-factory.git`
-4. This is a forge project. Follow the instructions here to get setup: [install foundry](https://book.getfoundry.sh/getting-started/installation)
+3. This is a forge project. Follow the instructions here to get setup: [install foundry](https://book.getfoundry.sh/getting-started/installation)
     - Mac Users may need to [install "brew" first](https://docs.brew.sh/Installation)
-6. Confirm you are set up correctly by navigating to the ds-hammer-factory folder and running `forge test` from the command line
+4. Confirm you are set up correctly by navigating to the ds-hammer-factory folder and running `forge test` from the command line
    **Note: Windows users will need to be in WSL for all command-line steps.**
 
 ## Creating a Pizzeria
@@ -22,12 +22,14 @@ We’re going to quickly create a new building - a Pizzeria.
 2. Duplicate both of these files and rename the new files to:
     - Pizzeria.js
     - Pizzeria.sol
+
 ### Important - These need to be new files. Don't overwrite the originals.
+
 ### Important 2 - Everything is case-sensitive!
 
 ### Pizzeria.sol
 
-The Pizzeria is a lot like the HammerFactory, but instead of crafting Hammers it will cook Pizzas! 
+The Pizzeria is a lot like the HammerFactory, but instead of crafting Hammers it will cook Pizzas!
 Because of the similar functionality we don’t need to change much in this file.
 
 1. Line 9: Rename the contract to Pizzeria
@@ -43,7 +45,7 @@ The Javascript file describes how the building will be represented in the game -
 1. Line 46: This is the console log that is printed when the building is used. You can put whatever you want here!
 
 ```jsx
-ds.log('Extra pepperoni coming up!');
+ds.log("Extra pepperoni coming up!");
 ```
 
 1. Line 54 & 55: Put in a relevant ID and title. The title will be displayed ingame
@@ -59,7 +61,7 @@ title: 'Paulo\'s Pizzeria',
 summary: `For the best pizza put ${want0?.balance}x ${want0?.item?.name?.value} and ${want1?.balance}x ${want1?.item?.name?.value} into our oven`,
 ```
 
-1. Line 61: This displays the button to “use” the building. 
+1. Line 61: This displays the button to “use” the building.
 
 ```jsx
 buttons: [{ text: 'Cook Pizza', type: 'action', action: craft, disabled: !canCraft }],
@@ -69,12 +71,12 @@ buttons: [{ text: 'Cook Pizza', type: 'action', action: craft, disabled: !canCra
 
 The deployment script will register the building and item to the game, and link them to your building scripts.
 
-1. Navigate to the /script folder and duplicate **********Deploy.sol**********
-2. Rename this new file to ************Deploy_Pizzeria.sol************
+1. Navigate to the /script folder and duplicate \***\*\*\*\*\***Deploy.sol\***\*\*\*\*\***
+2. Rename this new file to \***\*\*\*\*\*\*\***Deploy_Pizzeria.sol\***\*\*\*\*\*\*\***
 
 Open up the file and make the following edits:
 
-1. Line 11: Point the import to the *Pizzeria.sol*
+1. Line 11: Point the import to the _Pizzeria.sol_
 
 ```solidity
 import {Pizzeria} from "../src/Pizzeria.sol";
@@ -92,7 +94,7 @@ console2.log("ItemKind", uint256(bytes32(pizzaItem)));
 console2.log("BuildingKind", uint256(bytes32(pizzeria)));
 ```
 
-1. Lines 70 - 83:  This is where we define the details of the pizza
+1. Lines 70 - 83: This is where we define the details of the pizza
 
 ```solidity
 // register a new item id
@@ -111,7 +113,7 @@ console2.log("BuildingKind", uint256(bytes32(pizzeria)));
     }
 ```
 
-*******************For more information about these details, see the "Creating New Items" guide.*******************
+**\*\*\*\***\*\*\***\*\*\*\***For more information about these details, see the "Creating New Items" guide.**\*\*\*\***\*\*\***\*\*\*\***
 
 1. Lines 85 - 177: Finally we list the details of the Pizzeria.
 
@@ -120,23 +122,23 @@ console2.log("BuildingKind", uint256(bytes32(pizzeria)));
 
         // find the base item ids we will use as inputs for our Pizzeria
         bytes24 none = 0x0;
-        bytes24 glassGreenGoo = ItemUtils.GlassGreenGoo();
-        bytes24 beakerBlueGoo = ItemUtils.BeakerBlueGoo();
-        bytes24 flaskRedGoo = ItemUtils.FlaskRedGoo();
+        bytes24 GreenGoo = ItemUtils.GreenGoo();
+        bytes24 BlueGoo = ItemUtils.BlueGoo();
+        bytes24 RedGoo = ItemUtils.RedGoo();
 
         // register a new building kind
         return BuildingUtils.register(ds, BuildingConfig({
             id: extensionID,
             name: "Paulo\'s Pizzeria",
             materials: [
-                Material({quantity: 10, item: glassGreenGoo}), // these are what it costs to construct the factory
-                Material({quantity: 10, item: beakerBlueGoo}),
-                Material({quantity: 10, item: flaskRedGoo}),
+                Material({quantity: 10, item: GreenGoo}), // these are what it costs to construct the factory
+                Material({quantity: 10, item: BlueGoo}),
+                Material({quantity: 10, item: RedGoo}),
                 Material({quantity: 0, item: none})
             ],
             inputs: [
-                Input({quantity: 10, item: glassGreenGoo}), // these are required inputs to get the output
-                Input({quantity: 6, item: flaskRedGoo}),
+                Input({quantity: 10, item: GreenGoo}), // these are required inputs to get the output
+                Input({quantity: 6, item: RedGoo}),
                 Input({quantity: 0, item: none}),
                 Input({quantity: 0, item: none})
             ],
@@ -172,11 +174,11 @@ To test your new creation you’ll need to place it in the game!
 2. Log on with Metamask
     - Spawn a Unit if you don’t have one already
 3. Find enough construction materials
-    - 10 x Glass of Green Goo
-    - 10 x Beaker of Blue Goo
-    - 10 x Flask of Red Goo 
-5. Select the Build functionality and place your new building on an empty tile
-6. Move your Unit to a tile that is adjacent to your building
-7. Click the building, and click the "USE" button
-8. Add the required items to the crafting panel
-9. Click the “Cook Pizza” button
+    - 10 x Green Goo
+    - 10 x Blue Goo
+    - 10 x Red Goo
+4. Select the Build functionality and place your new building on an empty tile
+5. Move your Unit to a tile that is adjacent to your building
+6. Click the building, and click the "USE" button
+7. Add the required items to the crafting panel
+8. Click the “Cook Pizza” button


### PR DESCRIPTION
# What

Rename of base items so they are simply {color} Goo. 

For the cocktail hut I have doubled the input count so the cocktail contains the same number of atoms as before
For 'The Great Cleanup' instead of refactoring the whole mission, I have registered the old base items (flasks, beakers etc) as items and have added 3 'bottler' factories which can craft those items out of base goo. This is just a stop gap so the mission isn't broken however I'm expecting it to get refactored by Paul at some point when we are happy with extraction rates etc.

I have also changed the icons of the base items to be simple drips. 
1 drip = green
2 drips = blue
3 drips = red

This is so that old original beaker, bask and glass icons can be used by the items registerd for the great cleanup. 

![image](https://github.com/playmint/ds/assets/51167118/c184352c-046e-4dcd-9ff9-d9d71b6c7c4b)

<img width="255" alt="image" src="https://github.com/playmint/ds/assets/51167118/de109922-1b67-4c5e-adc2-d701f0165427">
