### PR TITLE
documentation plumbing

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -63,6 +63,13 @@ const commands = [
         prefixColor: 'blueBright',
     },
 
+    {
+        name: '  docs ',
+        command: 'npm run start',
+        prefixColor: 'blueBright',
+        cwd: path.resolve(__dirname, path.join('docs')),
+    },
+
 ];
 
 // run everything concurrently. if one exits, they all exit.

--- a/.github/workflows/build-exp.yml
+++ b/.github/workflows/build-exp.yml
@@ -11,9 +11,6 @@ jobs:
     with:
       DEPLOYMENT_ENVIRONMENT: exp
       DEPLOYMENT_PRIORITY: default
-      FRONTEND_IMAGE_NAME: playmint/ds-shell
-      CONTRACTS_IMAGE_NAME: playmint/ds-contracts
-      SERVICES_IMAGE_NAME: playmint/ds-services
       PLATFORMS: linux/amd64
     secrets:
       AZURE_REGISTRY_URL: ${{ secrets.AZURE_REGISTRY_URL }}

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -13,9 +13,6 @@ jobs:
     with:
       DEPLOYMENT_ENVIRONMENT: main
       DEPLOYMENT_PRIORITY: default
-      FRONTEND_IMAGE_NAME: playmint/ds-shell
-      CONTRACTS_IMAGE_NAME: playmint/ds-contracts
-      SERVICES_IMAGE_NAME: playmint/ds-services
       PLATFORMS: linux/amd64
     secrets:
       AZURE_REGISTRY_URL: ${{ secrets.AZURE_REGISTRY_URL }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,25 +12,6 @@ on:
         description: priorityClassName for pods
         required: true
         type: string
-      FRONTEND_REPLICAS:
-        description: Number of instances of frontend server
-        default: 1
-        type: number
-      FRONTEND_IMAGE_NAME:
-        description: ghcr image package name for the shell
-        required: true
-        default: playmint/ds-shell
-        type: string
-      CONTRACTS_IMAGE_NAME:
-        description: ghcr image package name for the contracts
-        required: true
-        default: playmint/ds-contracts
-        type: string
-      SERVICES_IMAGE_NAME:
-        description: ghcr image package name for cog services
-        required: true
-        default: playmint/ds-services
-        type: string
       PLATFORMS:
         description: platforms for multiarch images
         required: true
@@ -69,6 +50,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  FRONTEND_IMAGE_NAME: playmint/ds-shell
+  DOCS_IMAGE_NAME: playmint/ds-docs
+  CONTRACTS_IMAGE_NAME: playmint/ds-contracts
+  SERVICES_IMAGE_NAME: playmint/ds-services
 
 jobs:
 
@@ -127,11 +112,11 @@ jobs:
       id: meta
       uses: docker/metadata-action@v4
       with:
-        images: ${{ env.REGISTRY }}/${{ inputs.FRONTEND_IMAGE_NAME }}
+        images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
     - name: Finalize Docker Metadata
       id: docker_tagging
       run: |
-          echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ inputs.FRONTEND_IMAGE_NAME }}:${GITHUB_SHA}"
+          echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${GITHUB_SHA}"
     - name: Inspect Docker Metadata
       run: |
         echo "TAGS -> ${{ steps.docker_tagging.outputs.docker_tags }}"
@@ -141,6 +126,56 @@ jobs:
       with:
         context: .
         file: frontend/Dockerfile
+        push: true
+        tags: ${{ steps.docker_tagging.outputs.docker_tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: ${{ inputs.PLATFORMS }}
+        build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: 'arm64,arm'
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Log into registry ${{ env.REGISTRY }}
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.DOCS_IMAGE_NAME }}
+    - name: Finalize Docker Metadata
+      id: docker_tagging
+      run: |
+          echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.DOCS_IMAGE_NAME }}:${GITHUB_SHA}"
+    - name: Inspect Docker Metadata
+      run: |
+        echo "TAGS -> ${{ steps.docker_tagging.outputs.docker_tags }}"
+        echo "LABELS ->  ${{ steps.meta.outputs.labels }}"
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: docs/Dockerfile
         push: true
         tags: ${{ steps.docker_tagging.outputs.docker_tags }}
         labels: ${{ steps.meta.outputs.labels }}
@@ -183,11 +218,11 @@ jobs:
       id: meta
       uses: docker/metadata-action@v4
       with:
-        images: ${{ env.REGISTRY }}/${{ inputs.CONTRACTS_IMAGE_NAME }}
+        images: ${{ env.REGISTRY }}/${{ env.CONTRACTS_IMAGE_NAME }}
     - name: Finalize Docker Metadata
       id: docker_tagging
       run: |
-        echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ inputs.CONTRACTS_IMAGE_NAME }}:${GITHUB_SHA}"
+        echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.CONTRACTS_IMAGE_NAME }}:${GITHUB_SHA}"
     - name: Inspect Docker Metadata
       run: |
         echo "TAGS -> ${{ steps.docker_tagging.outputs.docker_tags }}"
@@ -239,11 +274,11 @@ jobs:
       id: meta
       uses: docker/metadata-action@v4
       with:
-        images: ${{ env.REGISTRY }}/${{ inputs.SERVICES_IMAGE_NAME }}
+        images: ${{ env.REGISTRY }}/${{ env.SERVICES_IMAGE_NAME }}
     - name: Finalize Docker Metadata
       id: docker_tagging
       run: |
-        echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ inputs.SERVICES_IMAGE_NAME }}:${GITHUB_SHA}"
+        echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.SERVICES_IMAGE_NAME }}:${GITHUB_SHA}"
     - name: Inspect Docker Metadata
       run: |
         echo "TAGS -> ${{ steps.docker_tagging.outputs.docker_tags }}"
@@ -270,6 +305,7 @@ jobs:
     - frontend
     - contracts
     - services
+    - docs
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/check-docs-lint.yaml
+++ b/.github/workflows/check-docs-lint.yaml
@@ -1,0 +1,24 @@
+name: check-docs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18.16.x
+      - name: Build
+        run: |
+          npm ci
+          (cd docs && npm ci && npm run build)

--- a/.github/workflows/check-frontend-lint.yaml
+++ b/.github/workflows/check-frontend-lint.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: 16.19.x
+          node-version: 18.16.x
       - name: Install
         run: |
           npm ci

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ map:
 debugmap:
 	$(UNITY_EDITOR) -batchmode -quit -projectPath ./map -executeMethod BuildScript.DevBuild -buildTarget WebGL -logFile -
 
-dev: all
+dev: all docs
 	$(NODE) .devstartup.js
 
 compose: frontend/public/ds-unity/Build/ds-unity.wasm
@@ -60,6 +60,11 @@ contracts/lib/cog/services/bin/ds-node: contracts/lib/cog/services/Makefile $(CO
 cli: node_modules core/dist/core.js
 	(cd cli && npm run build && npm install -g --force .)
 
+docs/node_modules: docs/package.json docs/package-lock.json
+	(cd docs && npm ci)
+
+docs: docs/node_modules
+
 publish: cli
 	(cd cli && npm version patch && npm publish)
 
@@ -82,9 +87,12 @@ clean:
 	rm -rf frontend/public/ds-unity
 	rm -rf frontend/dist
 	rm -rf frontend/node_modules
+	rm -rf docs/node_modules
+	rm -rf docs/.docusaurus
+	rm -rf docs/build
 	rm -rf node_modules
 	$(MAKE) -C contracts/lib/cog/services clean
 
 
-.PHONY: all clean dev map compose debugmap cli contracts release
+.PHONY: all clean dev docs map compose debugmap cli contracts release
 .SILENT: contracts/lib/cog/services/bin/ds-node frontend/public/ds-unity/Build/ds-unity.wasm

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -196,6 +196,7 @@ spec:
   selector:
     app: {{ $.Release.Name }}-services
 
+{{ if $.Values.anvil.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -211,6 +212,7 @@ spec:
       name: network
   selector:
     app: {{ $.Release.Name }}-services
+{{ end }}
 
 ---
 apiVersion: v1

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -153,6 +153,34 @@ spec:
             name: {{ $.Release.Name }}-frontend
 
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-docs
+  namespace: {{ $.Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-docs
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ $.Release.Name }}-docs
+      annotations:
+        gitsha: {{ $.Values.version | quote }}
+    spec:
+      priorityClassName: {{ $.Values.priorityClassName | quote }}
+      containers:
+        - name: docs
+          image: {{ printf "ghcr.io/playmint/ds-docs:%s" $.Values.version }}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -201,6 +229,22 @@ spec:
     app: {{ $.Release.Name }}-frontend
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-docs
+  namespace: {{ $.Release.Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ $.Release.Name }}-docs
+
+---
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
@@ -237,6 +281,19 @@ metadata:
 spec:
   endpoints:
   - dnsName: "frontend-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
+    recordTTL: 60
+    recordType: "CNAME"
+    targets: ["{{ $.Values.cluster.domain }}"]
+
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: {{ $.Release.Name }}-docs
+  namespace: {{ $.Release.Namespace }}
+spec:
+  endpoints:
+  - dnsName: "docs-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
     recordTTL: 60
     recordType: "CNAME"
     targets: ["{{ $.Values.cluster.domain }}"]
@@ -324,6 +381,36 @@ spec:
           kube:
             ref:
               name: {{ $.Release.Name }}-frontend
+              namespace: {{ $.Release.Namespace }}
+            port: 80
+      options:
+        timeout: 120s
+        retries:
+          retryOn: gateway-error
+          numRetries: 1
+          perTryTimeout: 120s
+  sslConfig:
+    secretRef:
+      name: "cluster-domain-certificate"
+      namespace: "ingress-system"
+
+---
+apiVersion: "gateway.solo.io/v1"
+kind: VirtualService
+metadata:
+  name: {{ $.Release.Name }}-docs
+  namespace: {{ $.Release.Namespace }}
+spec:
+  virtualHost:
+    domains: ["docs-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"]
+    routes:
+    - matchers:
+      - prefix: "/"
+      routeAction:
+        single:
+          kube:
+            ref:
+              name: {{ $.Release.Name }}-docs
               namespace: {{ $.Release.Namespace }}
             port: 80
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,14 @@ services:
     ports:
       - 3000:80
 
+  docs:
+    build:
+      context: .
+      dockerfile: ./docs/Dockerfile
+    image: playmint/ds-docs:local
+    ports:
+      - 3002:80
+
   cog:
     build:
       context: ./contracts/lib/cog/services

--- a/docs/.nvmrc
+++ b/docs/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/docs/Caddyfile
+++ b/docs/Caddyfile
@@ -1,0 +1,8 @@
+# https://caddyserver.com/docs/caddyfile
+
+:80 {
+	root * /usr/share/caddy
+	file_server
+    try_files {path}.html {path}
+}
+

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine AS builder
+RUN apk add --update python3 make g++\
+   && rm -rf /var/cache/apk/*
+WORKDIR /app
+COPY docs ./docs
+RUN cd docs && npm ci && npm run build
+
+# output image
+FROM caddy:2.6.4
+COPY --from=builder /app/docs/build /usr/share/caddy
+COPY frontend/Caddyfile /etc/caddy/Caddyfile
+

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "docusaurus",
+  "name": "@downstream/docs",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "docusaurus",
+      "name": "@downstream/docs",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "2.4.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,15 +1,14 @@
 {
-  "name": "docusaurus",
+  "name": "@downstream/docs",
   "version": "0.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --host 0.0.0.0 --port 3002 --no-open",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "docusaurus serve --host 0.0.0.0 --port 3002",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -44,6 +44,7 @@ async function main({
         contracts: containerImage('ds-contracts', longSHA),
         services: containerImage('ds-services', longSHA),
         shell: containerImage('ds-shell', longSHA),
+        docs: containerImage('ds-docs', longSHA),
     };
 
     // check not dirty


### PR DESCRIPTION
## what

* includes docs site in local startup script (ie `make dev` will start it up with everything else on port 3002)
* adds a Dockerfile to build and serve docs from a container
* adds Github Actions build the docker contianer image for the commit
* include Deployment of docs container in the helm chart so it gets deployed at `docs-ds-{env}.dev.playmint.com` like the other services
* include check in release script that docs site exists
* resolves: #511 