### PR TITLE
client-analytics: logging dispatch and login

### DIFF
--- a/core/src/cog.ts
+++ b/core/src/cog.ts
@@ -141,7 +141,7 @@ export function configureClient({
     const signin = async (owner: ethers.Signer) => {
         const key = ethers.Wallet.createRandom();
         const scope = '0xffffffff';
-        const ttl = 9999;
+        const ttl = 25000; // ~13hrs
         const msg = authMessage(key.address.toLowerCase(), ttl);
         const auth = await owner.signMessage(msg);
         const res = await gql

--- a/core/src/react.tsx
+++ b/core/src/react.tsx
@@ -21,9 +21,8 @@ import {
     Selector,
     GameState,
     World,
-    EthereumProvider,
 } from './types';
-import { makeWallet } from './wallet';
+import { makeWallet, WalletProvider } from './wallet';
 import { makeWorld } from './world';
 
 export interface DSContextProviderProps {
@@ -46,7 +45,7 @@ export interface DSContextStore {
     state: Source<GameState>;
     selection: Source<Selection>;
     selectors: SelectionSelectors;
-    selectProvider: Selector<EthereumProvider>;
+    selectProvider: Selector<WalletProvider>;
     ui: Source<PluginState[]>;
     logger: Logger;
     logs: Source<Log>;
@@ -119,7 +118,7 @@ export function usePlayer(): ConnectedPlayer | undefined {
     return useSource(sources.player);
 }
 
-export function useWallet(): { wallet: Wallet | undefined; selectProvider: Selector<EthereumProvider> } {
+export function useWallet(): { wallet: Wallet | undefined; selectProvider: Selector<WalletProvider> } {
     const sources = useSources();
     const wallet = useSource(sources.wallet);
     const selectProvider = sources.selectProvider;

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -209,6 +209,7 @@ export interface Wallet {
     address: string;
     signer: () => Promise<ethers.Signer>;
     session?: CogSession;
+    method: string;
 }
 
 export type AnyGameQuery = GetSelectedPlayerQuery | GetWorldQuery;

--- a/frontend/src/components/organisms/analytics/index.tsx
+++ b/frontend/src/components/organisms/analytics/index.tsx
@@ -1,4 +1,32 @@
 import Script from 'next/script';
+import { id } from 'ethers';
+
+export type TrackFunc = (name: string, params: { [key: string]: string }) => void;
+
+export const trackEvent: TrackFunc = (name, params) => {
+    const gtag = (window as any).gtag;
+    if (!gtag) {
+        return;
+    }
+    gtag('event', name, params);
+};
+
+export const trackPlayer = (address?: string) => {
+    const gtag = (window as any).gtag;
+    if (!gtag) {
+        return;
+    }
+    if (!address) {
+        return;
+    }
+    // even though addresses are public data, they are still potentially PII,
+    // and even if you think they are not on their own, there is no good reason
+    // to make it easy for google to tie the address to any other data
+    // collected that so hash it to anonymise it then replace the 0x so that
+    // google analytics doesn't treat it as a number
+    const obfuscatedAddr = id(`player:${address}`).replace(/^0x/, 'p');
+    gtag('set', 'user_id', obfuscatedAddr);
+};
 
 export const Analytics = ({ id }: { id: string }) => {
     return (
@@ -9,6 +37,7 @@ export const Analytics = ({ id }: { id: string }) => {
                 function gtag(){dataLayer.push(arguments);}
                 gtag('js', new Date());
                 gtag('config', '${id}');
+                window.gtag = gtag;
             `}</Script>
         </>
     );

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,13 +1,13 @@
 /** @format */
 
-import type { AppProps } from 'next/app';
-import dynamic from 'next/dynamic';
-import { Fragment, useEffect, useMemo, useState } from 'react';
-import Head from 'next/head';
+import Analytics from '@app/components/organisms/analytics';
+import { InventoryProvider } from '@app/plugins/inventory/inventory-provider';
 import { GlobalStyles } from '@app/styles/global.styles';
 import { DSProvider } from '@downstream/core';
-import { InventoryProvider } from '@app/plugins/inventory/inventory-provider';
-import Analytics from '@app/components/organisms/analytics';
+import type { AppProps } from 'next/app';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 
 const App = ({ Component, pageProps }: AppProps) => {
     const [config, setConfig] = useState<any>();

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,10 +1,12 @@
 /** @format */
+import { trackEvent } from '@app/components/organisms/analytics';
 import { useUnityMap } from '@app/components/organisms/unity-map';
 import Shell from '@app/components/views/shell';
 import { BlockTimeProvider } from '@app/contexts/block-time-provider';
 import { ModalProvider } from '@app/contexts/modal-provider';
 import { ActionName, useGameState, useWallet } from '@downstream/core';
 import { useCallback, useEffect, useState } from 'react';
+import { pipe, subscribe } from 'wonka';
 
 interface Message {
     msg: string;
@@ -291,6 +293,18 @@ export default function ShellPage() {
         selectMobileUnit,
         selectMapElement,
     ]);
+
+    // collect client dispatch analytics
+    useEffect(() => {
+        if (!player) {
+            return;
+        }
+        const { unsubscribe } = pipe(
+            player.dispatched,
+            subscribe((event) => event.actions.map((action) => trackEvent('dispatch', { action: action.name })))
+        );
+        return unsubscribe;
+    }, [player]);
 
     // We'll round the loading progression to a whole number to represent the
     // percentage of the Unity Application that has loaded.


### PR DESCRIPTION
## what

* adds tracking of recommended `login` event with a `method` set to the provider used (walletconnect or metamask)
* adds tracking of a custom `dispatch` analytics event with an `action` parameter set to the name of the action (ie "MOVE_MOBILE_UNIT")
* anonymises the user_id
* resolves: #547 

## why

so we can see some very basic information about client usage
