### PR TITLE
send world update separately from selection update

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -116,9 +116,7 @@ export default function ShellPage() {
                         if (pendingPlayer) {
                             args.push(pendingPlayer);
                         }
-                        if (pendingSelection) {
-                            args.push(pendingSelection);
-                        }
+                        args.push(pendingSelection);
                         pendingPlayer = null;
                         pendingSelection = null;
                     } else {

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -113,9 +113,14 @@ export default function ShellPage() {
                     // so that the UI feels snappier.
                     // any other updates will occur in the next loop
                     if (pendingSelection && hasSentAtLeastOneTilesUpdate) {
+                        if (pendingPlayer) {
+                            args.push(pendingPlayer);
+                        }
                         if (pendingSelection) {
                             args.push(pendingSelection);
                         }
+                        pendingPlayer = null;
+                        pendingSelection = null;
                     } else {
                         if (pendingPlayers) {
                             args = [...args, ...pendingPlayers];
@@ -130,15 +135,13 @@ export default function ShellPage() {
                         if (pendingPlayer) {
                             args.push(pendingPlayer);
                         }
+                        pendingPlayer = null;
+                        pendingPlayers = null;
+                        pendingTiles = null;
+                        pendingBuildings = null;
+                        pendingBlock = null;
                     }
                     args.push(['GameStateMediator', 'EndOnState']);
-
-                    pendingPlayer = null;
-                    pendingPlayers = null;
-                    pendingTiles = null;
-                    pendingBuildings = null;
-                    pendingBlock = null;
-                    pendingSelection = null;
 
                     for (let i = 0; i < args.length; i++) {
                         gSendMessage(...args[i]);

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -146,71 +146,89 @@ export default function ShellPage() {
         };
     }, []);
 
-    const game = { player, selected, world };
-    if (isReady && game.world) {
-        gSendMessage = sendMessage;
-        pendingBlock = game.world.block;
+    gSendMessage = sendMessage;
 
-        if (game.world.players) {
-            const nextPlayersJSON = JSON.stringify(game.world.players);
+    useEffect(() => {
+        if (!isReady) {
+            return;
+        }
+        if (!world) {
+            return;
+        }
+
+        if (world.players) {
+            const nextPlayersJSON = JSON.stringify(world.players);
             if (nextPlayersJSON != prevPlayersJSON) {
                 pendingPlayers = [['GameStateMediator', 'ResetWorldPlayers']];
-                for (let i = 0; i < game.world.players.length; i += CHUNK_PLAYERS) {
+                for (let i = 0; i < world.players.length; i += CHUNK_PLAYERS) {
                     pendingPlayers.push([
                         'GameStateMediator',
                         'AddWorldPlayers',
-                        JSON.stringify(game.world.players.slice(i, i + CHUNK_PLAYERS)),
+                        JSON.stringify(world.players.slice(i, i + CHUNK_PLAYERS)),
                     ]);
                 }
                 prevPlayersJSON = nextPlayersJSON;
             }
         }
 
-        if (game.world.tiles) {
-            const nextTilesJSON = JSON.stringify(game.world.tiles);
+        if (world.tiles) {
+            const nextTilesJSON = JSON.stringify(world.tiles);
             if (nextTilesJSON != prevTilesJSON) {
                 pendingTiles = [['GameStateMediator', 'ResetWorldTiles']];
-                for (let i = 0; i < game.world.tiles.length; i += CHUNK_TILES) {
+                for (let i = 0; i < world.tiles.length; i += CHUNK_TILES) {
                     pendingTiles.push([
                         'GameStateMediator',
                         'AddWorldTiles',
-                        JSON.stringify(game.world.tiles.slice(i, i + CHUNK_TILES)),
+                        JSON.stringify(world.tiles.slice(i, i + CHUNK_TILES)),
                     ]);
                 }
                 prevTilesJSON = nextTilesJSON;
             }
         }
 
-        if (game.world.buildings) {
-            const nextBuildingsJSON = JSON.stringify(game.world.buildings);
+        if (world.buildings) {
+            const nextBuildingsJSON = JSON.stringify(world.buildings);
             if (nextBuildingsJSON != prevBuildingsJSON) {
                 pendingBuildings = [['GameStateMediator', 'ResetWorldBuildings']];
-                for (let i = 0; i < game.world.buildings.length; i += CHUNK_BUILDINGS) {
+                for (let i = 0; i < world.buildings.length; i += CHUNK_BUILDINGS) {
                     pendingBuildings.push([
                         'GameStateMediator',
                         'AddWorldBuildings',
-                        JSON.stringify(game.world.buildings.slice(i, i + CHUNK_BUILDINGS)),
+                        JSON.stringify(world.buildings.slice(i, i + CHUNK_BUILDINGS)),
                     ]);
                 }
                 prevBuildingsJSON = nextBuildingsJSON;
             }
         }
 
-        if (game.player) {
-            // TODO: should allow setting player to null
-            const nextPlayerJSON = JSON.stringify(game.player);
-            if (nextPlayerJSON != prevPlayerJSON) {
-                pendingPlayer = ['GameStateMediator', 'SetPlayer', nextPlayerJSON];
-                prevPlayerJSON = nextPlayerJSON;
-            }
-        }
+        pendingBlock = world.block;
+    }, [isReady, world]);
 
-        const nextSelectionJSON = JSON.stringify(game.selected || {});
+    useEffect(() => {
+        if (!isReady) {
+            return;
+        }
+        // FIXME: map should allow setting player to null but currently explodes
+        if (!player) {
+            return;
+        }
+        const nextPlayerJSON = JSON.stringify(player);
+        if (nextPlayerJSON != prevPlayerJSON) {
+            pendingPlayer = ['GameStateMediator', 'SetPlayer', nextPlayerJSON];
+            prevPlayerJSON = nextPlayerJSON;
+        }
+    }, [isReady, player]);
+
+    useEffect(() => {
+        if (!isReady) {
+            return;
+        }
+        const nextSelectionJSON = JSON.stringify(selected || {});
         if (nextSelectionJSON != prevSelectionJSON) {
             pendingSelection = ['GameStateMediator', 'SetSelectionState', nextSelectionJSON];
             prevSelectionJSON = nextSelectionJSON;
         }
-    }
+    }, [isReady, selected]);
 
     useEffect(() => {
         if (!addEventListener || !removeEventListener) {

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -54,6 +54,7 @@ let pendingTiles: any;
 let pendingBuildings: any;
 let pendingBlock: any;
 let pendingSelection: any;
+let hasSentAtLeastOneTilesUpdate = false;
 
 export default function ShellPage() {
     const { wallet, selectProvider } = useWallet();
@@ -107,20 +108,28 @@ export default function ShellPage() {
                         JSON.stringify({ tiles: [], buildings: [], players: [], block: pendingBlock }),
                     ]);
 
-                    if (pendingPlayers) {
-                        args = [...args, ...pendingPlayers];
-                    }
-                    if (pendingTiles) {
-                        args = [...args, ...pendingTiles];
-                    }
-                    if (pendingBuildings) {
-                        args = [...args, ...pendingBuildings];
-                    }
-                    if (pendingPlayer) {
-                        args.push(pendingPlayer);
-                    }
-                    if (pendingSelection) {
-                        args.push(pendingSelection);
+                    // if there is a selection change pending,
+                    // then give it priority over the world state
+                    // so that the UI feels snappier.
+                    // any other updates will occur in the next loop
+                    if (pendingSelection && hasSentAtLeastOneTilesUpdate) {
+                        if (pendingSelection) {
+                            args.push(pendingSelection);
+                        }
+                    } else {
+                        if (pendingPlayers) {
+                            args = [...args, ...pendingPlayers];
+                        }
+                        if (pendingTiles) {
+                            hasSentAtLeastOneTilesUpdate = true;
+                            args = [...args, ...pendingTiles];
+                        }
+                        if (pendingBuildings) {
+                            args = [...args, ...pendingBuildings];
+                        }
+                        if (pendingPlayer) {
+                            args.push(pendingPlayer);
+                        }
                     }
                     args.push(['GameStateMediator', 'EndOnState']);
 

--- a/map/Assets/Scripts/Cog/Plugin/GameStateMediator.cs
+++ b/map/Assets/Scripts/Cog/Plugin/GameStateMediator.cs
@@ -88,6 +88,7 @@ namespace Cog
 
         // -- EVENTS
         public Action<GameState> EventStateUpdated;
+        public Action<Selection> EventSelectionUpdated;
 
         // -- //
 
@@ -432,6 +433,7 @@ namespace Cog
             try
             {
                 incoming.Selected = JsonConvert.DeserializeObject<Selection>(json);
+                EventSelectionUpdated.Invoke(incoming.Selected);
             }
             catch (Exception e)
             {


### PR DESCRIPTION

* prioritize seneding the select state over the tiles/player data to let the select UI update quicker
* stop calculating unscouted tiles ... there's no scouting so they are redundent and just slowing things down

fixes: #545 
fixes: #544 