### PR TITLE
cli: add some context to QR login

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -33,6 +33,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
+    "@downstream/core": "file:core",
     "@walletconnect/ethereum-provider": "^2.9.1",
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.3",

--- a/cli/src/utils/session.ts
+++ b/cli/src/utils/session.ts
@@ -32,7 +32,21 @@ const newWalletConnectProvider = async (): Promise<EthereumProvider> => {
         const onDisplayURI = (uri: string) => {
             qrcode.generate(uri, { small: true }, (qr) => {
                 console.clear();
+                console.log(`\n`);
                 console.log(qr);
+                console.log(`
+
+█▀▀▄ █▀▀█ █───█ █▀▀▄ █▀▀ ▀▀█▀▀ █▀▀█ █▀▀ █▀▀█ █▀▄▀█
+█──█ █──█ █▄█▄█ █──█ ▀▀█ ──█── █▄▄▀ █▀▀ █▄▄█ █─▀─█
+▀▀▀─ ▀▀▀▀ ─▀─▀─ ▀──▀ ▀▀▀ ──▀── ▀─▀▀ ▀▀▀ ▀──▀ ▀───▀
+`);
+                console.log(`\n`);
+                console.log(`Authorization required to continue...`);
+                console.log(`\n`);
+                console.log(
+                    `Please scan the QR code with your mobile wallet to connect, you will be prompted to sign a message to authenticate your Downstream session`
+                );
+                console.log(`\n`);
             });
         };
         const onConnect = (_info) => {
@@ -92,7 +106,7 @@ export const session = async (ctx) => {
                 toPromise
             );
             const provider = await newWalletConnectProvider();
-            selectProvider(provider);
+            selectProvider({ method: 'walletconnect', provider });
             await sleep(1000); // seems to be a bit of an eventual consistency race outside our control on the walletconnect api side
             // await provider.request({ method: 'eth_accounts' }); // check connection or explode
             const p = await player;

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -7,7 +7,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "noUnusedLocals": true,
-    "rootDir": ".",
     "baseUrl": ".",
     "paths": {
       "@downstream/core": ["../core/src"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
       "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
+        "@downstream/core": "file:core",
         "@walletconnect/ethereum-provider": "^2.9.1",
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.3",
@@ -84,8 +85,10 @@
         "typescript": "^5.1.6"
       }
     },
-    "cli/core": {
-      "extraneous": true
+    "cli/core": {},
+    "cli/node_modules/@downstream/core": {
+      "resolved": "cli/core",
+      "link": true
     },
     "cli/node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
@@ -23135,6 +23138,7 @@
     "@playmint/ds-cli": {
       "version": "file:cli",
       "requires": {
+        "@downstream/core": "file:core",
         "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^6.2.0",
         "@typescript-eslint/parser": "^6.2.0",
@@ -23159,6 +23163,9 @@
         "zod": "^3.21.4"
       },
       "dependencies": {
+        "@downstream/core": {
+          "version": "file:cli/core"
+        },
         "@esbuild/android-arm": {
           "version": "0.18.20",
           "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",


### PR DESCRIPTION
* cli: shows a message with a bit of context explaining to use a mobile wallet to scan the QR to authenticate with downstream 
* fixes: #506 

![Screenshot 2023-08-24 at 15 47 32](https://github.com/playmint/ds/assets/45921/a33b5b4a-e032-4a8c-bd83-02fca6d3f119)
