### PR TITLE
Fixed highlight and outline on extractor buildings

### DIFF
--- a/map/Assets/Map/Prefabs/MapElements/ExtractorMapElement.prefab
+++ b/map/Assets/Map/Prefabs/MapElements/ExtractorMapElement.prefab
@@ -1,5 +1,88 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6277045550653190580
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1888305638513581310}
+  - component: {fileID: 687513461674096077}
+  - component: {fileID: 8302268039992338879}
+  m_Layer: 8
+  m_Name: ExtractorGlass (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1888305638513581310
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6277045550653190580}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -4.1909514e-12, y: 1.6763806e-11, z: -0.0000000010728836}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5636529328674465528}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &687513461674096077
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6277045550653190580}
+  m_Mesh: {fileID: 877936591801982111, guid: cfadc4af243297f43b4b36a37e6f96e7, type: 3}
+--- !u!23 &8302268039992338879
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6277045550653190580}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 350e1b89b29f442e1ae981fd04ecfca4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &2453610119776138067
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -72,6 +155,18 @@ PrefabInstance:
 --- !u!23 &4392196376253484981 stripped
 MeshRenderer:
   m_CorrespondingSourceObject: {fileID: 2231760330056776934, guid: d5bff666d70b98d4cb9e06b90e04eb47,
+    type: 3}
+  m_PrefabInstance: {fileID: 2453610119776138067}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &5636529328674465528 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7796857855196861867, guid: d5bff666d70b98d4cb9e06b90e04eb47,
+    type: 3}
+  m_PrefabInstance: {fileID: 2453610119776138067}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &6806018015380479383 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 8970937585856081604, guid: d5bff666d70b98d4cb9e06b90e04eb47,
     type: 3}
   m_PrefabInstance: {fileID: 2453610119776138067}
   m_PrefabAsset: {fileID: 0}
@@ -241,13 +336,15 @@ MonoBehaviour:
     type: 3}
   outlineObjs:
   - {fileID: 7859648815774748197}
+  - {fileID: 6277045550653190580}
   createIcon: 0
   renderers:
-  - {fileID: 4392196376253484981}
-  highlightColor: {r: 0, g: 0, b: 0, a: 0}
+  - {fileID: 6806018015380479383}
+  highlightColor: {r: 0.079432175, g: 0.34517217, b: 0.4811321, a: 1}
   _red: {r: 0.8352941, g: 0.1882353, b: 0.5137255, a: 1}
   _green: {r: 0.27450982, g: 0.8156863, b: 0.17254902, a: 1}
   _blue: {r: 0.12156863, g: 0.5803922, b: 0.98039216, a: 1}
+  gooRend: {fileID: 4392196376253484981}
 --- !u!4 &7268972726949291940 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4011681257694613555, guid: a699dfdf8ea904492a4f3bc5ea3d169d,

--- a/map/Assets/Map/Scripts/GameplayElements/ExtractorBuildingController.cs
+++ b/map/Assets/Map/Scripts/GameplayElements/ExtractorBuildingController.cs
@@ -14,20 +14,15 @@ public class ExtractorBuildingController : MapElementController
     [SerializeField]
     private Color _blue;
 
+    [SerializeField]
+    private Renderer gooRend;
+
     private Color _gooColor;
 
     public void Setup(Vector3Int cell, Transform parent, string id, string model)
     {
         Setup(cell, parent, id);
         setColor(model);
-    }
-
-    protected void Update()
-    {
-        foreach (Renderer rend in renderers)
-        {
-            rend.material.SetColor("_BaseColor", _gooColor);
-        }
     }
 
     private void setColor(string color)
@@ -44,5 +39,6 @@ public class ExtractorBuildingController : MapElementController
                 _gooColor = _blue;
                 break;
         }
+        gooRend.material.SetColor("_BaseColor", _gooColor);
     }
 }


### PR DESCRIPTION
The extractor buildings weren't highlighting on mouse over and their outlines didn't account for the glass sphere.
This PR fixes those issues