### PR TITLE
show other unit's inventories

### DIFF
--- a/.github/workflows/check-frontend-lint.yaml
+++ b/.github/workflows/check-frontend-lint.yaml
@@ -14,6 +14,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -40,7 +43,7 @@ jobs:
         working-directory: frontend
         run: |
           npx eslint . --ext .ts --ext .tsx --quiet
-      - name: Build
+      - name: Export
         working-directory: frontend
         run: |
-          npx next build
+          npm run export

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -17,6 +17,9 @@ const nextConfig = {
         };
         return config;
     },
+    images: {
+        unoptimized: true
+    },
 };
 
 export default nextConfig;

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -17,7 +17,7 @@ export interface BagSlotProps extends ComponentProps {
     bagId?: string;
     equipIndex: number;
     slotKey: number;
-    isInteractable?: boolean;
+    isInteractable?: boolean | ((ownerId: string, slot?: ItemSlotFragment) => boolean);
     isPending?: boolean;
 }
 
@@ -34,7 +34,7 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
         bagId,
         equipIndex,
         slotKey,
-        isInteractable,
+        isInteractable: isInteractableFunc,
         isPending,
         ...otherProps
     } = props;
@@ -43,6 +43,8 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
     const item = itemSlot?.balance ? getItemDetails(itemSlot) : null;
     const placeholderItem = placeholder?.balance ? getItemDetails(placeholder) : null;
     const itemSlotBalance = itemSlot?.balance || 0;
+    const isInteractable =
+        typeof isInteractableFunc === 'function' ? isInteractableFunc(ownerId, itemSlot) : isInteractableFunc;
 
     const handleDrop = (dropQuantity: number) => {
         if (!isPickedUpItemVisible || !isInteractable || !pickedUpItem) {

--- a/frontend/src/plugins/inventory/bag/index.tsx
+++ b/frontend/src/plugins/inventory/bag/index.tsx
@@ -13,7 +13,7 @@ export interface BagProps extends ComponentProps {
     bagId?: string;
     ownerId: string;
     equipIndex: number;
-    isInteractable: boolean;
+    isInteractable?: boolean | ((ownerId: string, slot?: ItemSlotFragment) => boolean);
     recipe?: ItemSlotFragment[];
     numBagSlots?: number;
     showIcon?: boolean;

--- a/frontend/src/plugins/inventory/index.tsx
+++ b/frontend/src/plugins/inventory/index.tsx
@@ -10,6 +10,7 @@ export interface InventoryProps extends ComponentProps {
     ownerId: string;
     bags: EquipmentSlotFragment[];
     isInteractable: boolean;
+    showIcon?: boolean;
 }
 
 const StyledInventory = styled('div')`
@@ -21,7 +22,7 @@ const StyledInventory = styled('div')`
 `;
 
 export const Inventory: FunctionComponent<InventoryProps> = (props: InventoryProps) => {
-    const { bags, ownerId, isInteractable, ...otherProps } = props;
+    const { bags, ownerId, isInteractable, showIcon, ...otherProps } = props;
 
     return (
         <StyledInventory {...otherProps}>
@@ -33,6 +34,7 @@ export const Inventory: FunctionComponent<InventoryProps> = (props: InventoryPro
                         equipIndex={equipSlot.key}
                         ownerId={ownerId}
                         isInteractable={isInteractable}
+                        showIcon={showIcon}
                         as="li"
                     />
                 ))}

--- a/frontend/src/plugins/mobile-unit-list/index.tsx
+++ b/frontend/src/plugins/mobile-unit-list/index.tsx
@@ -1,15 +1,33 @@
 /** @format */
 
+import otherUnitIcon from '@app/../public/mobile-unit-theirs.png';
+import playerUnitIcon from '@app/../public/mobile-unit-yours.png';
 import { formatNameOrId } from '@app/helpers';
 import { ComponentProps } from '@app/types/component-props';
-import { ConnectedPlayer, MobileUnit } from '@downstream/core';
-import { FunctionComponent } from 'react';
+import { ConnectedPlayer, ItemSlotFragment, MobileUnit, SelectedTileFragment } from '@downstream/core';
+import Image from 'next/image';
+import { FunctionComponent, useCallback } from 'react';
 import styled from 'styled-components';
+import { Inventory } from '../inventory';
+import { useInventory } from '../inventory/inventory-provider';
 import { styles } from './mobile-unit-list.styles';
+
+const MobileUnitListItem = ({ unit, icon, isInteractable }) => {
+    return (
+        <div className="mobileUnitListItem">
+            <div className="mobileUnit">
+                <Image src={icon} alt="" width={65} />
+                {formatNameOrId(unit, 'Unit ')}
+            </div>
+            <Inventory showIcon={false} bags={unit.bags} ownerId={unit.id} isInteractable={isInteractable} />
+        </div>
+    );
+};
 
 export interface MobileUnitListProps extends ComponentProps {
     player?: ConnectedPlayer;
     mobileUnits: MobileUnit[];
+    tile?: SelectedTileFragment;
 }
 
 const StyledMobileUnitList = styled('div')`
@@ -17,19 +35,34 @@ const StyledMobileUnitList = styled('div')`
 `;
 
 export const MobileUnitList: FunctionComponent<MobileUnitListProps> = (props: MobileUnitListProps) => {
-    const { mobileUnits, player, ...otherProps } = props;
+    const { mobileUnits, player, tile, ...otherProps } = props;
+    const { isMobileUnitAtLocation } = useInventory();
+
+    const isInteractable = useCallback(
+        (ownerId: string, slot?: ItemSlotFragment) => {
+            if (ownerId === player?.id) {
+                return true;
+            }
+            if (!tile) {
+                return false;
+            }
+            if (!isMobileUnitAtLocation(tile)) {
+                return false;
+            }
+            return !slot || slot.balance === 0;
+        },
+        [player, tile, isMobileUnitAtLocation]
+    );
 
     return (
         <StyledMobileUnitList {...otherProps}>
-            {mobileUnits.map((mobileUnit, index) => (
-                <div key={index} className="mobileUnit">
-                    {player && mobileUnit?.owner?.id == player.id ? (
-                        <img src="/mobile-unit-yours.png" alt="" />
-                    ) : (
-                        <img src="/mobile-unit-theirs.png" alt="" />
-                    )}
-                    {formatNameOrId(mobileUnit, 'Unit ')}
-                </div>
+            {mobileUnits.map((unit) => (
+                <MobileUnitListItem
+                    key={unit.id}
+                    icon={player && unit.owner?.id == player.id ? playerUnitIcon : otherUnitIcon}
+                    unit={unit}
+                    isInteractable={isInteractable}
+                />
             ))}
         </StyledMobileUnitList>
     );

--- a/frontend/src/plugins/mobile-unit-list/mobile-unit-list.styles.ts
+++ b/frontend/src/plugins/mobile-unit-list/mobile-unit-list.styles.ts
@@ -10,7 +10,10 @@ import { MobileUnitListProps } from './index';
  * @return Base styles for the mobileUnit list component
  */
 const baseStyles = (_: Partial<MobileUnitListProps>) => css`
-    > .mobileUnit {
+    .mobileUnitListItem {
+        margin-bottom: 2rem;
+    }
+    .mobileUnit {
         position: relative;
         background: #030f25;
         margin-left: 1rem;
@@ -18,7 +21,7 @@ const baseStyles = (_: Partial<MobileUnitListProps>) => css`
         padding: 0.7rem 0 0.7rem 6rem;
         margin-bottom: 2.4rem;
 
-        img {
+        > img {
             position: absolute;
             left: -2rem;
             top: 50%;


### PR DESCRIPTION
## what

* show other unit's inventories when clicking on a tile
* fixes: #117 

![Screenshot 2023-08-29 at 19 37 51](https://github.com/playmint/ds/assets/45921/fbe175a4-037e-472c-a8a3-38110f44db3c)


## why

so we can be nosy and drop stuff in peoples bags

## quirks:

* we now hide our self from the list of units on tile if our unit selected (it was weird showing two of the same inventories at the same time)
* you now can't see other units standing at a building, the UI can't handle it well enough with the big building UI
* it's not gonna work well if tons of people are on same tile ... I tried a simple accordian UI, but it was just too hidden ... need proper design
* normally you can drop same item on same item ... when airdropping you can only use empty slots, (ie if you airdrop 1, you now can't drop the other 99 on top).... this is a limitation of isInteractable property of the inventory that needs addressesing and is out of scope of this task