### PR TITLE
Extractor values

### DIFF
--- a/contracts/src/fixtures/extractors/GenericExtractor.js
+++ b/contracts/src/fixtures/extractors/GenericExtractor.js
@@ -25,10 +25,10 @@ const getSecsPerGoo = (atomVal) => {
     if (atomVal < 10) return 0;
 
     const x = atomVal - 32;
-    const baseSecsPerGoo = 120 * Math.pow(0.98, x);
+    const baseSecsPerGoo = 120 * Math.pow(0.9775, x);
 
-    if (atomVal >= 200) return baseSecsPerGoo / 4;
-    else if (atomVal >= 170) return baseSecsPerGoo / 2;
+    if (atomVal >= 165) return Math.max(baseSecsPerGoo / 4, 1);
+    else if (atomVal >= 155) return baseSecsPerGoo / 3;
     else return baseSecsPerGoo;
 };
 

--- a/contracts/src/rules/ExtractionRule.sol
+++ b/contracts/src/rules/ExtractionRule.sol
@@ -158,8 +158,8 @@ contract ExtractionRule is Rule {
         uint256 x = atomVal > 32 ? atomVal - 32 : 0;
         int128 baseSecsPerGoo = Math.fromUInt(120).mul(Math.fromUInt(98).div(Math.fromUInt(100)).pow(x));
 
-        if (atomVal >= 200) return baseSecsPerGoo.div(Math.fromUInt(4));
-        else if (atomVal >= 170) return baseSecsPerGoo.div(Math.fromUInt(2));
+        if (atomVal >= 165) return baseSecsPerGoo.div(Math.fromUInt(4));
+        else if (atomVal >= 155) return baseSecsPerGoo.div(Math.fromUInt(2));
         else return baseSecsPerGoo;
     }
 

--- a/contracts/src/rules/ExtractionRule.sol
+++ b/contracts/src/rules/ExtractionRule.sol
@@ -156,10 +156,16 @@ contract ExtractionRule is Rule {
         if (atomVal < 10) return Math.fromUInt(0);
 
         uint256 x = atomVal > 32 ? atomVal - 32 : 0;
-        int128 baseSecsPerGoo = Math.fromUInt(120).mul(Math.fromUInt(98).div(Math.fromUInt(100)).pow(x));
+        int128 baseSecsPerGoo = Math.fromUInt(120).mul(Math.fromUInt(9775).div(Math.fromUInt(10000)).pow(x));
 
-        if (atomVal >= 165) return baseSecsPerGoo.div(Math.fromUInt(4));
-        else if (atomVal >= 155) return baseSecsPerGoo.div(Math.fromUInt(2));
+        if (atomVal >= 165)
+        {
+            baseSecsPerGoo = baseSecsPerGoo.div(Math.fromUInt(4));
+            
+            if (baseSecsPerGoo < 1) return 1;
+            else return baseSecsPerGoo;
+        }
+        else if (atomVal >= 155) return baseSecsPerGoo.div(Math.fromUInt(3));
         else return baseSecsPerGoo;
     }
 


### PR DESCRIPTION
Have changed the Goo Per Sec values so that...
- The curve is not quite so steep
- The thresholds match the new map art thresholds
- The max goo per sec = 1

@chrisfarms has got the change to the Tile UI's goo per sec display in his PR