### PR TITLE
Remove goo under buildings, stop goo z-fighting

### DIFF
--- a/map/Assets/Map/Scripts/Environment/GooController.cs
+++ b/map/Assets/Map/Scripts/Environment/GooController.cs
@@ -11,11 +11,19 @@ public class GooController : MonoBehaviour
     [SerializeField]
     private GameObject small;
 
+    bool isBig;
+
     public void Setup(bool isBig)
+    {
+        this.isBig = isBig;
+        Show();
+        transform.Rotate(0, Random.Range(0, 12) * 30.0f, 0);
+    }
+
+    public void Show()
     {
         big.SetActive(isBig);
         small.SetActive(!isBig);
-        transform.Rotate(0, Random.Range(0, 12) * 30.0f, 0);
     }
 
     public void Hide()

--- a/map/Assets/Map/Scripts/Environment/MapManager.cs
+++ b/map/Assets/Map/Scripts/Environment/MapManager.cs
@@ -186,7 +186,12 @@ public class MapManager : MonoBehaviour
             Transform tileTransform = AddTile(cellPosCube, tile)?.transform;
             if (tile.Atoms != null && tile.Atoms.Count > 0)
             {
-                MapElementManager.instance.CreateGoo(tile.Atoms, cellPosCube, tileTransform);
+                MapElementManager.instance.CreateGoo(
+                    tile.Atoms,
+                    cellPosCube,
+                    tileTransform,
+                    tile.Building != null || incompleteBuildings.Contains(tile.Id.Substring(10))
+                );
             }
 
             if (hasResource || hasReward)

--- a/map/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
+++ b/map/Assets/Map/Scripts/GameplayElements/AOIPulseController.cs
@@ -71,7 +71,7 @@ public class AOIPulseController : MonoBehaviour
                     _spawnedHighlights[i].transform.position.x,
                     MapHeightManager.instance.GetHeightAtPosition(
                         _spawnedHighlights[i].transform.position
-                    ),
+                    ) + 0.01f,
                     _spawnedHighlights[i].transform.position.z
                 );
             }
@@ -79,7 +79,7 @@ public class AOIPulseController : MonoBehaviour
             {
                 _spawnedHighlights[i].transform.position = new Vector3(
                     _spawnedHighlights[i].transform.position.x,
-                    MapHeightManager.UNSCOUTED_HEIGHT,
+                    MapHeightManager.UNSCOUTED_HEIGHT + 0.01f,
                     _spawnedHighlights[i].transform.position.z
                 );
             }

--- a/map/Assets/Map/Scripts/GameplayElements/MapElementManager.cs
+++ b/map/Assets/Map/Scripts/GameplayElements/MapElementManager.cs
@@ -154,13 +154,17 @@ public class MapElementManager : MonoBehaviour
     public void CreateGoo(
         ICollection<Cog.Atoms2> atoms,
         Vector3Int cubicCoords,
-        Transform tileTransform
+        Transform tileTransform,
+        bool hasBuilding
     )
     {
         if (!_spawnedGoo.ContainsKey(cubicCoords))
         {
-            // Find highest goo val
+            if (hasBuilding)
+                return;
+
             var atom = atoms.OrderByDescending(atom => atom.Weight).First();
+            // Find highest goo val
             if (atom.Weight >= smallGooThreshold)
             {
                 GameObject gooPrefab;
@@ -185,6 +189,17 @@ public class MapElementManager : MonoBehaviour
                 var goo = gooGO.GetComponent<GooController>();
                 goo.Setup(atom.Weight >= bigGooThreshold);
                 _spawnedGoo.Add(cubicCoords, goo);
+            }
+        }
+        else
+        {
+            if (hasBuilding)
+            {
+                _spawnedGoo[cubicCoords].Hide();
+            }
+            else
+            {
+                _spawnedGoo[cubicCoords].Show();
             }
         }
     }

--- a/map/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
+++ b/map/Assets/Map/Scripts/GameplayElements/MapInteractionManager.cs
@@ -268,7 +268,7 @@ public class MapInteractionManager : MonoBehaviour
             Vector3 markerPos = MapManager.instance.grid.CellToWorld(CurrentSelectedCell);
             float height = MapHeightManager.UNSCOUTED_HEIGHT;
             if (MapManager.instance.IsDiscoveredTile(cellPosCube))
-                height = MapHeightManager.instance.GetHeightAtPosition(markerPos);
+                height = MapHeightManager.instance.GetHeightAtPosition(markerPos) + 0.01f;
             selectedMarker1.position = new Vector3(markerPos.x, height, markerPos.z);
 
             selectedMarker1.gameObject.SetActive(true);

--- a/map/Assets/Map/Scripts/Intent/CombatIntent.cs
+++ b/map/Assets/Map/Scripts/Intent/CombatIntent.cs
@@ -219,7 +219,7 @@ public class CombatIntent : IntentHandler
                 );
                 highlight.transform.position = new Vector3(
                     cellPos.x,
-                    MapHeightManager.instance.GetHeightAtPosition(cellPos),
+                    MapHeightManager.instance.GetHeightAtPosition(cellPos) + 0.01f,
                     cellPos.z
                 );
                 spawnedHighlights.Add(cellPosCube, highlight);

--- a/map/Assets/Map/Scripts/Intent/ConstructIntent.cs
+++ b/map/Assets/Map/Scripts/Intent/ConstructIntent.cs
@@ -194,7 +194,7 @@ public class ConstructIntent : IntentHandler
                 );
                 highlight.transform.position = new Vector3(
                     cellPos.x,
-                    MapHeightManager.instance.GetHeightAtPosition(cellPos),
+                    MapHeightManager.instance.GetHeightAtPosition(cellPos) + 0.01f,
                     cellPos.z
                 );
                 spawnedHighlights.Add(cellPosCube, highlight);

--- a/map/Assets/Map/Scripts/Intent/MoveIntent.cs
+++ b/map/Assets/Map/Scripts/Intent/MoveIntent.cs
@@ -277,7 +277,7 @@ public class MoveIntent : IntentHandler
                 );
                 highlight.position = new Vector3(
                     highlight.position.x,
-                    MapHeightManager.instance.GetHeightAtPosition(highlight.position),
+                    MapHeightManager.instance.GetHeightAtPosition(highlight.position) + 0.01f,
                     highlight.position.z
                 );
                 lit.Add(space, highlight.gameObject);

--- a/map/Assets/Map/Scripts/UI/TravelMarkerController.cs
+++ b/map/Assets/Map/Scripts/UI/TravelMarkerController.cs
@@ -31,12 +31,12 @@ public class TravelMarkerController : MonoBehaviour
     {
         Vector3 startOffset = new Vector3(
             startPos.x,
-            MapHeightManager.instance.GetHeightAtPosition(startPos),
+            MapHeightManager.instance.GetHeightAtPosition(startPos) + 0.01f,
             startPos.z
         );
         Vector3 endOffset = new Vector3(
             endPos.x,
-            MapHeightManager.instance.GetHeightAtPosition(endPos),
+            MapHeightManager.instance.GetHeightAtPosition(endPos) + 0.01f,
             endPos.z
         );
         Vector3 worldEndPos = endOffset;


### PR DESCRIPTION
This PR hides the goo if any type of building is on top of it (including enemies, blockers and under-construction towers).
If the building is destroyed, the goo reappears.

Also in this PR is a fix for the z-fighting issues that the occur with the goo and the various UI highlights.