### PR TITLE
fixed tile heights, increased starting camera zoom

### DIFF
--- a/map/Assets/Map/Prefabs/MapCamera.prefab
+++ b/map/Assets/Map/Prefabs/MapCamera.prefab
@@ -268,7 +268,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6518314203346260197}
   m_LocalRotation: {x: 0.38268343, y: 0, z: 0, w: 0.92387956}
-  m_LocalPosition: {x: 0, y: 4.9497476, z: -4.949748}
+  m_LocalPosition: {x: 0, y: 10.606602, z: -10.606603}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -409,7 +409,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6518314203603543956}
   m_LocalRotation: {x: 0.38268343, y: -0, z: -0, w: 0.92387956}
-  m_LocalPosition: {x: 0, y: 4.9497476, z: -4.949748}
+  m_LocalPosition: {x: 0, y: 10.606602, z: -10.606603}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -690,7 +690,7 @@ MonoBehaviour:
   m_TargetMovementOnly: 1
   m_ScreenX: 0.5
   m_ScreenY: 0.5
-  m_CameraDistance: 7
+  m_CameraDistance: 15
   m_DeadZoneWidth: 0
   m_DeadZoneHeight: 0
   m_DeadZoneDepth: 0

--- a/map/Assets/Map/Scenes/MapScene.unity
+++ b/map/Assets/Map/Scenes/MapScene.unity
@@ -1540,7 +1540,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   heightScale: 0.5
-  heightOffset: -0.2
+  heightOffset: -0.3
   heightFrequency: 0.5
 --- !u!4 &739230786
 Transform:
@@ -3123,7 +3123,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   target: {fileID: 681872498}
   positionMask: {x: 1, y: 0, z: 1}
-  offset: {x: 0, y: -0.18, z: 0}
+  offset: {x: 0, y: -0.4, z: 0}
 --- !u!23 &1987954017
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -3459,16 +3459,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: MapCamera
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203346260187, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -4.949748
-      objectReference: {fileID: 0}
-    - target: {fileID: 6518314203603543945, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -4.949748
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13c17ec3607f94f34a8d6fc7cf4300af, type: 3}


### PR DESCRIPTION
Sometimes tiles would spawn below the ground plane (ocean) and would look like missing tiles.
This was because the minimum spawn height was set lower than the ground plane's height by a bit.
This PR fixes that.

Also I've made the camera start a bit more zoomed out to show more of the world when it loads in.