### PR TITLE
colorizing item icons based on atom/goo structure

### DIFF
--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -17,3 +17,67 @@ export const formatNameOrId = (node?: MaybeNamed, idPrefix: string = ''): string
     }
     return node.name?.value ? node.name.value : `${idPrefix}${formatShortId(node.id)}`;
 };
+
+export const getItemStructure = (itemId: string) => {
+    return [...itemId]
+        .slice(2)
+        .reduce((bs, b, idx) => {
+            if (idx % 8 === 0) {
+                bs.push('0x');
+            }
+            bs[bs.length - 1] += b;
+            return bs;
+        }, [] as string[])
+        .map((n: string) => Number(BigInt(n)))
+        .slice(-4);
+};
+
+// these hues map each goo color to a starting point on the hue wheel
+const HUE_BLUE = 0.55;
+const HUE_GREEN = 0.3;
+const HUE_RED = 0.92;
+
+// insecure little string=>number hash
+export const hashCode = (str: string): number => {
+    let hash = 0;
+    for (let i = 0, len = str.length; i < len; i++) {
+        const chr = str.charCodeAt(i);
+        hash = (hash << 5) - hash + chr;
+        hash |= 0;
+    }
+    return hash;
+};
+
+export const getItemColorCSS = (itemId: string): string => {
+    const [_stackable, greenGoo, blueGoo, redGoo] = getItemStructure(itemId);
+    const goo = [
+        { hue: HUE_RED, value: redGoo, hash: hashCode(`${itemId}-red`) },
+        { hue: HUE_GREEN, value: greenGoo, hash: hashCode(`${itemId}-green`) },
+        { hue: HUE_BLUE, value: blueGoo, hash: hashCode(`${itemId}-blue`) },
+    ]
+        .sort((a, b) => {
+            if (a.value === b.value) {
+                return a.hash - b.hash;
+            }
+            return a.value - b.value;
+        })
+        .reverse();
+
+    // calculate the hue of the item
+    // take goo0's hue
+    // shift the hue to the left by the difference betwee goo0 and goo1
+    // shift the hue to the right by the difference betwee goo1 and goo2
+    const shiftLeft = goo[0].value > 0 ? (1 - (goo[0].value - goo[1].value) / goo[0].value) * 0.2 : 0;
+    const shiftRight = goo[1].value > 0 ? (1 - (goo[1].value - goo[2].value) / goo[1].value) * 0.2 : 0;
+    const hue = goo[0].hue - shiftLeft + shiftRight;
+
+    // calculuate the lightness in range 50 - 100
+    // where 50 is a bright saturated color and 100 is pure white
+    // a item mostly made of a single goo ==> closer to a bright color
+    // a item evenly mixed of all goos ==> closer to white
+    const pureness1 = 1 - goo[1].value / goo[0].value;
+    const pureness2 = 1 - goo[2].value / goo[0].value;
+    const lightness = 100 - 10 * pureness1 - 40 * pureness2;
+
+    return `hsl(${hue}turn 90% ${lightness}%)`;
+};

--- a/frontend/src/plugins/combat/helpers.ts
+++ b/frontend/src/plugins/combat/helpers.ts
@@ -1,4 +1,4 @@
-import { formatNameOrId } from '@app/helpers';
+import { formatNameOrId, getItemStructure } from '@app/helpers';
 import { ATOM_ATTACK, ATOM_DEFENSE, ATOM_LIFE, CombatAction, EntityState } from '@app/plugins/combat/combat';
 import { CombatParticipantProps } from '@app/plugins/combat/combat-participant';
 import {
@@ -149,26 +149,12 @@ export const getEntityName = (entityID: BytesLike, world: WorldStateFragment) =>
     return formatNameOrId(unit, 'Unit ');
 };
 
-export const getItemStats = (itemId: string) => {
-    return [...itemId]
-        .slice(2)
-        .reduce((bs, b, idx) => {
-            if (idx % 8 === 0) {
-                bs.push('0x');
-            }
-            bs[bs.length - 1] += b;
-            return bs;
-        }, [] as string[])
-        .map((n: string) => Number(BigInt(n)))
-        .slice(-4);
-};
-
 export const getEquipmentStats = (equipmentSlots: EquipmentSlotFragment[]) => {
     return equipmentSlots.reduce(
         (stats, { bag }) => {
             bag.slots.forEach((slot) => {
                 if (slot.balance > 0) {
-                    const [stackable, life, defense, attack] = getItemStats(slot.item.id);
+                    const [stackable, life, defense, attack] = getItemStructure(slot.item.id);
                     if (!stackable) {
                         stats[ATOM_LIFE] += life * LIFE_MUL;
                         stats[ATOM_DEFENSE] += defense;
@@ -186,7 +172,7 @@ export const getMaterialStats = (materials: ItemSlotFragment[]) => {
     return materials.reduce(
         (stats, { item, balance }) => {
             if (balance > 0) {
-                const [_, life, defense, attack] = getItemStats(item.id);
+                const [_, life, defense, attack] = getItemStructure(item.id);
                 stats[ATOM_LIFE] += life * balance;
                 stats[ATOM_DEFENSE] += defense * balance;
                 stats[ATOM_ATTACK] += attack * balance;

--- a/frontend/src/plugins/inventory/bag-item/bag-item.styles.ts
+++ b/frontend/src/plugins/inventory/bag-item/bag-item.styles.ts
@@ -24,8 +24,11 @@ const baseStyles = ({ isPickable, isInteractable }: BagItemStyleProps) => css`
     cursor: ${isPickable && !isInteractable ? 'pointer' : 'auto'};
 
     .icon {
-        filter: invert(100%);
-        width: 50%;
+        width: 100%;
+        height: 100%;
+        mask-size: 50%;
+        mask-repeat: no-repeat;
+        mask-position: center;
     }
 
     .amount {

--- a/frontend/src/plugins/inventory/bag-item/index.tsx
+++ b/frontend/src/plugins/inventory/bag-item/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { ComponentProps } from '@app/types/component-props';
 import { styles } from './bag-item.styles';
 import { useInventory } from '@app/plugins/inventory/inventory-provider';
+import { getItemColorCSS, getItemStructure } from '@app/helpers';
 
 export interface BagItemProps extends ComponentProps {
     name: string;
@@ -56,17 +57,7 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
 
     const isPickable = !isPickedUpItemVisible;
 
-    const [stackable, greenGoo, blueGoo, redGoo] = [...itemId]
-        .slice(2)
-        .reduce((bs, b, idx) => {
-            if (idx % 8 === 0) {
-                bs.push('0x');
-            }
-            bs[bs.length - 1] += b;
-            return bs;
-        }, [] as string[])
-        .map((n: string) => BigInt(n))
-        .slice(-4);
+    const [stackable, greenGoo, blueGoo, redGoo] = getItemStructure(itemId);
 
     const isStackable = !!stackable;
 
@@ -83,7 +74,14 @@ export const BagItem: FunctionComponent<BagItemProps> = (props: BagItemProps) =>
             title={tooltip}
         >
             {isPending && <span className="spinner" />}
-            <img src={icon} alt={name} className="icon" />
+            <div
+                className="icon"
+                style={{
+                    maskImage: `url(${icon})`,
+                    WebkitMaskImage: `url(${icon})`,
+                    backgroundColor: getItemColorCSS(itemId),
+                }}
+            ></div>
             {isStackable && <span className="amount">{quantity}</span>}
         </StyledBagItem>
     );

--- a/frontend/src/plugins/inventory/bag-slot/bag-slot.styles.ts
+++ b/frontend/src/plugins/inventory/bag-slot/bag-slot.styles.ts
@@ -33,8 +33,11 @@ const baseStyles = ({ isDroppable, isDisabled, isInteractable, isInvalid }: BagS
         opacity: 0.3;
 
         .icon {
-            filter: invert(100%);
-            width: 50%;
+            width: 100%;
+            height: 100%;
+            mask-size: 50%;
+            mask-repeat: no-repeat;
+            mask-position: center;
         }
 
         .amount {

--- a/frontend/src/plugins/inventory/bag-slot/index.tsx
+++ b/frontend/src/plugins/inventory/bag-slot/index.tsx
@@ -1,5 +1,6 @@
 /** @format */
 
+import { getItemStructure } from '@app/helpers';
 import { BagItem } from '@app/plugins/inventory/bag-item';
 import { getItemDetails } from '@app/plugins/inventory/helpers';
 import { useInventory } from '@app/plugins/inventory/inventory-provider';
@@ -91,19 +92,7 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
         handleDrop(quantity);
     };
 
-    const [isStackableItem] = item
-        ? [...item.itemId]
-              .slice(2)
-              .reduce((bs, b, idx) => {
-                  if (idx % 8 === 0) {
-                      bs.push('0x');
-                  }
-                  bs[bs.length - 1] += b;
-                  return bs;
-              }, [] as string[])
-              .map((n: string) => BigInt(n))
-              .slice(-4)
-        : [false];
+    const [isStackableItem] = item ? getItemStructure(item.itemId) : [false];
 
     const isCompatiblePlaceholder =
         pickedUpItem && ((placeholder && placeholder.item.id === pickedUpItem.transferInfo.itemId) || !placeholder);
@@ -144,7 +133,14 @@ export const BagSlot: FunctionComponent<BagSlotProps> = (props: BagSlotProps) =>
                   )
                 : placeholderItem && (
                       <div className="placeholder" title={`${placeholderItem.quantity} ${placeholderItem.name}`}>
-                          <img src={placeholderItem.icon} alt={placeholderItem.name} className="icon" />
+                          <div
+                              className="icon"
+                              style={{
+                                  maskImage: `url(${placeholderItem.icon})`,
+                                  WebkitMaskImage: `url(${placeholderItem.icon})`,
+                                  backgroundColor: 'white',
+                              }}
+                          ></div>
                           <span className="amount">{placeholderItem.quantity}</span>
                       </div>
                   )}

--- a/frontend/src/plugins/inventory/inventory-provider.tsx
+++ b/frontend/src/plugins/inventory/inventory-provider.tsx
@@ -210,7 +210,14 @@ export const InventoryProvider = ({ children }: InventoryContextProviderProps): 
                     }}
                 >
                     <StyledPickedUpItem isPickable={false}>
-                        <img src={pickedUpItemRef.current.icon} alt={pickedUpItemRef.current.name} className="icon" />
+                        <div
+                            className="icon"
+                            style={{
+                                maskImage: `url(${pickedUpItemRef.current.icon})`,
+                                WebkitMaskImage: `url(${pickedUpItemRef.current.icon})`,
+                                backgroundColor: 'white',
+                            }}
+                        ></div>
                         <span className="amount">{pickedUpItemRef.current.quantity}</span>
                     </StyledPickedUpItem>
                 </div>


### PR DESCRIPTION
shows colored item icons in inventory ... the colors are dervived from the atomic structure of the Item.

the more "pure" an item is (more that it is mostly made up of a single color goo) then the more colorful the icon will be

the more "mixed" an item is (more evenly distributed goo makeup) then the more white the icon will be

![Screenshot 2023-09-01 at 10 55 46](https://github.com/playmint/ds/assets/45921/1905a1ae-5f4a-4ea4-b0f7-7131b127cf6d)

green goo shows as a colorful green as it is pure green

tyre is showing as an slightly light orange as it is a mix of two goo types (so the hue got shifted a bit into orange) and then a bit of lightness is added as it's not pure 

the duck is white as it is an even mix of goos

* resolves: #549 
