### PR TITLE
Fixed shadow distance

### DIFF
--- a/map/Assets/Map/URP Settings/URPAsset.asset
+++ b/map/Assets/Map/URP Settings/URPAsset.asset
@@ -25,8 +25,8 @@ MonoBehaviour:
   m_OpaqueDownsampling: 1
   m_SupportsTerrainHoles: 0
   m_StoreActionsOptimization: 0
-  m_SupportsHDR: 1
-  m_MSAA: 1
+  m_SupportsHDR: 0
+  m_MSAA: 4
   m_RenderScale: 1
   m_UpscalingFilter: 0
   m_FsrOverrideSharpness: 0
@@ -43,9 +43,9 @@ MonoBehaviour:
   m_AdditionalLightsShadowResolutionTierHigh: 1024
   m_ReflectionProbeBlending: 0
   m_ReflectionProbeBoxProjection: 0
-  m_ShadowDistance: 10
-  m_ShadowCascadeCount: 1
-  m_Cascade2Split: 0.2116851
+  m_ShadowDistance: 30
+  m_ShadowCascadeCount: 3
+  m_Cascade2Split: 0.352
   m_Cascade3Split: {x: 0.238889, y: 0.6009264}
   m_Cascade4Split: {x: 0.02, y: 0.19999999, z: 0.39999995}
   m_CascadeBorder: 0.506

--- a/map/Assets/Map/URP Settings/URPRenderer.asset
+++ b/map/Assets/Map/URP Settings/URPRenderer.asset
@@ -73,7 +73,7 @@ MonoBehaviour:
     passOperation: 2
     failOperation: 0
     zFailOperation: 0
-  m_ShadowTransparentReceive: 1
+  m_ShadowTransparentReceive: 0
   m_RenderingMode: 0
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 0

--- a/map/ProjectSettings/QualitySettings.asset
+++ b/map/ProjectSettings/QualitySettings.asset
@@ -21,7 +21,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 0
-    antiAliasing: 0
+    antiAliasing: 4
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0


### PR DESCRIPTION
Shadows were disappearing when the camera zoomed out a certain distance.
Shadows now have cascades that increase quality at closer distances and reduce it at farther distances while keeping the shadow visible.

Soft shadows don't seem to be working in the WebGL builds, cursory investigation suggested that this was an issue with a previous version of Unity which had supposedly been fixed. Could be something else is causing it, but I'll cross that bridge when I come to it.

Also I set the MSAA level to 4x to add some anti-aliasing and improve the render quality.

These are all changes that would effect performance on lower-end hardware. The quality of these effects (and others) can be reduced/removed if performance drops too low.