### PR TITLE
Added docs for building totem IDs

### DIFF
--- a/docs/content/code-docs/building-model-ids.md
+++ b/docs/content/code-docs/building-model-ids.md
@@ -1,0 +1,28 @@
+# Building Model IDs
+
+Building visuals are constructed using two stacked 'totems'.
+You can choose which totems to use for your building by setting the `model` tag in your buildings manifest.
+
+The format for setting the model tag is as follows: `model: ID-ID` where the first 'ID' is the **lower** building in the stack and the second is the **upper** building.
+
+For example, `model: 01-08` would create a building with a Bird Totem on the bottom and a Wooden Hut on the top.
+
+**Here is a list of all available totem IDs for you to choose from:**
+- **ID: `00` Barrel** 
+    - ![](/images/building-totems/Block_Barrel.png)
+- **ID: `01` Bird Totem** 
+    - ![](/images/building-totems/Block_BirdTotem.png)
+- **ID: `02` Burger** 
+    - ![](/images/building-totems/Block_Burger.png)
+- **ID: `03` Cactus** 
+    - ![](/images/building-totems/Block_Cactus.png)
+- **ID: `04` Cistern** 
+    - ![](/images/building-totems/Block_Cistern.png)
+- **ID: `05` Horned Totem** 
+    - ![](/images/building-totems/Block_HornedTotem.png)
+- **ID: `06` Stone Turret** 
+    - ![](/images/building-totems/Block_StoneTurret.png)
+- **ID: `07` Van** 
+    - ![](/images/building-totems/Block_Van.png)
+- **ID: `08` Wooden Hut** 
+    - ![](/images/building-totems/Block_WoodenHut.png)

--- a/docs/content/code-docs/building-model-ids.md
+++ b/docs/content/code-docs/building-model-ids.md
@@ -57,13 +57,13 @@ For example, `model: GrassLarge` would create a blocker with the Large Grass mod
     - ![](/images/building-totems/blockers/PineTreesLarge.png)
 - **ID: `'PineTreesSmall'`** 
     - ![](/images/building-totems/blockers/PineTreesSmall.png)
-- **ID: `'rocksLarge'`** 
-    - ![](/images/building-totems/blockers/Shrub.png)
-- **ID: `'rocksSmall'`** 
-    - ![](/images/building-totems/blockers/StoneWall.png)
 - **ID: `'Shrub'`** 
-    - ![](/images/building-totems/blockers/rocksLarge.png)
+    - ![](/images/building-totems/blockers/Shrub.png)
 - **ID: `'StoneWall'`** 
+    - ![](/images/building-totems/blockers/StoneWall.png)
+- **ID: `'rocksLarge'`** 
+    - ![](/images/building-totems/blockers/rocksLarge.png)
+- **ID: `'rocksSmall'`** 
     - ![](/images/building-totems/blockers/rocksSmall.png)
 
 ## Extractor Buildings ##

--- a/docs/content/code-docs/building-model-ids.md
+++ b/docs/content/code-docs/building-model-ids.md
@@ -1,9 +1,13 @@
 # Building Model IDs
 
-Building visuals are constructed using two stacked 'totems'.
-You can choose which totems to use for your building by setting the `model` tag in your buildings manifest.
+The types of models that your building can use depend on the **category** of building that you are creating.
 
-The format for setting the model tag is as follows: `model: ID-ID` where the first 'ID' is the **lower** building in the stack and the second is the **upper** building.
+This page explains which models are available for which categories and how to use them.
+
+## Factory/Custom Buildings ##
+The visuals for `category: factory` or `category: custom` buildings are created using two stacked 'Totems'.
+
+The format for setting these totems in your building's model tag is as follows: `model: ID-ID` where the first 'ID' is the **lower** building in the stack and the second is the **upper** building.
 
 For example, `model: 01-08` would create a building with a Bird Totem on the bottom and a Wooden Hut on the top.
 
@@ -26,3 +30,51 @@ For example, `model: 01-08` would create a building with a Bird Totem on the bot
     - ![](/images/building-totems/Block_Van.png)
 - **ID: `08` Wooden Hut** 
     - ![](/images/building-totems/Block_WoodenHut.png)
+
+## Blocker Buildings ##
+The visuals for `category: blocker` buildings are chosen using a single named ID.
+
+For example, `model: GrassLarge` would create a blocker with the Large Grass model.
+
+**Here is a list of all available blocker IDs for you to choose from:**
+- **ID: `'enemy'`** 
+    - ![](/images/building-totems/blockers/Enemy.png)
+- **ID: `'CactusLarge'`** 
+    - ![](/images/building-totems/blockers/CactusLarge.png)
+- **ID: `'CactusSmall'`** 
+    - ![](/images/building-totems/blockers/CactusSmall.png)
+- **ID: `'GrassLarge'`** 
+    - ![](/images/building-totems/blockers/GrassLarge.png)
+- **ID: `'LogWall'`** 
+    - ![](/images/building-totems/blockers/LogWall.png)
+- **ID: `'OakTreesLarge'`** 
+    - ![](/images/building-totems/blockers/OakTreesLarge.png)
+- **ID: `'OakTreesSmall'`** 
+    - ![](/images/building-totems/blockers/OakTreesSmall.png)
+- **ID: `'PalmTrees'`** 
+    - ![](/images/building-totems/blockers/PalmTrees.png)
+- **ID: `'PineTreesLarge'`** 
+    - ![](/images/building-totems/blockers/PineTreesLarge.png)
+- **ID: `'PineTreesSmall'`** 
+    - ![](/images/building-totems/blockers/PineTreesSmall.png)
+- **ID: `'rocksLarge'`** 
+    - ![](/images/building-totems/blockers/Shrub.png)
+- **ID: `'rocksSmall'`** 
+    - ![](/images/building-totems/blockers/StoneWall.png)
+- **ID: `'Shrub'`** 
+    - ![](/images/building-totems/blockers/rocksLarge.png)
+- **ID: `'StoneWall'`** 
+    - ![](/images/building-totems/blockers/rocksSmall.png)
+
+## Extractor Buildings ##
+The visuals for `category: extractor` buildings are chosen using a color ID to decide which color goo should be shown in the extractor's tank.
+
+For example, `model: red` would create an extractor with red colored goo.
+
+**Here is a list of all available extractor IDs for you to choose from:**
+- **ID: `red`** 
+    - ![](/images/building-totems/extractors/ExtractorRed.png)
+- **ID: `green`** 
+    - ![](/images/building-totems/extractors/ExtractorGreen.png)
+- **ID: `blue`** 
+    - ![](/images/building-totems/extractors/ExtractorBlue.png)

--- a/docs/static/images/building-totems/Block_Barrel.png
+++ b/docs/static/images/building-totems/Block_Barrel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63ef4ec77b6920f3f269117b7c4f92f1a124d1dc74623ff5c34fe3266dd879d8
+size 51624

--- a/docs/static/images/building-totems/Block_BirdTotem.png
+++ b/docs/static/images/building-totems/Block_BirdTotem.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:913d6950332b2989cf02366a4e362e5bac0c4ba5bf49bcd22fa78616c0737afa
+size 46616

--- a/docs/static/images/building-totems/Block_Burger.png
+++ b/docs/static/images/building-totems/Block_Burger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbc6ea38a96f94e4a164eb632ea45735395c49e8525c940b7aba321e642efc5f
+size 43459

--- a/docs/static/images/building-totems/Block_Cactus.png
+++ b/docs/static/images/building-totems/Block_Cactus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acda1ac0f79fb97110f597376042d547f9e298de20727b97368268bfa9e8679f
+size 42841

--- a/docs/static/images/building-totems/Block_Cistern.png
+++ b/docs/static/images/building-totems/Block_Cistern.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6c3a768c7d1d215757ab6ac6ed478d41aad40da1f7a28d700bfca538e73edad
+size 44520

--- a/docs/static/images/building-totems/Block_HornedTotem.png
+++ b/docs/static/images/building-totems/Block_HornedTotem.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2026b6d828a56d236228a88ff92e9d1617d611552a8f121d84e76b392c5d5315
+size 50384

--- a/docs/static/images/building-totems/Block_StoneTurret.png
+++ b/docs/static/images/building-totems/Block_StoneTurret.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3e37be4ab37b07af7e6ca76ada4cb5488800c63794ced3002034db3629ebeb2
+size 56785

--- a/docs/static/images/building-totems/Block_Van.png
+++ b/docs/static/images/building-totems/Block_Van.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:908c7a0817066fae64fb422c77ba281b9f0ef5eea289b822999014ee5c277e50
+size 54485

--- a/docs/static/images/building-totems/Block_WoodenHut.png
+++ b/docs/static/images/building-totems/Block_WoodenHut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39f7d74e0b5c33cd7c72c2b6c1c904d0ef5fa218e56a70d1a66fa7b5390c3f56
+size 55327

--- a/docs/static/images/building-totems/blockers/CactusLarge.png
+++ b/docs/static/images/building-totems/blockers/CactusLarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43251b2e0dc1da313d2b928a2219cab91525dae5a7f2694545a38c6fbc7be348
+size 24007

--- a/docs/static/images/building-totems/blockers/CactusSmall.png
+++ b/docs/static/images/building-totems/blockers/CactusSmall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2698555c7835e45ed48da624d4f9920dc103d7129c2b4378e537b91a8f420d49
+size 21413

--- a/docs/static/images/building-totems/blockers/Enemy.png
+++ b/docs/static/images/building-totems/blockers/Enemy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd2327c92dba64a63f7e4207529ac3fc8228d774f1bc9326bf5a5a8cea83dac5
+size 32525

--- a/docs/static/images/building-totems/blockers/GrassLarge.png
+++ b/docs/static/images/building-totems/blockers/GrassLarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e685ea254fad43334623f27c3c78f0842ca489ca79cfb3ca73586295b8ae684
+size 23726

--- a/docs/static/images/building-totems/blockers/LogWall.png
+++ b/docs/static/images/building-totems/blockers/LogWall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0581d68ce47d1393bf701fd8f7db350731da0c53334473199f45129a2b5e721a
+size 27900

--- a/docs/static/images/building-totems/blockers/OakTreesLarge.png
+++ b/docs/static/images/building-totems/blockers/OakTreesLarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e16fe3d7adfeab01670527cc5d9c2091a7e012018136cfb2e3337862600a9326
+size 36724

--- a/docs/static/images/building-totems/blockers/OakTreesSmall.png
+++ b/docs/static/images/building-totems/blockers/OakTreesSmall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2300a632f94954f4139c662d253cb0f304628cce06f3df21b8ea01ad63da366b
+size 34844

--- a/docs/static/images/building-totems/blockers/PalmTrees.png
+++ b/docs/static/images/building-totems/blockers/PalmTrees.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8387e5de69bf8f460732b6eb7acaa12eddb7ee78ef6ac05a6e9de98bc59fee1
+size 33686

--- a/docs/static/images/building-totems/blockers/PineTreesLarge.png
+++ b/docs/static/images/building-totems/blockers/PineTreesLarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe092be354aff08875aac2710f838fdb52e1c22a27fff8d4be0481b599918a92
+size 31923

--- a/docs/static/images/building-totems/blockers/PineTreesSmall.png
+++ b/docs/static/images/building-totems/blockers/PineTreesSmall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04dc8bff710d3f042c08beea2e36ec8b9af58d805865c3cd62ff46d3b74d9a52
+size 27313

--- a/docs/static/images/building-totems/blockers/Shrub.png
+++ b/docs/static/images/building-totems/blockers/Shrub.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5ee6f2c12f9cc676e2117a74862931b75e132aa3ca4b44da038a24466b6014e
+size 22428

--- a/docs/static/images/building-totems/blockers/StoneWall.png
+++ b/docs/static/images/building-totems/blockers/StoneWall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67ce93b61a1aebb17a9e45e07f4073f947790101b295dfde9d8f6e00d1ec626c
+size 29802

--- a/docs/static/images/building-totems/blockers/rocksLarge.png
+++ b/docs/static/images/building-totems/blockers/rocksLarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46bf75d19886ea7591d4259a8d7d4c168b339fefbc5837151865c797f16b852d
+size 35649

--- a/docs/static/images/building-totems/blockers/rocksSmall.png
+++ b/docs/static/images/building-totems/blockers/rocksSmall.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d0c3a3dcabc7613482e796ae088a7660a7852c0944e99356b50e137dc8afe30
+size 22359

--- a/docs/static/images/building-totems/extractors/ExtractorBlue.png
+++ b/docs/static/images/building-totems/extractors/ExtractorBlue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b7ec8fc13212bfb2fce006cdcdee0c5e0e38f8eac526600657c7a5a11d4fb5a
+size 41770

--- a/docs/static/images/building-totems/extractors/ExtractorGreen.png
+++ b/docs/static/images/building-totems/extractors/ExtractorGreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:821f9e8ffb9e06f7703ce8f113e488162a8bffa47e67bbd75799be765bd0c295
+size 41948

--- a/docs/static/images/building-totems/extractors/ExtractorRed.png
+++ b/docs/static/images/building-totems/extractors/ExtractorRed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb8a246343b2439bde157120897fafb77d8b57c16994b4333ebca3a8c87a8bcc
+size 41901


### PR DESCRIPTION
This PR adds a page to the Downstream docs which explains how to use totem IDs for customising building visuals.
It also provides a visual list of the IDs and their models.