### PR TITLE
Slowed down goo rates, and changed tiles to display goo per hour

### DIFF
--- a/contracts/src/fixtures/extractors/GenericExtractor.js
+++ b/contracts/src/fixtures/extractors/GenericExtractor.js
@@ -24,18 +24,19 @@ function getGooColor(gooIndex) {
 const getSecsPerGoo = (atomVal) => {
     if (atomVal < 70) return 0;
 
-    const x = atomVal - 63;
-    const baseSecsPerGoo = 120 * Math.pow(0.973, x);
+    const x = atomVal - 70;
+    const baseSecsPerGoo = 120 * Math.pow(0.985, x);
 
-    if (atomVal >= 165) return Math.max(baseSecsPerGoo * 0.75, 4);
+    if (atomVal >= 165) return Math.max(baseSecsPerGoo * 0.75, 20);
     else if (atomVal >= 155) return baseSecsPerGoo * 0.85;
     else return baseSecsPerGoo;
 };
 
 const getGooPerSec = (atomVal) => {
     const secsPerGoo = getSecsPerGoo(atomVal);
-    return secsPerGoo > 0 ? Math.floor((1 / secsPerGoo) * 100) / 100 : 0;
+    return secsPerGoo > 0 ? ((1 / secsPerGoo) * 100) / 100 : 0;
 };
+
 
 export default function update({ selected, world }, block) {
     const { tiles, mobileUnit } = selected || {};

--- a/contracts/src/rules/ExtractionRule.sol
+++ b/contracts/src/rules/ExtractionRule.sol
@@ -155,7 +155,7 @@ contract ExtractionRule is Rule {
     function _getSecsPerGoo(uint64 atomVal) private pure returns (int128) {
         if (atomVal < 70) return Math.fromUInt(0);
 
-        uint256 x = atomVal > 70 ? atomVal - 70 : 0;
+        uint256 x = atomVal >= 70 ? atomVal - 70 : 0;
         int128 baseSecsPerGoo = Math.fromUInt(120).mul(Math.fromUInt(9850).div(Math.fromUInt(10000)).pow(x));
 
         if (atomVal >= 165) {

--- a/contracts/src/rules/ExtractionRule.sol
+++ b/contracts/src/rules/ExtractionRule.sol
@@ -155,8 +155,8 @@ contract ExtractionRule is Rule {
     function _getSecsPerGoo(uint64 atomVal) private pure returns (int128) {
         if (atomVal < 70) return Math.fromUInt(0);
 
-        uint256 x = atomVal > 70 ? atomVal - 63 : 0;
-        int128 baseSecsPerGoo = Math.fromUInt(120).mul(Math.fromUInt(9730).div(Math.fromUInt(10000)).pow(x));
+        uint256 x = atomVal > 70 ? atomVal - 70 : 0;
+        int128 baseSecsPerGoo = Math.fromUInt(120).mul(Math.fromUInt(9850).div(Math.fromUInt(10000)).pow(x));
 
         if (atomVal >= 165) {
             baseSecsPerGoo = Math.mul(baseSecsPerGoo, Math.fromUInt(75).div(Math.fromUInt(100)));
@@ -164,7 +164,7 @@ contract ExtractionRule is Rule {
             baseSecsPerGoo = Math.mul(baseSecsPerGoo, Math.fromUInt(85).div(Math.fromUInt(100)));
         }
 
-        if (baseSecsPerGoo < 4) return 4;
+        if (baseSecsPerGoo < 20) return 20;
         else return baseSecsPerGoo;
     }
 

--- a/contracts/test/rules/ExtractionRule.t.sol
+++ b/contracts/test/rules/ExtractionRule.t.sol
@@ -102,7 +102,7 @@ contract ExtractionRuleTest is Test, GameTest {
         state.setTileAtomValues(tile, [uint64(255), uint64(0), uint64(0)]);
 
         // -- Move time forward to completely fill reservoir
-        vm.roll(block.number + 200);
+        vm.roll(block.number + 1000);
 
         // extract
         vm.startPrank(address(mockBuildingContract));

--- a/contracts/test/rules/ExtractionRule.t.sol
+++ b/contracts/test/rules/ExtractionRule.t.sol
@@ -102,7 +102,7 @@ contract ExtractionRuleTest is Test, GameTest {
         state.setTileAtomValues(tile, [uint64(255), uint64(0), uint64(0)]);
 
         // -- Move time forward to completely fill reservoir
-        vm.roll(block.number + 1000);
+        vm.roll(block.number + 2000);
 
         // extract
         vm.startPrank(address(mockBuildingContract));

--- a/frontend/src/helpers/tile.ts
+++ b/frontend/src/helpers/tile.ts
@@ -61,10 +61,10 @@ export const GOO_RED = 2;
 export const getSecsPerGoo = (atomVal: number) => {
     if (atomVal < 70) return 0;
 
-    const x = atomVal - 63;
-    const baseSecsPerGoo = 120 * Math.pow(0.973, x);
+    const x = atomVal - 70;
+    const baseSecsPerGoo = 120 * Math.pow(0.985, x);
 
-    if (atomVal >= 165) return Math.max(baseSecsPerGoo * 0.75, 4);
+    if (atomVal >= 165) return Math.max(baseSecsPerGoo * 0.75, 20);
     else if (atomVal >= 155) return baseSecsPerGoo * 0.85;
     else return baseSecsPerGoo;
 };

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -182,7 +182,7 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, world, m
             {gooRatesInNameOrder.map((goo) => (
                 <span key={goo?.name} className="label" style={{ width: '30%' }}>
                     <strong>{goo?.name.toUpperCase().slice(0, 1)}:</strong>{' '}
-                    {`${Math.floor((goo?.gooPerSec || 0) * 100) / 100}/s`}
+                    {`${Math.floor((goo?.gooPerSec || 0) * 3600)}/h`}
                 </span>
             ))}
             {author && (
@@ -256,7 +256,7 @@ const TileAvailable: FunctionComponent<TileAvailableProps> = ({ player }) => {
             {gooRatesInNameOrder.map((goo) => (
                 <span key={goo?.name} className="label" style={{ width: '30%' }}>
                     <strong>{goo?.name.toUpperCase().slice(0, 1)}:</strong>{' '}
-                    {`${Math.floor((goo?.gooPerSec || 0) * 100) / 100}/s`}
+                    {`${Math.floor((goo?.gooPerSec || 0) * 3600)}/h`}
                 </span>
             ))}
         </StyledActionContextPanel>


### PR DESCRIPTION
- Goo extraction is about 5x slower on the best tiles (slightly better on the worst tiles)
- Goo rate on tile display is now shown in goo per hour
- Edited Generic Extractor.js to deal with slow goo per seconds (rather than rounding to 0)