### PR TITLE
Increased the amount of time allowed to extract goo for the test

### DIFF
--- a/contracts/test/rules/ExtractionRule.t.sol
+++ b/contracts/test/rules/ExtractionRule.t.sol
@@ -102,7 +102,7 @@ contract ExtractionRuleTest is Test, GameTest {
         state.setTileAtomValues(tile, [uint64(255), uint64(0), uint64(0)]);
 
         // -- Move time forward to completely fill reservoir
-        vm.roll(block.number + 200);
+        vm.roll(block.number + 500);
 
         // extract
         vm.startPrank(address(mockBuildingContract));


### PR DESCRIPTION
The new slower goo extraction means that the Extraction test is failing because it doesn't have time to collect enough (I think)

Have increased the time allowed in the test