### PR TITLE
Goo not visible under construction highlight

### DIFF
--- a/map/Assets/Map/Animations/HighlightFadeIn.anim
+++ b/map/Assets/Map/Animations/HighlightFadeIn.anim
@@ -31,7 +31,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.16666667
-        value: 1
+        value: 0.8509804
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -96,7 +96,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.16666667
-        value: 1
+        value: 0.8509804
         inSlope: 0
         outSlope: 0
         tangentMode: 136


### PR DESCRIPTION
Reduced opacity of construction highlight so that goo is still visible.