### PR TITLE
Selecting an invalid tile in move Intent does NOT cancel move intent

### DIFF
--- a/map/Assets/Map/Scripts/Intent/MoveIntent.cs
+++ b/map/Assets/Map/Scripts/Intent/MoveIntent.cs
@@ -338,7 +338,12 @@ public class MoveIntent : IntentHandler
             GameStateMediator.Instance.SendSelectTileMsg(tileIDs);
         }
         else
-            DeselectMobileUnitAndIntent(true);
+        {
+            // invalid selection
+            // - do nothing
+            // - might want to cancel moving here with DeselectMobileUnitAndIntent(true),
+            //   but that's currently too easy to do by mistake)
+        }
     }
 
     void DeselectMobileUnitAndIntent(bool andTile = false)


### PR DESCRIPTION
### What
The move intent, as handled by the map, no longer cancels if the player clicks an invalid tile. Instead the current path does not change and the player remains in move intent.

To cancel move the player must not click the UI cancel cross, or click an empty space with no tiles.

### Why
Its too easy to cancel by mistake

fixes #615 
fixes #636 