### PR TITLE
Readme - submodules added to clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You will need the following tools installed:
 clone this repository:
 
 ```
-git clone https://github.com/playmint/ds-unity.git
+git clone --recurse-submodules https://github.com/playmint/ds-unity.git
 ```
 
 build and start the client and supporting services in development mode run:


### PR DESCRIPTION
The Readme instructions give the clone command without submodules, which are needed for it to work.