### PR TITLE
Screen space UI

### DIFF
--- a/frontend/public/Polygon 2.png
+++ b/frontend/public/Polygon 2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e76e1ff4120a56d8b911ed554f39ff965a50b95670e8344ff61813c47feed278
+size 1087

--- a/frontend/public/Subtract.png
+++ b/frontend/public/Subtract.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50cc6020c493042c11aeadae5d33f8136f713f0e160fd7b80f9b3b4a83f8c7c1
+size 451

--- a/frontend/src/components/map/Bag.tsx
+++ b/frontend/src/components/map/Bag.tsx
@@ -85,6 +85,7 @@ export const Bags = memo(
 
                     return t.bagCount > 0 || rewardBags.length > 0 ? (
                         <Bag
+                            sendScreenPosition={false}
                             id={`bag/${t.id}`}
                             key={`bag/${t.id}`}
                             height={getTileHeight(t)}

--- a/frontend/src/components/map/Bag.tsx
+++ b/frontend/src/components/map/Bag.tsx
@@ -10,6 +10,7 @@ export interface BagData {
     height: number;
     corner: number; // 0,1,2,3,3,4,5
     selected?: '' | 'none' | 'highlight' | 'outline';
+    sendScreenPosition: boolean;
 }
 
 export const Bag = memo(
@@ -21,6 +22,7 @@ export const Bag = memo(
         height,
         corner,
         selected,
+        sendScreenPosition,
         onPointerEnter,
         onPointerExit,
         onPointerClick,
@@ -35,7 +37,10 @@ export const Bag = memo(
         useUnityComponentManager<BagData>({
             type: 'BagData',
             id,
-            data: useMemo(() => ({ q, r, s, height, corner, selected }), [q, r, s, height, corner, selected]),
+            data: useMemo(
+                () => ({ q, r, s, height, corner, selected, sendScreenPosition }),
+                [q, r, s, height, corner, selected, sendScreenPosition]
+            ),
             onPointerEnter,
             onPointerExit,
             onPointerClick,

--- a/frontend/src/components/map/BlockerBuilding.tsx
+++ b/frontend/src/components/map/BlockerBuilding.tsx
@@ -9,6 +9,7 @@ export interface BlockerBuildingData {
     rotation: number;
     model?: string;
     selected?: '' | 'none' | 'highlight' | 'outline';
+    sendScreenPosition?: boolean;
 }
 
 export const BlockerBuilding = memo(
@@ -21,6 +22,7 @@ export const BlockerBuilding = memo(
         model,
         selected,
         rotation,
+        sendScreenPosition,
         onPointerEnter,
         onPointerExit,
         onPointerClick,
@@ -36,14 +38,13 @@ export const BlockerBuilding = memo(
             type: 'BlockerBuildingData',
             id,
             data: useMemo(
-                () => ({ q, r, s, height, model, selected, rotation }),
-                [q, r, s, height, model, selected, rotation]
+                () => ({ q, r, s, height, model, selected, rotation, sendScreenPosition }),
+                [q, r, s, height, model, selected, rotation, sendScreenPosition]
             ),
             onPointerEnter,
             onPointerExit,
             onPointerClick,
         });
-
         return null;
     }
 );

--- a/frontend/src/components/map/FactoryBuilding.tsx
+++ b/frontend/src/components/map/FactoryBuilding.tsx
@@ -9,6 +9,7 @@ export interface FactoryBuildingData {
     rotation: number;
     model?: string;
     selected?: '' | 'none' | 'highlight' | 'outline';
+    sendScreenPosition?: boolean;
 }
 
 export const FactoryBuilding = memo(
@@ -21,6 +22,7 @@ export const FactoryBuilding = memo(
         model,
         selected,
         rotation,
+        sendScreenPosition,
         onPointerEnter,
         onPointerExit,
         onPointerClick,
@@ -36,8 +38,8 @@ export const FactoryBuilding = memo(
             type: 'FactoryBuildingData',
             id,
             data: useMemo(
-                () => ({ q, r, s, height, model, selected, rotation }),
-                [q, r, s, height, model, selected, rotation]
+                () => ({ q, r, s, height, model, selected, rotation, sendScreenPosition }),
+                [q, r, s, height, model, selected, rotation, sendScreenPosition]
             ),
             onPointerEnter,
             onPointerExit,

--- a/frontend/src/components/map/Icon.tsx
+++ b/frontend/src/components/map/Icon.tsx
@@ -9,16 +9,27 @@ export interface IconData {
     backgroundColor: string;
     foregroundColor: string;
     image: string;
+    sendScreenPosition?: boolean;
 }
 
 export const Icon = memo(
-    ({ id, q, r, s, height, backgroundColor, foregroundColor, image }: UnityComponentProps & IconData) => {
+    ({
+        id,
+        q,
+        r,
+        s,
+        height,
+        backgroundColor,
+        foregroundColor,
+        image,
+        sendScreenPosition,
+    }: UnityComponentProps & IconData) => {
         useUnityComponentManager<IconData>({
             type: 'IconData',
             id,
             data: useMemo(
-                () => ({ q, r, s, height, backgroundColor, foregroundColor, image }),
-                [q, r, s, height, backgroundColor, foregroundColor, image]
+                () => ({ q, r, s, height, backgroundColor, foregroundColor, image, sendScreenPosition }),
+                [q, r, s, height, backgroundColor, foregroundColor, image, sendScreenPosition]
             ),
         });
 

--- a/frontend/src/components/map/Label.tsx
+++ b/frontend/src/components/map/Label.tsx
@@ -7,13 +7,17 @@ export interface LabelData {
     s: number;
     height: number;
     text: string;
+    sendScreenPosition?: boolean;
 }
 
-export const Label = memo(({ id, q, r, s, height, text }: UnityComponentProps & LabelData) => {
+export const Label = memo(({ id, q, r, s, height, text, sendScreenPosition }: UnityComponentProps & LabelData) => {
     useUnityComponentManager<LabelData>({
         type: 'LabelData',
         id,
-        data: useMemo(() => ({ q, r, s, height, text }), [q, r, s, height, text]),
+        data: useMemo(
+            () => ({ q, r, s, height, text, sendScreenPosition }),
+            [q, r, s, height, text, sendScreenPosition]
+        ),
     });
 
     return null;

--- a/frontend/src/components/map/Tile.tsx
+++ b/frontend/src/components/map/Tile.tsx
@@ -69,7 +69,8 @@ export const Tiles = memo(
                     const coords = getCoords(t);
                     return (
                         <Tile
-                            sendScreenPosition={false} key={t.id}
+                            sendScreenPosition={false}
+                            key={t.id}
                             id={t.id}
                             height={getTileHeight(t)}
                             color="#7288A6"

--- a/frontend/src/components/map/Tile.tsx
+++ b/frontend/src/components/map/Tile.tsx
@@ -10,14 +10,29 @@ export interface TileData {
     s: number;
     height: number;
     color: string;
+    sendScreenPosition: boolean;
 }
 
 export const Tile = memo(
-    ({ id, q, r, s, height, color, onPointerEnter, onPointerExit, onPointerClick }: UnityComponentProps & TileData) => {
+    ({
+        id,
+        q,
+        r,
+        s,
+        height,
+        color,
+        sendScreenPosition,
+        onPointerEnter,
+        onPointerExit,
+        onPointerClick,
+    }: UnityComponentProps & TileData) => {
         useUnityComponentManager<TileData>({
             type: 'TileData',
             id,
-            data: useMemo(() => ({ q, r, s, height, color }), [q, r, s, height, color]),
+            data: useMemo(
+                () => ({ q, r, s, height, color, sendScreenPosition }),
+                [q, r, s, height, color, sendScreenPosition]
+            ),
             onPointerEnter,
             onPointerExit,
             onPointerClick,

--- a/frontend/src/components/map/Tile.tsx
+++ b/frontend/src/components/map/Tile.tsx
@@ -69,7 +69,7 @@ export const Tiles = memo(
                     const coords = getCoords(t);
                     return (
                         <Tile
-                            key={t.id}
+                            sendScreenPosition={false} key={t.id}
                             id={t.id}
                             height={getTileHeight(t)}
                             color="#7288A6"

--- a/frontend/src/components/map/TileHighlight.tsx
+++ b/frontend/src/components/map/TileHighlight.tsx
@@ -9,16 +9,26 @@ export interface TileHighlightData {
     color: string;
     animation?: 'none' | 'pulse';
     style?: 'flat' | 'gradient' | 'gradient_blue' | 'gradient_outline';
+    sendScreenPosition?: boolean;
 }
 
 export const TileHighlight = memo(
-    ({ id, q, r, s, height, color, style, animation }: UnityComponentProps & TileHighlightData) => {
+    ({ id, q, r, s, height, color, style, animation, sendScreenPosition }: UnityComponentProps & TileHighlightData) => {
         useUnityComponentManager<TileHighlightData>({
             type: 'TileHighlightData',
             id,
             data: useMemo(
-                () => ({ q, r, s, height, color, style: style || 'gradient_outline', animation: animation || 'none' }),
-                [q, r, s, height, color, style, animation]
+                () => ({
+                    q,
+                    r,
+                    s,
+                    height,
+                    color,
+                    sendScreenPosition,
+                    style: style || 'gradient_outline',
+                    animation: animation || 'none',
+                }),
+                [q, r, s, height, color, style, animation, sendScreenPosition]
             ),
         });
 

--- a/frontend/src/components/map/TileIcon.tsx
+++ b/frontend/src/components/map/TileIcon.tsx
@@ -7,14 +7,20 @@ export interface TileIconData {
     s: number;
     height: number;
     icon: string;
+    sendScreenPosition?: boolean;
 }
 
-export const TileIcon = memo(({ id, q, r, s, height, icon }: UnityComponentProps & TileIconData) => {
-    useUnityComponentManager<TileIconData>({
-        type: 'TileIconData',
-        id,
-        data: useMemo(() => ({ q, r, s, height, icon }), [q, r, s, height, icon]),
-    });
+export const TileIcon = memo(
+    ({ id, q, r, s, height, icon, sendScreenPosition }: UnityComponentProps & TileIconData) => {
+        useUnityComponentManager<TileIconData>({
+            type: 'TileIconData',
+            id,
+            data: useMemo(
+                () => ({ q, r, s, height, icon, sendScreenPosition }),
+                [q, r, s, height, icon, sendScreenPosition]
+            ),
+        });
 
-    return null;
-});
+        return null;
+    }
+);

--- a/map/Assets/Scenes/MapScene.unity
+++ b/map/Assets/Scenes/MapScene.unity
@@ -254,7 +254,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &359895530
 GameObject:
@@ -421,7 +421,7 @@ RectTransform:
   - {fileID: 359895531}
   - {fileID: 1759083160}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -603,7 +603,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &752386732
 MonoBehaviour:
@@ -838,193 +838,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &834498989
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 834498991}
-  - component: {fileID: 834498990}
-  m_Layer: 0
-  m_Name: SelectedMarker
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &834498990
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 834498989}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: 6da8d971b2cc2f5418472bad9888d8ec, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.78431374}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.0039216, y: 1.0039216}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &834498991
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 834498989}
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: -1.58, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!1 &1206279867
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1206279871}
-  - component: {fileID: 1206279870}
-  - component: {fileID: 1206279869}
-  - component: {fileID: 1206279868}
-  m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1206279868
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1206279867}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &1206279869
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1206279867}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!223 &1206279870
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1206279867}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!224 &1206279871
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1206279867}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1825468674}
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
 --- !u!1 &1302764675
 GameObject:
   m_ObjectHideFlags: 0
@@ -1091,7 +906,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1394982058 stripped
 GameObject:
@@ -1247,82 +1062,6 @@ MonoBehaviour:
   strokeCutoff: 0.2
   farWidth: 2
   nearWidth: 7
---- !u!1 &1825468673
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1825468674}
-  - component: {fileID: 1825468676}
-  - component: {fileID: 1825468675}
-  m_Layer: 5
-  m_Name: Image
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1825468674
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1825468673}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1206279871}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1825468675
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1825468673}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1825468676
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1825468673}
-  m_CullTransparentMesh: 1
 --- !u!20 &1911231969 stripped
 Camera:
   m_CorrespondingSourceObject: {fileID: 6518314203603543946, guid: 13c17ec3607f94f34a8d6fc7cf4300af,

--- a/map/Assets/Scenes/MapScene.unity
+++ b/map/Assets/Scenes/MapScene.unity
@@ -924,6 +924,107 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &1206279867
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1206279871}
+  - component: {fileID: 1206279870}
+  - component: {fileID: 1206279869}
+  - component: {fileID: 1206279868}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1206279868
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1206279867}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1206279869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1206279867}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1206279870
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1206279867}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1206279871
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1206279867}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1825468674}
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &1302764675
 GameObject:
   m_ObjectHideFlags: 0
@@ -1136,7 +1237,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a1ab31ed6427e4d91910a0d1a1ae4cfb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  outlineTexture: {fileID: 0}
   outlineCam: {fileID: 591643644}
   camController: {fileID: 324799505}
   outlineRenderer: {fileID: -1408938807035450848, guid: 27dd91c15039b4701906e82860452235,
@@ -1147,6 +1247,82 @@ MonoBehaviour:
   strokeCutoff: 0.2
   farWidth: 2
   nearWidth: 7
+--- !u!1 &1825468673
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1825468674}
+  - component: {fileID: 1825468676}
+  - component: {fileID: 1825468675}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1825468674
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1825468673}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1206279871}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1825468675
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1825468673}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1825468676
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1825468673}
+  m_CullTransparentMesh: 1
 --- !u!20 &1911231969 stripped
 Camera:
   m_CorrespondingSourceObject: {fileID: 6518314203603543946, guid: 13c17ec3607f94f34a8d6fc7cf4300af,

--- a/map/Assets/Scripts/Components/Bag/BagController.cs.meta
+++ b/map/Assets/Scripts/Components/Bag/BagController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 300
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/Base/BaseComponentController.cs
+++ b/map/Assets/Scripts/Components/Base/BaseComponentController.cs
@@ -39,13 +39,15 @@ public class BaseComponentController<Data>
     {
         if (!_nextData.sendScreenPosition)
             return;
-        Vector3 screenPoint = Camera.main.WorldToViewportPoint(transform.position + (Vector3.up * _nextData.screenPositionHeightOffset));
+        Vector3 screenPoint = Camera.main.WorldToViewportPoint(
+            transform.position + (Vector3.up * _nextData.screenPositionHeightOffset)
+        );
         if (screenPoint.x > 0 && screenPoint.x < 1 && screenPoint.y > 0 && screenPoint.y < 1)
         {
             SendPosition("screen_position", screenPoint, true);
             _isVisible = true;
         }
-        else if(_isVisible)
+        else if (_isVisible)
         {
             SendPosition("screen_position", screenPoint, false);
             _isVisible = false;

--- a/map/Assets/Scripts/Components/Base/BaseComponentData.cs
+++ b/map/Assets/Scripts/Components/Base/BaseComponentData.cs
@@ -1,5 +1,8 @@
 public class BaseComponentData
 {
+    public bool sendScreenPosition;
+    public float screenPositionHeightOffset;
+
     public string GetTypeName()
     {
         return this.GetType().Name;

--- a/map/Assets/Scripts/Components/BlockerBuilding/BlockerBuildingController.cs.meta
+++ b/map/Assets/Scripts/Components/BlockerBuilding/BlockerBuildingController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 301
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/ComponentManager.cs
+++ b/map/Assets/Scripts/Components/ComponentManager.cs
@@ -38,7 +38,13 @@ public class ComponentManager : MonoBehaviour
     public static extern void SendEventRPC(string? eventName);
 
     [DllImport("__Internal")]
-    public static extern void SendPositionRPC(string? eventName, float x, float y, float z, bool isVisible);
+    public static extern void SendPositionRPC(
+        string? eventName,
+        float x,
+        float y,
+        float z,
+        bool isVisible
+    );
 
     protected async void Start()
     {

--- a/map/Assets/Scripts/Components/ComponentManager.cs
+++ b/map/Assets/Scripts/Components/ComponentManager.cs
@@ -37,6 +37,9 @@ public class ComponentManager : MonoBehaviour
     [DllImport("__Internal")]
     public static extern void SendEventRPC(string? eventName);
 
+    [DllImport("__Internal")]
+    public static extern void SendPositionRPC(string? eventName, float x, float y, float z, bool isVisible);
+
     protected async void Start()
     {
         await Ready();

--- a/map/Assets/Scripts/Components/ComponentManager.jslib
+++ b/map/Assets/Scripts/Components/ComponentManager.jslib
@@ -12,4 +12,14 @@ mergeInto(LibraryManager.library, {
 		);
 	},
 
+	SendPositionRPC: function (eventName, x, y, z, isVisible) {
+		window.dispatchReactUnityEvent(
+			UTF8ToString(eventName),
+			x,
+			y,
+			z,
+			isVisible
+		);
+	},
+
 });

--- a/map/Assets/Scripts/Components/ExtractorBuilding/ExtractorBuildingController.cs.meta
+++ b/map/Assets/Scripts/Components/ExtractorBuilding/ExtractorBuildingController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 302
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs.meta
+++ b/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 303
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/GroundPlane/GroundPlaneController.cs
+++ b/map/Assets/Scripts/Components/GroundPlane/GroundPlaneController.cs
@@ -56,7 +56,7 @@ public class GroundPlaneController : BaseComponentController<GroundPlaneData>
         }
     }
 
-    private void LateUpdate()
+    protected override void LateUpdate()
     {
         if (_camTrans == null)
             return;

--- a/map/Assets/Scripts/Components/Icon/IconController.cs
+++ b/map/Assets/Scripts/Components/Icon/IconController.cs
@@ -76,8 +76,9 @@ public class IconController : BaseComponentController<IconData>
         }
     }
 
-    protected void LateUpdate()
+    protected override void LateUpdate()
     {
+        base.LateUpdate();
         transform.rotation = _camTrans.rotation;
     }
 

--- a/map/Assets/Scripts/Components/Icon/IconController.cs.meta
+++ b/map/Assets/Scripts/Components/Icon/IconController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 304
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/Label/LabelController.cs
+++ b/map/Assets/Scripts/Components/Label/LabelController.cs
@@ -32,8 +32,10 @@ public class LabelController : BaseComponentController<LabelData>
         _prevData = _nextData;
     }
 
-    protected void LateUpdate()
+    protected override void LateUpdate()
     {
+        base.LateUpdate();
+
         if (canvasRect != null)
             transform.position = WorldToUIPosition(
                 new Vector3(worldPos.x, _nextData.height, worldPos.z)

--- a/map/Assets/Scripts/Components/Label/LabelController.cs.meta
+++ b/map/Assets/Scripts/Components/Label/LabelController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 305
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs.meta
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 306
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/Tile/TileController.cs.meta
+++ b/map/Assets/Scripts/Components/Tile/TileController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 307
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/TileGoo/TileGooController.cs.meta
+++ b/map/Assets/Scripts/Components/TileGoo/TileGooController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 308
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/TileHighlight/TileHighlightController.cs.meta
+++ b/map/Assets/Scripts/Components/TileHighlight/TileHighlightController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 309
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/map/Assets/Scripts/Components/TileIcon/TileIconController.cs.meta
+++ b/map/Assets/Scripts/Components/TileIcon/TileIconController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 310
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
This PR adds the ability for the Unity map to tell the frontend about the screen space positions of world space elements.
So the frontend can know where on the screen an object on the map is currently rendered at, which lets us do all sorts of fun stuff with the UI.

Currently I've implemented a very rough version of the Unit icon as well as the counter version of it.

To get the screen space position of an element, that element must first tell Unity that it wants to know its position. It doesn that by setting sendScreenPosition to true. By default, positions are sent from the element root position, so there's a screenPositionHeightOffset variable for getting a position above the root in world space (like if you want an icon floating above a Unit's head for example).

Unity then works out the world to screen space coordinate and sends it back with screenPosition, which includes an x and y coordinate for the 0-1 normalised screen position, a z coordinate for the world space distance from the camera to the element and also an isVisible boolean which states whether the position is currently on screen or not.