### PR TITLE
Quest system

### DIFF
--- a/cli/src/commands/apply.ts
+++ b/cli/src/commands/apply.ts
@@ -38,7 +38,10 @@ const encodeTaskID = ({ name, kind }) => {
     const id = Number(BigInt.asUintN(32, BigInt(keccak256UTF8(`task/${name}`))));
     const kindHash = Number(BigInt.asUintN(32, BigInt(keccak256UTF8(kind))));
 
-    return solidityPacked(['bytes4', 'uint64', 'uint32', 'uint64'], [NodeSelectors.Task, 0, kindHash, id]);
+    return solidityPacked(
+        ['bytes4', 'uint32', 'uint32', 'uint32', 'uint32', 'uint32'],
+        [NodeSelectors.Task, 0, 0, 0, kindHash, id]
+    );
 };
 
 const encodeQuestID = ({ name }) => {

--- a/cli/src/commands/apply.ts
+++ b/cli/src/commands/apply.ts
@@ -42,7 +42,7 @@ const encodeTaskID = ({ name, kind }) => {
 };
 
 const encodeQuestID = ({ name }) => {
-    const id = Number(BigInt.asUintN(32, BigInt(keccak256UTF8(`quest/${name}`))));
+    const id = BigInt.asUintN(64, BigInt(keccak256UTF8(`quest/${name}`)));
     return solidityPacked(['bytes4', 'uint32', 'uint64', 'uint64'], [NodeSelectors.Quest, 0, 0, id]);
 };
 
@@ -488,24 +488,24 @@ const deploy = {
         }
 
         // spawn tile manifests (this is only valid while cheats are enabled)
-        // opn++;
-        // opsets[opn] = [];
-        // for (const doc of docs) {
-        //     if (doc.manifest.kind != 'Tile') {
-        //         continue;
-        //     }
-        //     const spec = doc.manifest.spec;
-        //     opsets[opn].push({
-        //         doc,
-        //         actions: [
-        //             {
-        //                 name: 'DEV_SPAWN_TILE',
-        //                 args: spec.location,
-        //             },
-        //         ],
-        //         note: `spawned tile ${spec.location.join(',')}`,
-        //     });
-        // }
+        opn++;
+        opsets[opn] = [];
+        for (const doc of docs) {
+            if (doc.manifest.kind != 'Tile') {
+                continue;
+            }
+            const spec = doc.manifest.spec;
+            opsets[opn].push({
+                doc,
+                actions: [
+                    {
+                        name: 'DEV_SPAWN_TILE',
+                        args: spec.location,
+                    },
+                ],
+                note: `spawned tile ${spec.location.join(',')}`,
+            });
+        }
 
         // abort here if dry-run
         if (ctx.dryRun) {

--- a/cli/src/commands/apply.ts
+++ b/cli/src/commands/apply.ts
@@ -291,6 +291,10 @@ const questDeploymentActions = async (
                 );
                 return coder.encode(['bytes24', 'string'], [buildingKindId, task.message]);
             }
+            case 'questAccept':
+            case 'questComplete': {
+                return coder.encode(['bytes24'], [encodeQuestID({ name: task.quest })]);
+            }
         }
 
         return solidityPacked(['uint8'], [0]);

--- a/cli/src/commands/apply.ts
+++ b/cli/src/commands/apply.ts
@@ -311,10 +311,12 @@ const questDeploymentActions = async (
     // register quest
     const questId = encodeQuestID(spec);
     const taskIds = spec.tasks.map((task) => encodeTaskID(task));
+    const nextQuestIds = spec.next?.map((questName) => encodeQuestID({ name: questName })) || [];
     const [q, r, s] = spec.location ? spec.location : [0, 0, 0];
+
     ops.push({
         name: 'REGISTER_QUEST',
-        args: [questId, spec.name, spec.description, !!spec.location, q, r, s, taskIds],
+        args: [questId, spec.name, spec.description, !!spec.location, q, r, s, taskIds, nextQuestIds],
     });
 
     return ops;

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -265,7 +265,7 @@ export const QuestSpec = z.object({
     description: OneLiner.nonempty(),
     location: Coords.optional(),
     tasks: Task.array().min(1),
-    next: Name.array().optional(),
+    next: Name.array().max(5).optional(),
 });
 
 export const Quest = z.object({

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -198,7 +198,84 @@ export const Player = z.object({
         .optional(),
 });
 
-export const Manifest = z.discriminatedUnion('kind', [BuildingKind, Item, Building, Tile, MobileUnit, Player]);
+// Quest
+
+export const TaskCoord = z.object({
+    kind: z.literal('coord'),
+    name: z.string(),
+    location: Coords,
+});
+
+export const TaskButton = z.object({
+    kind: z.literal('button'),
+    name: z.string(),
+    button: z.string().min(1).max(32),
+    location: z.string().min(1).max(32),
+});
+
+export const TaskInventory = z.object({
+    kind: z.literal('inventory'),
+    name: z.string(),
+    item: Slot,
+});
+
+export const TaskCombat = z.object({
+    kind: z.literal('combat'),
+    name: z.string(),
+    // optional location of tile to be attacked?
+});
+
+export const TaskCombatWinAttack = z.object({
+    kind: z.literal('combatWinAttack'),
+    name: z.string(),
+    // optional location of tile to be attacked?
+});
+
+export const TaskCombatWinDefense = z.object({
+    kind: z.literal('combatWinDefense'),
+    name: z.string(),
+    // optional location of tile to be defended?
+});
+
+export const TaskQuestAccept = z.object({
+    kind: z.literal('questAccept'),
+    name: z.string(),
+    quest: Name,
+});
+
+export const TaskQuestComplete = z.object({
+    kind: z.literal('questComplete'),
+    name: z.string(),
+    quest: Name,
+});
+
+export const Task = z.discriminatedUnion('kind', [
+    TaskCoord,
+    TaskButton,
+    TaskInventory,
+    TaskCombat,
+    TaskCombatWinAttack,
+    TaskCombatWinDefense,
+    TaskQuestAccept,
+    TaskQuestComplete,
+]);
+
+export const QuestSpec = z.object({
+    name: Name,
+    description: OneLiner.nonempty(),
+    location: Coords.optional(),
+    tasks: Task.array().min(1),
+    next: Name.array().optional(),
+});
+
+export const Quest = z.object({
+    kind: z.literal('Quest'),
+    spec: QuestSpec,
+});
+
+// -- //
+
+export const Manifest = z.discriminatedUnion('kind', [BuildingKind, Item, Building, Tile, MobileUnit, Player, Quest]);
 
 export const ManifestDocument = z.object({
     filename: z.string(),

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -206,11 +206,11 @@ export const TaskCoord = z.object({
     location: Coords,
 });
 
-export const TaskButton = z.object({
-    kind: z.literal('button'),
+export const TaskMessage = z.object({
+    kind: z.literal('message'),
     name: z.string(),
-    button: z.string().min(1).max(32),
-    location: z.string().min(1).max(32),
+    message: z.string(),
+    buildingKind: z.string(),
 });
 
 export const TaskInventory = z.object({
@@ -251,7 +251,7 @@ export const TaskQuestComplete = z.object({
 
 export const Task = z.discriminatedUnion('kind', [
     TaskCoord,
-    TaskButton,
+    TaskMessage,
     TaskInventory,
     TaskCombat,
     TaskCombatWinAttack,

--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -24,6 +24,7 @@ import {CombatRule} from "@ds/rules/CombatRule.sol";
 import {NamingRule} from "@ds/rules/NamingRule.sol";
 import {BagRule} from "@ds/rules/BagRule.sol";
 import {ExtractionRule} from "@ds/rules/ExtractionRule.sol";
+import {QuestRule} from "@ds/rules/QuestRule.sol";
 
 using Schema for State;
 
@@ -60,6 +61,7 @@ contract GameDeployer is Script {
         dispatcher.registerRule(new NamingRule());
         dispatcher.registerRule(new BagRule());
         dispatcher.registerRule(new ExtractionRule(ds));
+        dispatcher.registerRule(new QuestRule());
 
         // register base goos
         dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.GreenGoo(), "Green Goo", "15-185")));

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -65,6 +65,8 @@ contract DownstreamGame is BaseGame {
         state.registerNodeType(Kind.Hash.selector, "Hash", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.Atom.selector, "Atom", CompoundKeyKind.UINT160);
         state.registerNodeType(Kind.BlockNum.selector, "BlockNum", CompoundKeyKind.UINT160);
+        state.registerNodeType(Kind.Quest.selector, "Quest", CompoundKeyKind.UINT160);
+        state.registerNodeType(Kind.Task.selector, "Task", CompoundKeyKind.UINT160);
 
         // register the relationship ids we are using
         state.registerEdgeType(Rel.Owner.selector, "Owner", WeightKind.UINT64);
@@ -81,6 +83,8 @@ contract DownstreamGame is BaseGame {
         state.registerEdgeType(Rel.Has.selector, "Has", WeightKind.UINT64);
         state.registerEdgeType(Rel.Combat.selector, "Combat", WeightKind.UINT64);
         state.registerEdgeType(Rel.IsFinalised.selector, "IsFinalised", WeightKind.UINT64);
+        state.registerEdgeType(Rel.HasQuest.selector, "HasQuest", WeightKind.UINT64);
+        state.registerEdgeType(Rel.HasTask.selector, "HasTask", WeightKind.UINT64);
 
         // create a session router
         BaseRouter router = new DownstreamRouter();

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -66,7 +66,7 @@ contract DownstreamGame is BaseGame {
         state.registerNodeType(Kind.Atom.selector, "Atom", CompoundKeyKind.UINT160);
         state.registerNodeType(Kind.BlockNum.selector, "BlockNum", CompoundKeyKind.UINT160);
         state.registerNodeType(Kind.Quest.selector, "Quest", CompoundKeyKind.UINT160);
-        state.registerNodeType(Kind.Task.selector, "Task", CompoundKeyKind.UINT160);
+        state.registerNodeType(Kind.Task.selector, "Task", CompoundKeyKind.UINT32_ARRAY);
 
         // register the relationship ids we are using
         state.registerEdgeType(Rel.Owner.selector, "Owner", WeightKind.UINT64);

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -141,6 +141,10 @@ interface Actions {
 
     function REGISTER_TASK(bytes24 task, string calldata name, bytes calldata taskData) external;
 
+    function ACCEPT_QUEST(bytes24 quest, uint8 questNum) external;
+
+    function COMPLETE_QUEST(bytes24 quest, uint8 questNum) external;
+
     // ---------------------
     // the DEV_ actions below this point are not for public use they are
     // only available by a single authorized account and only for a short

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -136,7 +136,8 @@ interface Actions {
         int16 q,
         int16 r,
         int16 s,
-        bytes24[] calldata tasks
+        bytes24[] calldata tasks,
+        bytes24[] calldata nextQuests
     ) external;
 
     function REGISTER_TASK(bytes24 task, string calldata name, bytes calldata taskData) external;

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -126,6 +126,21 @@ interface Actions {
 
     function SPAWN_EMPTY_BAG(bytes24 equipee, uint8 equipSlot) external;
 
+    // Quests
+
+    function REGISTER_QUEST(
+        bytes24 quest,
+        string calldata name,
+        string calldata description,
+        bool hasLocation,
+        int16 q,
+        int16 r,
+        int16 s,
+        bytes24[] calldata tasks
+    ) external;
+
+    function REGISTER_TASK(bytes24 task, string calldata name, bytes calldata taskData) external;
+
     // ---------------------
     // the DEV_ actions below this point are not for public use they are
     // only available by a single authorized account and only for a short

--- a/contracts/src/fixtures/IntroOrientation/ControlTower.js
+++ b/contracts/src/fixtures/IntroOrientation/ControlTower.js
@@ -1,21 +1,16 @@
-import ds from 'downstream';
+import ds from "downstream";
 
 let questStage = 0;
 
 export default async function update({ selected, world }) {
-
-
     const { tiles, mobileUnit } = selected || {};
     const selectedTile = tiles && tiles.length === 1 ? tiles[0] : undefined;
     const selectedBuilding = selectedTile?.building;
     const selectedUnit = mobileUnit;
 
-
-
     const placeholder = () => {
         questStage++;
-    }
-
+    };
 
     //Show this if there is no selected unit
     if (!selectedUnit) {
@@ -23,20 +18,19 @@ export default async function update({ selected, world }) {
             version: 1,
             components: [
                 {
-                    type: 'building',
-                    id: 'control-tower',
+                    type: "building",
+                    id: "control-tower",
                     content: [
                         {
-                            id: 'default',
-                            type: 'inline',
-                            html: `Select your unit and stand next to the building to interact with it`
-                        }
-                    ]
+                            id: "default",
+                            type: "inline",
+                            html: `Select your unit and stand next to the building to interact with it`,
+                        },
+                    ],
                 },
             ],
         };
     }
-
 
     //If quest 2 isn't active or completed
     if (questStage === 0) {
@@ -44,15 +38,26 @@ export default async function update({ selected, world }) {
             version: 1,
             components: [
                 {
-                    type: 'building',
-                    id: 'control-tower',
+                    type: "building",
+                    id: "control-tower",
                     content: [
                         {
-                            id: 'default',
-                            type: 'inline',
-                            html: 'M.O.R.T.O.N. welcomes you to Hexwood, whilst wondering who you are. Please verify your credentials.',
-                            buttons: [{ text: 'Verify Credentials', type: 'action', action: placeholder, disabled: false }]
-                        }
+                            id: "default",
+                            type: "inline",
+                            html: "M.O.R.T.O.N. welcomes you to Hexwood, whilst wondering who you are. Please verify your credentials.",
+                            buttons: [
+                                {
+                                    text: "Verify Credentials",
+                                    type: "action",
+                                    action: () => {
+                                        ds.sendQuestMessage(
+                                            "verifyCredentials",
+                                        );
+                                    },
+                                    disabled: false,
+                                },
+                            ],
+                        },
                     ],
                 },
             ],
@@ -65,16 +70,28 @@ export default async function update({ selected, world }) {
             version: 1,
             components: [
                 {
-                    type: 'building',
-                    id: 'control-tower',
+                    type: "building",
+                    id: "control-tower",
                     content: [
                         {
-                            id: 'default',
-                            type: 'inline',
-                            html: 'Registration Error! Please collect valid User License',
-                            buttons: [{ text: 'Register User', type: 'action', action: placeholder, disabled: true },
-                                        { text: 'Advance Quest', type: 'action', action: placeholder, disabled: false }] //placeholder
-                        }
+                            id: "default",
+                            type: "inline",
+                            html: "Registration Error! Please collect valid User License",
+                            buttons: [
+                                {
+                                    text: "Register User",
+                                    type: "action",
+                                    action: placeholder,
+                                    disabled: true,
+                                },
+                                {
+                                    text: "Advance Quest",
+                                    type: "action",
+                                    action: placeholder,
+                                    disabled: false,
+                                },
+                            ], //placeholder
+                        },
                     ],
                 },
             ],
@@ -87,64 +104,91 @@ export default async function update({ selected, world }) {
             version: 1,
             components: [
                 {
-                    type: 'building',
-                    id: 'control-tower',
+                    type: "building",
+                    id: "control-tower",
                     content: [
                         {
-                            id: 'default',
-                            type: 'inline',
+                            id: "default",
+                            type: "inline",
                             html: 'User identified as with status: "Newb". Please accept newbie quests and level up A.S.A.P.',
-                            buttons: [{ text: 'Accept Orientation Quest', type: 'action', action: placeholder, disabled: questStage > 2 },
-                                { text: 'Accept Creation Quest', type: 'action', action: placeholder, disabled: questStage > 3 },
-                                { text: 'Advance Quest', type: 'action', action: placeholder, disabled: questStage < 4 } //Placeholder
-                            ]
-                        }
+                            buttons: [
+                                {
+                                    text: "Accept Orientation Quest",
+                                    type: "action",
+                                    action: placeholder,
+                                    disabled: questStage > 2,
+                                },
+                                {
+                                    text: "Accept Creation Quest",
+                                    type: "action",
+                                    action: placeholder,
+                                    disabled: questStage > 3,
+                                },
+                                {
+                                    text: "Advance Quest",
+                                    type: "action",
+                                    action: placeholder,
+                                    disabled: questStage < 4,
+                                }, //Placeholder
+                            ],
+                        },
                     ],
                 },
             ],
         };
-    }
-
-    else if (questStage >= 5 && questStage <= 7) {
+    } else if (questStage >= 5 && questStage <= 7) {
         return {
             version: 1,
             components: [
                 {
-                    type: 'building',
-                    id: 'control-tower',
+                    type: "building",
+                    id: "control-tower",
                     content: [
                         {
-                            id: 'default',
-                            type: 'inline',
-                            html: 'Simulation abnormalies have been detected. Please accept normalisation assignments.',
-                            buttons: [{ text: 'Accept Paperclip Maximiser Quest', type: 'action', action: placeholder, disabled: questStage > 5 },
-                                { text: 'Accept Corrupted User Quest', type: 'action', action: placeholder, disabled: questStage > 6 },
-                                { text: 'Advance Quest', type: 'action', action: placeholder, disabled: questStage < 7 } //Placeholder
-                            ]
-                        }
+                            id: "default",
+                            type: "inline",
+                            html: "Simulation abnormalies have been detected. Please accept normalisation assignments.",
+                            buttons: [
+                                {
+                                    text: "Accept Paperclip Maximiser Quest",
+                                    type: "action",
+                                    action: placeholder,
+                                    disabled: questStage > 5,
+                                },
+                                {
+                                    text: "Accept Corrupted User Quest",
+                                    type: "action",
+                                    action: placeholder,
+                                    disabled: questStage > 6,
+                                },
+                                {
+                                    text: "Advance Quest",
+                                    type: "action",
+                                    action: placeholder,
+                                    disabled: questStage < 7,
+                                }, //Placeholder
+                            ],
+                        },
                     ],
                 },
             ],
         };
-    }
-
-    else {
+    } else {
         return {
             version: 1,
             components: [
                 {
-                    type: 'building',
-                    id: 'control-tower',
+                    type: "building",
+                    id: "control-tower",
                     content: [
                         {
-                            id: 'default',
-                            type: 'inline',
-                            html: 'No quest are available at this time'
-                        }
+                            id: "default",
+                            type: "inline",
+                            html: "No quest are available at this time",
+                        },
                     ],
                 },
             ],
         };
     }
 }
-

--- a/contracts/src/fixtures/IntroOrientation/ControlTower.js
+++ b/contracts/src/fixtures/IntroOrientation/ControlTower.js
@@ -1,15 +1,80 @@
 import ds from "downstream";
 
-let questStage = 0;
+const QUEST_ACCEPTED = 1;
+const QUEST_COMPLETED = 2;
 
-export default async function update({ selected, world }) {
+// const QUEST_1 = "Report to Control";
+const QUEST_2 = "Registration Error";
+const QUEST_3 = "Report to Control (again!)";
+const QUEST_4 = "Orientation";
+const QUEST_5 = "Creation";
+const QUEST_6 = "Paperclip Maximiser";
+const QUEST_7 = "Corrupted User";
+
+export default async function update({ selected, player }) {
     const { tiles, mobileUnit } = selected || {};
     const selectedTile = tiles && tiles.length === 1 ? tiles[0] : undefined;
     const selectedBuilding = selectedTile?.building;
     const selectedUnit = mobileUnit;
+    const quests = player.quests;
 
-    const placeholder = () => {
-        questStage++;
+    // Have to use encode function call
+    // const encodeQuestID = ({ name }) => {
+    //     const id = BigInt.asUintN(64, BigInt(keccak256UTF8(`quest/${name}`)));
+    //     return solidityPacked(['bytes4', 'uint32', 'uint64', 'uint64'], [NodeSelectors.Quest, 0, 0, id]);
+    // };
+
+    const getNextQuestNum = () => {
+        const questNum = quests.reduce(
+            (qNum, q) => (q.key > qNum ? q.key : qNum),
+            -1,
+        );
+        return questNum + 1;
+    };
+
+    const areAllQuestsCompleted = (questNames) => {
+        const completedQuests = quests.filter(
+            (q) =>
+                questNames.includes(q.node.name.value) &&
+                q.status == QUEST_COMPLETED,
+        );
+
+        return completedQuests.length == questNames.length;
+    };
+
+    const findQuestByName = (questName) => {
+        return quests.find((q) => q.node.name.value == questName);
+    };
+
+    // TODO: use name as param and encode the questID
+    const acceptQuest = (questId) => {
+        const questNum = getNextQuestNum();
+        ds.dispatch({
+            name: "ACCEPT_QUEST",
+            args: [questId, questNum],
+        });
+    };
+
+    const getQuestStage = () => {
+        if (!quests) return 0;
+
+        const questRegError = findQuestByName(QUEST_2);
+        if (!questRegError) return 0;
+
+        if (questRegError.status == QUEST_ACCEPTED) return 1;
+
+        const questReturn = findQuestByName(QUEST_3);
+        if (!questReturn) return 1;
+        if (questReturn.status == QUEST_ACCEPTED) return 2;
+
+        // show newb quests if not complete
+        if (!areAllQuestsCompleted([QUEST_4, QUEST_5])) return 2;
+
+        // show advanced quests if not complete
+        if (!areAllQuestsCompleted([QUEST_6, QUEST_7])) return 3;
+
+        // out of quests
+        return -1;
     };
 
     //Show this if there is no selected unit
@@ -32,6 +97,8 @@ export default async function update({ selected, world }) {
         };
     }
 
+    const questStage = getQuestStage();
+
     //If quest 2 isn't active or completed
     if (questStage === 0) {
         return {
@@ -44,7 +111,9 @@ export default async function update({ selected, world }) {
                         {
                             id: "default",
                             type: "inline",
-                            html: "M.O.R.T.O.N. welcomes you to Hexwood, whilst wondering who you are. Please verify your credentials.",
+                            html:
+                                "M.O.R.T.O.N. welcomes you to Hexwood, whilst wondering who you are. Please verify your credentials." +
+                                quests.length,
                             buttons: [
                                 {
                                     text: "Verify Credentials",
@@ -76,19 +145,17 @@ export default async function update({ selected, world }) {
                         {
                             id: "default",
                             type: "inline",
-                            html: "Registration Error! Please collect valid User License",
+                            html: "Registration Error! Please collect valid Registration Receipt",
                             buttons: [
                                 {
                                     text: "Register User",
                                     type: "action",
-                                    action: placeholder,
-                                    disabled: true,
-                                },
-                                {
-                                    text: "Advance Quest",
-                                    type: "action",
-                                    action: placeholder,
-                                    disabled: false,
+                                    action: () => {
+                                        ds.sendQuestMessage(
+                                            "verifyCredentials2",
+                                        );
+                                    },
+                                    disabled: true, // This button is never used as the quest will advance on by itself when the receipt is collected
                                 },
                             ], //placeholder
                         },
@@ -99,7 +166,9 @@ export default async function update({ selected, world }) {
     }
 
     //Show this if quest 3 is active
-    else if (questStage >= 2 && questStage <= 4) {
+    else if (questStage === 2) {
+        const orientationQuest = findQuestByName(QUEST_4);
+        const creationQuest = findQuestByName(QUEST_5);
         return {
             version: 1,
             components: [
@@ -115,28 +184,33 @@ export default async function update({ selected, world }) {
                                 {
                                     text: "Accept Orientation Quest",
                                     type: "action",
-                                    action: placeholder,
-                                    disabled: questStage > 2,
+                                    action: () => {
+                                        acceptQuest(
+                                            "0xadbb33ce000000000000000000000000c533c3b1b9d5856c",
+                                        );
+                                    }, // TODO: use name instead of ID
+                                    disabled: !!orientationQuest,
                                 },
                                 {
                                     text: "Accept Creation Quest",
                                     type: "action",
-                                    action: placeholder,
-                                    disabled: questStage > 3,
+                                    action: () => {
+                                        acceptQuest(
+                                            "0xadbb33ce000000000000000000000000de3bb0a48fe15c39",
+                                        );
+                                    },
+                                    disabled: !!creationQuest,
                                 },
-                                {
-                                    text: "Advance Quest",
-                                    type: "action",
-                                    action: placeholder,
-                                    disabled: questStage < 4,
-                                }, //Placeholder
                             ],
                         },
                     ],
                 },
             ],
         };
-    } else if (questStage >= 5 && questStage <= 7) {
+    } else if (questStage === 3) {
+        const paperclipQuest = findQuestByName(QUEST_6);
+        const corruptQuest = findQuestByName(QUEST_7);
+
         return {
             version: 1,
             components: [
@@ -152,21 +226,19 @@ export default async function update({ selected, world }) {
                                 {
                                     text: "Accept Paperclip Maximiser Quest",
                                     type: "action",
-                                    action: placeholder,
-                                    disabled: questStage > 5,
+                                    action: () => {
+                                        acceptQuest(QUEST_6);
+                                    },
+                                    disabled: !!paperclipQuest,
                                 },
                                 {
                                     text: "Accept Corrupted User Quest",
                                     type: "action",
-                                    action: placeholder,
-                                    disabled: questStage > 6,
+                                    action: () => {
+                                        acceptQuest(QUEST_7);
+                                    },
+                                    disabled: !!corruptQuest,
                                 },
-                                {
-                                    text: "Advance Quest",
-                                    type: "action",
-                                    action: placeholder,
-                                    disabled: questStage < 7,
-                                }, //Placeholder
                             ],
                         },
                     ],

--- a/contracts/src/fixtures/quests/01.yaml
+++ b/contracts/src/fixtures/quests/01.yaml
@@ -1,0 +1,48 @@
+---
+kind: Quest
+spec:
+  name: Report to Control
+  description: "Welcome new user. Report to the control tower for further instructions"
+  location: [1, 1, -2]
+  tasks:
+    - kind: coord
+      name: Move to the Control Tower
+      location: [1, 1, -2]
+    - kind: button
+      name: Click on the Control Tower’s Report button
+      button: report
+      location: Cocktail Hut
+  next: ["Registration Error"]
+
+---
+kind: Quest
+spec:
+  name: Registration Error
+  description: "Cannot recognise user profile. Please rectify this issue by crafting a new user license"
+  tasks:
+    - kind: coord
+      name: Move to the Registration Office
+      location: [1, 1, -2]
+    - kind: inventory
+      name: Make a cocktail
+      item:
+        name: Cocktail
+        quantity: 2
+  next: ["Report to Control (again!)"]
+
+---
+kind: Quest
+spec:
+  name: Report to Control (again!)
+  description: "TBD"
+  location: [1, 1, -2]
+  tasks:
+    - kind: coord
+      name: Move to the Control Tower
+      location: [1, 1, -2]
+    - kind: questAccept
+      name: Accept Orientation quest
+      quest: Orientation
+    - kind: questAccept
+      name: Accept Creation quest
+      quest: Creation

--- a/contracts/src/fixtures/quests/01.yaml
+++ b/contracts/src/fixtures/quests/01.yaml
@@ -1,4 +1,10 @@
 ---
+kind: Building
+spec:
+  name: Cocktail Hut
+  location: [-1, -1, 2]
+
+---
 kind: Quest
 spec:
   name: Report to Control
@@ -19,15 +25,16 @@ kind: Quest
 spec:
   name: Registration Error
   description: "Cannot recognise user profile. Please rectify this issue by crafting a new user license"
+  location: [-1, -1, 2]
   tasks:
     - kind: coord
       name: Move to the Registration Office
-      location: [1, 1, -2]
+      location: [-1, -1, 2]
     - kind: inventory
       name: Make a cocktail
       item:
         name: Cocktail
-        quantity: 2
+        quantity: 1
   next: ["Report to Control (again!)"]
 
 ---

--- a/contracts/src/fixtures/quests/01.yaml
+++ b/contracts/src/fixtures/quests/01.yaml
@@ -9,14 +9,14 @@ kind: Quest
 spec:
   name: Report to Control
   description: "Welcome new user. Report to the control tower for further instructions"
-  location: [1, -1, 0]
+  location: [-6, 5, 1]
   tasks:
     - kind: coord
       name: Move to the Control Tower
-      location: [1, -1, 0]
+      location: [-6, 5, 1]
     - kind: message
       name: Click on the Control Tower’s Report button
-      message: report
+      message: verifyCredentials
       buildingKind: Control Tower
   next: ["Registration Error"]
 

--- a/contracts/src/fixtures/quests/01.yaml
+++ b/contracts/src/fixtures/quests/01.yaml
@@ -9,15 +9,15 @@ kind: Quest
 spec:
   name: Report to Control
   description: "Welcome new user. Report to the control tower for further instructions"
-  location: [1, 1, -2]
+  location: [1, -1, 0]
   tasks:
     - kind: coord
       name: Move to the Control Tower
-      location: [1, 1, -2]
-    - kind: button
+      location: [1, -1, 0]
+    - kind: message
       name: Click on the Control Tower’s Report button
-      button: report
-      location: Cocktail Hut
+      message: report
+      buildingKind: Control Tower
   next: ["Registration Error"]
 
 ---
@@ -42,11 +42,11 @@ kind: Quest
 spec:
   name: Report to Control (again!)
   description: "TBD"
-  location: [1, 1, -2]
+  location: [1, -1, 0]
   tasks:
     - kind: coord
       name: Move to the Control Tower
-      location: [1, 1, -2]
+      location: [1, -1, 0]
     - kind: questAccept
       name: Accept Orientation quest
       quest: Orientation

--- a/contracts/src/fixtures/quests/creation.yaml
+++ b/contracts/src/fixtures/quests/creation.yaml
@@ -1,0 +1,12 @@
+---
+kind: Quest
+spec:
+  name: Creation
+  description: "Make a Cocktail"
+  location: [-6, 5, 1]
+  tasks:
+    - kind: inventory
+      name: Make a Cocktail Hut and make a Cocktail
+      item:
+        name: Cocktail
+        quantity: 1

--- a/contracts/src/fixtures/quests/intro.yaml
+++ b/contracts/src/fixtures/quests/intro.yaml
@@ -1,10 +1,4 @@
 ---
-kind: Building
-spec:
-  name: Cocktail Hut
-  location: [-1, -1, 2]
-
----
 kind: Quest
 spec:
   name: Report to Control
@@ -15,7 +9,7 @@ spec:
       name: Move to the Control Tower
       location: [-6, 5, 1]
     - kind: message
-      name: Click on the Control Tower’s Report button
+      name: Verify credentials
       message: verifyCredentials
       buildingKind: Control Tower
   next: ["Registration Error"]
@@ -24,16 +18,16 @@ spec:
 kind: Quest
 spec:
   name: Registration Error
-  description: "Cannot recognise user profile. Please rectify this issue by crafting a new user license"
-  location: [-1, -1, 2]
+  description: "Cannot recognise user profile. Please rectify this issue by crafting a new Registration Receipt"
+  location: [5, -1, -4]
   tasks:
     - kind: coord
       name: Move to the Registration Office
-      location: [-1, -1, 2]
+      location: [5, -1, -4]
     - kind: inventory
-      name: Make a cocktail
+      name: Convert Acceptance Letter and ID Card into a Registration Receipt
       item:
-        name: Cocktail
+        name: Registration Receipt
         quantity: 1
   next: ["Report to Control (again!)"]
 
@@ -42,11 +36,12 @@ kind: Quest
 spec:
   name: Report to Control (again!)
   description: "TBD"
-  location: [1, -1, 0]
+  location: [-6, 5, 1]
   tasks:
     - kind: coord
       name: Move to the Control Tower
-      location: [1, -1, 0]
+      location: [-6, 5, 1]
+      buildingKind: Control Tower
     - kind: questAccept
       name: Accept Orientation quest
       quest: Orientation

--- a/contracts/src/fixtures/quests/orientation.yaml
+++ b/contracts/src/fixtures/quests/orientation.yaml
@@ -1,0 +1,11 @@
+---
+kind: Quest
+spec:
+  name: Orientation
+  description: "This world was created from the gooey remains of the last. You need to learn how to extract this gooo."
+  tasks:
+    - kind: inventory
+      name: Have 50 x Red Goo in your bag (from any extractor)
+      item:
+        name: Red Goo
+        quantity: 50

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -57,6 +57,9 @@ contract NewPlayerRule is Rule {
             state.setItemSlot(bag1, 0, ItemUtils.GreenGoo(), 100);
             state.setItemSlot(bag1, 1, ItemUtils.BlueGoo(), 100);
             state.setItemSlot(bag1, 2, ItemUtils.RedGoo(), 100);
+
+            // Accept the first quest in the chain
+            state.setQuestAccepted(Node.Quest("Registration Error"), Node.Player(ctx.sender), 0);
         }
 
         return state;

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -59,7 +59,7 @@ contract NewPlayerRule is Rule {
             state.setItemSlot(bag1, 2, ItemUtils.RedGoo(), 100);
 
             // Accept the first quest in the chain
-            state.setQuestAccepted(Node.Quest("Registration Error"), Node.Player(ctx.sender), 0);
+            state.setQuestAccepted(Node.Quest("Report to Control"), Node.Player(ctx.sender), 0);
         }
 
         return state;

--- a/contracts/src/rules/QuestRule.sol
+++ b/contracts/src/rules/QuestRule.sol
@@ -17,11 +17,12 @@ using Schema for State;
 //     function inventory(bytes24 item, uint64 quantity) external;
 // }
 
+uint8 constant MAX_NEXT_QUESTS = 5;
+
 contract QuestRule is Rule {
     constructor() {}
 
     function reduce(State state, bytes calldata action, Context calldata ctx) public returns (State) {
-        // REGISTER_TASK(bytes24 task, string calldata name, bytes calldata taskData) external;
         if (bytes4(action) == Actions.REGISTER_TASK.selector) {
             (bytes24 task, string memory name, bytes memory taskData) = abi.decode(action[4:], (bytes24, string, bytes));
 
@@ -54,8 +55,9 @@ contract QuestRule is Rule {
                 int16 q,
                 int16 r,
                 int16 s,
-                bytes24[] memory tasks
-            ) = abi.decode(action[4:], (bytes24, string, string, bool, int16, int16, int16, bytes24[]));
+                bytes24[] memory tasks,
+                bytes24[] memory nextQuests
+            ) = abi.decode(action[4:], (bytes24, string, string, bool, int16, int16, int16, bytes24[], bytes24[]));
 
             // TODO: Check for owner
 
@@ -70,10 +72,16 @@ contract QuestRule is Rule {
             // Link tasks
             for (uint8 i = 0; i < tasks.length; i++) {
                 bytes24 task = tasks[i];
+                require(bytes4(task) == Kind.Task.selector, "Linked task must be a task node");
                 state.set(Rel.HasTask.selector, i, quest, task, 0);
             }
 
-            // Point to next quest
+            // Point to next quests
+            for (uint8 i = 0; i < nextQuests.length; i++) {
+                bytes24 nextQuest = nextQuests[i];
+                require(bytes4(nextQuest) == Kind.Quest.selector, "Linked quest must be a quest node");
+                state.set(Rel.HasQuest.selector, i, quest, nextQuest, 0);
+            }
         }
 
         if (bytes4(action) == Actions.ACCEPT_QUEST.selector) {
@@ -89,14 +97,38 @@ contract QuestRule is Rule {
         if (bytes4(action) == Actions.COMPLETE_QUEST.selector) {
             (bytes24 quest, uint8 questNum) = abi.decode(action[4:], (bytes24, uint8));
 
-            (bytes24 currentQuest, QuestStatus questStatus) = state.getPlayerQuest(Node.Player(ctx.sender), questNum);
+            // Check the quest at questNum matches supplied quest. Maybe we only need to supply questNum seeing as we have to fetch it
+            {
+                (bytes24 currentQuest, QuestStatus questStatus) =
+                    state.getPlayerQuest(Node.Player(ctx.sender), questNum);
 
-            require(quest == currentQuest, "Quest at given questNum doesn't match supplied quest ID");
-            require(questStatus == QuestStatus.ACCEPTED, "Quest must be in ACCEPTED state to be completed");
+                require(quest == currentQuest, "Quest at given questNum doesn't match supplied quest ID");
+                require(questStatus == QuestStatus.ACCEPTED, "Quest must be in ACCEPTED state to be completed");
+            }
+
+            // TODO: Do evalutation of task completion
 
             state.setQuestCompleted(quest, Node.Player(ctx.sender), questNum);
 
-            // Auto accept next quest
+            // Auto accept next quests
+
+            bytes24 questAtSlot = quest;
+            for (uint8 i = 0; i < MAX_NEXT_QUESTS; i++) {
+                (bytes24 nextQuest, /*uint8 weight*/ ) = state.get(Rel.HasQuest.selector, i, quest);
+                if (nextQuest == bytes24(0)) {
+                    continue;
+                }
+
+                // Find next available questNum (questSlot?)
+                while (questAtSlot != bytes24(0)) {
+                    // TODO: Quests are linked to a player via edges which means there is a hard limit of 256 quests
+                    require(questNum < 255, "Reached maximum number of quests the player can have record of");
+                    questNum++;
+                    (questAtSlot, /*questStatus*/ ) = state.getPlayerQuest(Node.Player(ctx.sender), questNum);
+                }
+
+                state.setQuestAccepted(nextQuest, Node.Player(ctx.sender), questNum);
+            }
         }
 
         return state;

--- a/contracts/src/rules/QuestRule.sol
+++ b/contracts/src/rules/QuestRule.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "cog/IState.sol";
+import "cog/IRule.sol";
+import "cog/IDispatcher.sol";
+
+import {Schema, Node, Kind, Rel, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+
+import "forge-std/console.sol";
+
+using Schema for State;
+
+// interface TaskKind {
+//     function coord(int16 q, int16 r, int16 s) external;
+//     function inventory(bytes24 item, uint64 quantity) external;
+// }
+
+contract QuestRule is Rule {
+    constructor() {}
+
+    function reduce(State state, bytes calldata action, Context calldata ctx) public returns (State) {
+        // REGISTER_TASK(bytes24 task, string calldata name, bytes calldata taskData) external;
+        if (bytes4(action) == Actions.REGISTER_TASK.selector) {
+            (bytes24 task, string memory name, bytes memory taskData) = abi.decode(action[4:], (bytes24, string, bytes));
+
+            // TODO: Check for owner
+
+            // Store the task data
+            uint32 taskKind = state.getTaskKind(task);
+            if (uint32(uint256(keccak256(abi.encodePacked("coord")))) == taskKind) {
+                (int16 q, int16 r, int16 s) = abi.decode(taskData, (int16, int16, int16));
+                bytes24 tile = Node.Tile(DEFAULT_ZONE, q, r, s);
+                state.set(Rel.Location.selector, 0, task, tile, 0);
+            } else if (uint32(uint256(keccak256(abi.encodePacked("inventory")))) == taskKind) {
+                (bytes24 item, uint64 quantity) = abi.decode(taskData, (bytes24, uint64));
+                state.set(Rel.Balance.selector, 0, task, item, quantity);
+            }
+
+            _setName(state, Node.Player(ctx.sender), task, name);
+        }
+
+        if (bytes4(action) == Actions.REGISTER_QUEST.selector) {
+            (
+                bytes24 quest,
+                string memory name,
+                string memory description,
+                bool hasLocation,
+                int16 q,
+                int16 r,
+                int16 s,
+                bytes24[] memory tasks
+            ) = abi.decode(action[4:], (bytes24, string, string, bool, int16, int16, int16, bytes24[]));
+
+            // TODO: Check for owner
+
+            _setName(state, Node.Player(ctx.sender), quest, name);
+            _setDescription(state, Node.Player(ctx.sender), quest, description);
+
+            if (hasLocation) {
+                bytes24 tile = Node.Tile(DEFAULT_ZONE, q, r, s);
+                state.set(Rel.Location.selector, 0, quest, tile, 0);
+            }
+
+            // Link tasks
+            for (uint8 i = 0; i < tasks.length; i++) {
+                bytes24 task = tasks[i];
+                state.set(Rel.HasTask.selector, i, quest, task, 0);
+            }
+        }
+        return state;
+    }
+
+    function _setName(State state, bytes24 player, bytes24 entity, string memory name) private {
+        bytes24 existingOwner = state.getOwner(entity);
+        if (existingOwner != 0x0 && existingOwner != player) {
+            revert("EntityNotOwnedByPlayer");
+        }
+        state.annotate(entity, "name", name);
+    }
+
+    function _setDescription(State state, bytes24 player, bytes24 entity, string memory name) private {
+        bytes24 existingOwner = state.getOwner(entity);
+        if (existingOwner != 0x0 && existingOwner != player) {
+            revert("EntityNotOwnedByPlayer");
+        }
+        state.annotate(entity, "description", name);
+    }
+}

--- a/contracts/src/rules/QuestRule.sol
+++ b/contracts/src/rules/QuestRule.sol
@@ -36,6 +36,10 @@ contract QuestRule is Rule {
             } else if (uint32(uint256(keccak256(abi.encodePacked("inventory")))) == taskKind) {
                 (bytes24 item, uint64 quantity) = abi.decode(taskData, (bytes24, uint64));
                 state.set(Rel.Balance.selector, 0, task, item, quantity);
+            } else if (uint32(uint256(keccak256(abi.encodePacked("message")))) == taskKind) {
+                (bytes24 buildingKind, string memory message) = abi.decode(taskData, (bytes24, string));
+                state.set(Rel.Has.selector, 0, task, buildingKind, 0);
+                state.annotate(task, "message", message);
             }
 
             _setName(state, Node.Player(ctx.sender), task, name);

--- a/contracts/src/rules/QuestRule.sol
+++ b/contracts/src/rules/QuestRule.sol
@@ -5,7 +5,7 @@ import "cog/IState.sol";
 import "cog/IRule.sol";
 import "cog/IDispatcher.sol";
 
-import {Schema, Node, Kind, Rel, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
+import {Schema, Node, Kind, Rel, DEFAULT_ZONE, QuestStatus} from "@ds/schema/Schema.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 
 import "forge-std/console.sol";
@@ -68,6 +68,18 @@ contract QuestRule is Rule {
                 bytes24 task = tasks[i];
                 state.set(Rel.HasTask.selector, i, quest, task, 0);
             }
+
+            // Point to next quest
+        }
+
+        if (bytes4(action) == Actions.ACCEPT_QUEST.selector) {
+            (bytes24 quest, uint8 questNum) = abi.decode(action[4:], (bytes24, uint8));
+
+            ( /*bytes24 currentQuest*/ , QuestStatus questStatus) =
+                state.getPlayerQuest(Node.Player(ctx.sender), questNum);
+            require(questStatus == QuestStatus.NONE, "Quest already present at given questNum");
+
+            state.setQuestAccepted(quest, Node.Player(ctx.sender), questNum);
         }
         return state;
     }

--- a/contracts/src/rules/QuestRule.sol
+++ b/contracts/src/rules/QuestRule.sol
@@ -41,6 +41,12 @@ contract QuestRule is Rule {
                 (bytes24 buildingKind, string memory message) = abi.decode(taskData, (bytes24, string));
                 state.set(Rel.Has.selector, 0, task, buildingKind, 0);
                 state.annotate(task, "message", message);
+            } else if (
+                uint32(uint256(keccak256(abi.encodePacked("questAccept")))) == taskKind
+                    || uint32(uint256(keccak256(abi.encodePacked("questComplete")))) == taskKind
+            ) {
+                (bytes24 quest) = abi.decode(taskData, (bytes24));
+                state.set(Rel.HasQuest.selector, 0, task, quest, 0);
             }
 
             _setName(state, Node.Player(ctx.sender), task, name);

--- a/contracts/src/rules/QuestRule.sol
+++ b/contracts/src/rules/QuestRule.sol
@@ -81,6 +81,20 @@ contract QuestRule is Rule {
 
             state.setQuestAccepted(quest, Node.Player(ctx.sender), questNum);
         }
+
+        if (bytes4(action) == Actions.COMPLETE_QUEST.selector) {
+            (bytes24 quest, uint8 questNum) = abi.decode(action[4:], (bytes24, uint8));
+
+            (bytes24 currentQuest, QuestStatus questStatus) = state.getPlayerQuest(Node.Player(ctx.sender), questNum);
+
+            require(quest == currentQuest, "Quest at given questNum doesn't match supplied quest ID");
+            require(questStatus == QuestStatus.ACCEPTED, "Quest must be in ACCEPTED state to be completed");
+
+            state.setQuestCompleted(quest, Node.Player(ctx.sender), questNum);
+
+            // Auto accept next quest
+        }
+
         return state;
     }
 

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -19,6 +19,8 @@ interface Rel {
     function Has() external;
     function Combat() external;
     function IsFinalised() external;
+    function HasTask() external;
+    function HasQuest() external;
 }
 
 interface Kind {
@@ -35,6 +37,8 @@ interface Kind {
     function CombatSession() external;
     function Hash() external;
     function BlockNum() external;
+    function Quest() external;
+    function Task() external;
 }
 
 uint64 constant BLOCK_TIME_SECS = 2;
@@ -134,6 +138,15 @@ library Node {
 
     function BlockNum() internal pure returns (bytes24) {
         return bytes24(Kind.BlockNum.selector);
+    }
+
+    function Task(uint64 id, string memory kind) internal pure returns (bytes24) {
+        uint32 kindHash = uint32(uint256(keccak256(abi.encode(kind))));
+        return CompoundKeyEncoder.BYTES(Kind.BuildingKind.selector, bytes20(abi.encodePacked(uint64(0), kindHash, id)));
+    }
+
+    function Quest(uint64 id) internal pure returns (bytes24) {
+        return CompoundKeyEncoder.BYTES(Kind.BuildingKind.selector, bytes20(abi.encodePacked(uint32(0), uint64(0), id)));
     }
 }
 
@@ -428,5 +441,9 @@ library Schema {
 
     function getBlockNum(State state, bytes24 kind, uint8 slot) internal view returns (uint64 blockNum) {
         ( /*bytes24 item*/ , blockNum) = state.get(Rel.Has.selector, slot, kind);
+    }
+
+    function getTaskKind(State, /*state*/ bytes24 task) internal pure returns (uint32) {
+        return uint32(uint192(task) >> 64 & type(uint32).max);
     }
 }

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -146,9 +146,11 @@ library Node {
         return bytes24(Kind.BlockNum.selector);
     }
 
-    function Task(uint64 id, string memory kind) internal pure returns (bytes24) {
+    function Task(uint32 id, string memory kind) internal pure returns (bytes24) {
         uint32 kindHash = uint32(uint256(keccak256(abi.encode(kind))));
-        return CompoundKeyEncoder.BYTES(Kind.Task.selector, bytes20(abi.encodePacked(uint64(0), kindHash, id)));
+        return CompoundKeyEncoder.BYTES(
+            Kind.Task.selector, bytes20(abi.encodePacked(uint32(0), uint32(0), uint32(0), kindHash, id))
+        );
     }
 
     function Quest(string memory name) internal pure returns (bytes24) {
@@ -451,7 +453,7 @@ library Schema {
     }
 
     function getTaskKind(State, /*state*/ bytes24 task) internal pure returns (uint32) {
-        return uint32(uint192(task) >> 64 & type(uint32).max);
+        return uint32(uint192(task) >> 32 & type(uint32).max);
     }
 
     function setQuestAccepted(State state, bytes24 quest, bytes24 player, uint8 questNum) internal {

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -460,6 +460,10 @@ library Schema {
         state.set(Rel.HasQuest.selector, questNum, player, quest, uint8(QuestStatus.ACCEPTED));
     }
 
+    function setQuestCompleted(State state, bytes24 quest, bytes24 player, uint8 questNum) internal {
+        state.set(Rel.HasQuest.selector, questNum, player, quest, uint8(QuestStatus.COMPLETED));
+    }
+
     function getPlayerQuest(State state, bytes24 player, uint8 questNum) internal view returns (bytes24, QuestStatus) {
         (bytes24 quest, uint64 status) = state.get(Rel.HasQuest.selector, questNum, player);
         return (quest, QuestStatus(status));

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -20,6 +20,8 @@ export const NodeSelectors = {
     BuildingKind: getSelector('BuildingKind'),
     ClientPlugin: getSelector('ClientPlugin'),
     Bag: getSelector('Bag'),
+    Quest: getSelector('Quest'),
+    Task: getSelector('Task'),
 };
 
 export const CompoundKeyEncoder = {

--- a/core/src/player.graphql
+++ b/core/src/player.graphql
@@ -17,16 +17,19 @@ fragment SelectedPlayer on Node {
             }
             location: node(match: { kinds: "tile" }) {
                 id
+                coords: keys
             }
             tasks: edges(match: { kinds: "task" }) {
                 key
-                task: node {
+                node {
                     id
+                    keys
                     name: annotation(name: "name") {
                         value
                     }
                     location: node(match: { kinds: "tile" }) {
                         id
+                        coords: keys
                     }
                     itemSlot: edge(match: { kinds: "item" }) {
                         balance: weight

--- a/core/src/player.graphql
+++ b/core/src/player.graphql
@@ -19,7 +19,7 @@ fragment SelectedPlayer on Node {
                 id
                 coords: keys
             }
-            tasks: edges(match: { kinds: "task" }) {
+            tasks: edges(match: { kinds: "task", via: { rel: "HasTask", dir: OUT } }) {
                 key
                 node {
                     id
@@ -41,6 +41,9 @@ fragment SelectedPlayer on Node {
                         value
                     }
                     buildingKind: node(match: { kinds: "buildingKind" }) {
+                        id
+                    }
+                    quest: node(match: { kinds: "quest", via: { rel: "HasQuest", dir: OUT } }) {
                         id
                     }
                 }

--- a/core/src/player.graphql
+++ b/core/src/player.graphql
@@ -3,6 +3,44 @@ fragment SelectedPlayer on Node {
     mobileUnits: nodes(match: { kinds: "MobileUnit", via: { rel: "Owner", dir: IN } }) {
         ...SelectedMobileUnit
     }
+
+    quests: edges(match: { via: { rel: "HasQuest" } }) {
+        key
+        status: weight
+        node {
+            id
+            name: annotation(name: "name") {
+                value
+            }
+            description: annotation(name: "description") {
+                value
+            }
+            location: node(match: { kinds: "tile" }) {
+                id
+            }
+            tasks: edges(match: { kinds: "task" }) {
+                key
+                task: node {
+                    id
+                    name: annotation(name: "name") {
+                        value
+                    }
+                    location: node(match: { kinds: "tile" }) {
+                        id
+                    }
+                    itemSlot: edge(match: { kinds: "item" }) {
+                        balance: weight
+                        item: node {
+                            id
+                        }
+                    }
+                    button: annotation(name: "button") {
+                        value
+                    }
+                }
+            }
+        }
+    }
 }
 
 query GetSelectedPlayer($gameID: ID!, $id: String!) {

--- a/core/src/player.graphql
+++ b/core/src/player.graphql
@@ -37,8 +37,11 @@ fragment SelectedPlayer on Node {
                             id
                         }
                     }
-                    button: annotation(name: "button") {
+                    message: annotation(name: "message") {
                         value
+                    }
+                    buildingKind: node(match: { kinds: "buildingKind" }) {
+                        id
                     }
                 }
             }

--- a/core/src/player.ts
+++ b/core/src/player.ts
@@ -73,5 +73,6 @@ function toFakeSelectedPlayer(wallet: Wallet): SelectedPlayerFragment {
         id: wallet.id,
         addr: wallet.address,
         mobileUnits: [],
+        quests: [],
     };
 }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -358,3 +358,5 @@ export interface ConnectedPlayer extends SelectedPlayerFragment {
 export type UnconnectedPlayer = undefined;
 
 export type SelectedMapElement = { id: string; type: string };
+
+export type QuestFragment = SelectedPlayerFragment['quests'][0];

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -360,3 +360,15 @@ export type UnconnectedPlayer = undefined;
 export type SelectedMapElement = { id: string; type: string };
 
 export type QuestFragment = SelectedPlayerFragment['quests'][0];
+
+// TODO: Generate these from the contract
+export enum TaskKinds {
+    coord = 'coord',
+    button = 'button',
+    inventory = 'inventory',
+    combat = 'combat',
+    combatWinAttack = 'combatWinAttack',
+    combatWinDefense = 'combatWinDefense',
+    questAccept = 'questAccept',
+    questComplete = 'questComplete',
+}

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -372,3 +372,8 @@ export enum TaskKinds {
     questAccept = 'questAccept',
     questComplete = 'questComplete',
 }
+
+export type QuestTask = QuestFragment['node']['tasks'][0];
+
+export const QUEST_STATUS_ACCEPTED = 1;
+export const QUEST_STATUS_COMPLETED = 2;

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -364,7 +364,7 @@ export type QuestFragment = SelectedPlayerFragment['quests'][0];
 // TODO: Generate these from the contract
 export enum TaskKinds {
     coord = 'coord',
-    button = 'button',
+    message = 'message',
     inventory = 'inventory',
     combat = 'combat',
     combatWinAttack = 'combatWinAttack',

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -18,7 +18,29 @@ const Panel = styled.div`
     }
 
     > .taskContainer {
-        margin-top: 1rem;
+        margin-top: 2rem;
+    }
+
+    .taskItem {
+        display: flex;
+        align-items: center;
+        margin-bottom: 1rem;
+    }
+
+    .taskItem .tickBox {
+        flex-shrink: 0;
+        margin-right: 1rem;
+        background: white;
+        width: 2rem;
+        height: 2rem;
+        border-radius: 0.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .taskItem svg {
+        fill: #63b204;
     }
 
     > .buttonContainer {
@@ -31,6 +53,12 @@ const Panel = styled.div`
         width: 30rem;
     }
 `;
+
+const tick = (
+    <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
+        <path d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z" />
+    </svg>
+);
 
 export interface QuestProps {
     player: ConnectedPlayer;
@@ -55,9 +83,10 @@ type Task = QuestFragment['node']['tasks'][0] & Partial<{ isCompleted: boolean }
 
 const TaskItem: FunctionComponent<{ task: Task }> = ({ task }) => {
     return (
-        <p>
-            {task.isCompleted ? '[X]' : '[ ]'} {task.node.name?.value}
-        </p>
+        <div className="taskItem">
+            <div className="tickBox">{task.isCompleted && tick}</div>
+            <p>{task.node.name?.value}</p>
+        </div>
     );
 };
 const LocationButton: FunctionComponent<{ location: Locatable }> = ({ location }) => {

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -40,7 +40,7 @@ export const COMPLETED = 2;
 
 // TODO: Generate these
 export const taskCoord = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.coord))).toString(16);
-export const taskButton = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.button))).toString(16);
+export const taskButton = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.message))).toString(16);
 export const taskInventory = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.inventory))).toString(16);
 export const taskCombat = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.combat))).toString(16);
 export const taskCombatWinAttack =
@@ -68,6 +68,7 @@ const evalTaskCompletion = (task: Task, player: Player) => {
     switch (task.node.keys[0]) {
         case taskCoord:
             return player.mobileUnits?.some((unit) => {
+                console.log(`compare loc: ${unit.nextLocation?.tile.coords} : ${task.node.location?.coords}`);
                 return (
                     unit.nextLocation &&
                     task.node.location &&

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -1,42 +1,136 @@
-import { PluginType, QuestFragment, SelectedPlayerFragment } from '@app/../../core/src';
-import { usePluginState } from '@app/hooks/use-game-state';
-import { PluginContent } from '../organisms/tile-action';
+import { Player, QuestFragment, TaskKinds } from '@app/../../core/src';
 import styled from 'styled-components';
 import { FunctionComponent } from 'react';
+import { Locatable, getCoords, getTileDistance } from '@app/helpers/tile';
+import { id as keccak256UTF8 } from 'ethers';
 
 const Panel = styled.div`
     background: #143063;
     color: #fff;
     padding: 2rem 2rem;
     margin-bottom: 1.2rem;
+    width: 52rem;
+
+    > h1 {
+        text-align: center;
+        margin-bottom: 1rem;
+    }
+
+    > .taskContainer {
+        margin-top: 1rem;
+    }
+
+    > .buttonContainer {
+        margin-top: 1rem;
+        display: flex;
+        justify-content: center;
+    }
+
+    > .buttonContainer .completeQuestButton {
+        width: 30rem;
+    }
 `;
 
 export interface QuestProps {
-    quests: QuestFragment[];
+    player: Player;
 }
 
 export const ACCEPTED = 1;
 export const COMPLETED = 2;
 
-export const QuestPanel: FunctionComponent<QuestProps> = ({ quests }: QuestProps) => {
-    const acceptedQuests = quests.filter((q) => q.status == ACCEPTED).sort((a, b) => a.key - b.key);
+// TODO: Generate these
+export const taskCoord = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.coord))).toString(16);
+export const taskButton = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.button))).toString(16);
+export const taskInventory = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.inventory))).toString(16);
+export const taskCombat = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.combat))).toString(16);
+export const taskCombatWinAttack =
+    '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.combatWinAttack))).toString(16);
+export const taskCombatWinDefense =
+    '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.combatWinDefense))).toString(16);
+export const taskQuestAccept = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.questAccept))).toString(16);
+export const taskQuestComplete = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.questComplete))).toString(16);
+
+type Task = QuestFragment['node']['tasks'][0] & Partial<{ isCompleted: boolean }>;
+
+const TaskItem: FunctionComponent<{ task: Task }> = ({ task }) => {
+    return (
+        <p>
+            {task.isCompleted ? '[X]' : '[ ]'} {task.node.name?.value}
+        </p>
+    );
+};
+const LocationButton: FunctionComponent<{ location: Locatable }> = ({ location }) => {
+    const { q, r, s } = getCoords(location);
+    return <p>{`${q} ${r} ${s}`}</p>;
+};
+
+const evalTaskCompletion = (task: Task, player: Player) => {
+    console.log(`compare ${task.node.keys[0]} with ${taskCoord}`);
+    switch (task.node.keys[0]) {
+        case taskCoord:
+            return player.mobileUnits?.some((unit) => {
+                console.log(`compare ${unit.nextLocation?.tile.coords} : ${task.node.location?.coords}`);
+                return (
+                    unit.nextLocation &&
+                    task.node.location &&
+                    getTileDistance(unit.nextLocation.tile, task.node.location) < 2
+                );
+            });
+
+        case taskInventory:
+            return true;
+    }
+    return false;
+};
+
+export const QuestPanel: FunctionComponent<QuestProps> = ({ player }: QuestProps) => {
+    const acceptedQuests = player.quests?.filter((q) => q.status == ACCEPTED).sort((a, b) => a.key - b.key) || [];
+    if (acceptedQuests.length === 0) {
+        return <></>;
+    }
+
+    const tasks: Task[] = acceptedQuests[0].node.tasks.map((task) => {
+        return {
+            ...task,
+            isCompleted: evalTaskCompletion(task, player),
+        };
+    });
+
+    const numCompleted = tasks.reduce((acc, t) => (t.isCompleted ? acc + 1 : acc), 0);
+    const allCompleted = numCompleted == tasks.length;
+
+    const onCompleteClick = () => {
+        console.log('Complete quest!!' + numCompleted);
+    };
 
     return (
         <>
-            {acceptedQuests.length > 0 && (
-                <Panel>
-                    <h1>Quests</h1>
-                    {[acceptedQuests[0]].map((quest, idx) => (
-                        <>
-                            <h2 key={idx}>{quest.node.name?.value}</h2>
-                            <h3 key={`taskHeader/${idx}`}>Tasks:</h3>
-                            {quest.node.tasks.map((task, idx) => (
-                                <p key={idx}>{task.task.name?.value}</p>
-                            ))}
-                        </>
-                    ))}
-                </Panel>
-            )}
+            <Panel>
+                <h1>Q.U.E.S.T.s</h1>
+                {[acceptedQuests[0]].map((quest) => (
+                    <>
+                        <div className="header">
+                            <h2>{quest.node.name?.value}</h2>
+                            {/* {quest.node.location && <LocationButton location={quest.node.location} />} */}
+                        </div>
+                        <p>{quest.node.description?.value}</p>
+                        <div className="taskContainer">
+                            {tasks
+                                .sort((a, b) => a.key - b.key)
+                                .map((task, idx) => (
+                                    <TaskItem key={idx} task={task} />
+                                ))}
+                        </div>
+                        {allCompleted && (
+                            <div className="buttonContainer">
+                                <button onClick={onCompleteClick} className="action-icon-button completeQuestButton">
+                                    Complete Quest
+                                </button>
+                            </div>
+                        )}
+                    </>
+                ))}
+            </Panel>
         </>
     );
 };

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -1,0 +1,42 @@
+import { PluginType, QuestFragment, SelectedPlayerFragment } from '@app/../../core/src';
+import { usePluginState } from '@app/hooks/use-game-state';
+import { PluginContent } from '../organisms/tile-action';
+import styled from 'styled-components';
+import { FunctionComponent } from 'react';
+
+const Panel = styled.div`
+    background: #143063;
+    color: #fff;
+    padding: 2rem 2rem;
+    margin-bottom: 1.2rem;
+`;
+
+export interface QuestProps {
+    quests: QuestFragment[];
+}
+
+export const ACCEPTED = 1;
+export const COMPLETED = 2;
+
+export const QuestPanel: FunctionComponent<QuestProps> = ({ quests }: QuestProps) => {
+    const acceptedQuests = quests.filter((q) => q.status == ACCEPTED).sort((a, b) => a.key - b.key);
+
+    return (
+        <>
+            {acceptedQuests.length > 0 && (
+                <Panel>
+                    <h1>Quests</h1>
+                    {[acceptedQuests[0]].map((quest, idx) => (
+                        <>
+                            <h2 key={idx}>{quest.node.name?.value}</h2>
+                            <h3 key={`taskHeader/${idx}`}>Tasks:</h3>
+                            {quest.node.tasks.map((task, idx) => (
+                                <p key={idx}>{task.task.name?.value}</p>
+                            ))}
+                        </>
+                    ))}
+                </Panel>
+            )}
+        </>
+    );
+};

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -11,6 +11,7 @@ const Panel = styled.div`
     color: #fff;
     padding: 2rem 2rem;
     width: 52rem;
+    position: absolute;
 
     > h1 {
         text-align: center;

--- a/frontend/src/components/quest-task/kinds/task-coord.tsx
+++ b/frontend/src/components/quest-task/kinds/task-coord.tsx
@@ -1,0 +1,29 @@
+import { getTileDistance } from '@app/helpers/tile';
+import { QuestTask, MobileUnit } from '@downstream/core';
+import { memo, useState } from 'react';
+import { TaskView } from '../task-view';
+
+export const TaskCoord = memo(
+    ({
+        isFirst,
+        task,
+        mobileUnits,
+        setAllCompleted,
+    }: {
+        isFirst: boolean;
+        task: QuestTask;
+        mobileUnits: MobileUnit[];
+        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
+    }) => {
+        console.log(`evaluating TaskCoord`);
+        const isCompleted = mobileUnits?.some((unit) => {
+            return (
+                unit.nextLocation &&
+                task.node.location &&
+                getTileDistance(unit.nextLocation.tile, task.node.location) < 2
+            );
+        });
+
+        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+    }
+);

--- a/frontend/src/components/quest-task/kinds/task-coord.tsx
+++ b/frontend/src/components/quest-task/kinds/task-coord.tsx
@@ -2,19 +2,16 @@ import { getTileDistance } from '@app/helpers/tile';
 import { QuestTask, MobileUnit } from '@downstream/core';
 import { memo, useState } from 'react';
 import { TaskView } from '../task-view';
+import { TaskItemProps } from '../task-item';
 
 export const TaskCoord = memo(
     ({
-        isFirst,
         task,
         mobileUnits,
-        setAllCompleted,
+        setTaskCompletion,
     }: {
-        isFirst: boolean;
-        task: QuestTask;
         mobileUnits: MobileUnit[];
-        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
-    }) => {
+    } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         console.log(`evaluating TaskCoord`);
         const isCompleted = mobileUnits?.some((unit) => {
             return (
@@ -24,6 +21,6 @@ export const TaskCoord = memo(
             );
         });
 
-        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-coord.tsx
+++ b/frontend/src/components/quest-task/kinds/task-coord.tsx
@@ -1,6 +1,6 @@
 import { getTileDistance } from '@app/helpers/tile';
-import { QuestTask, MobileUnit } from '@downstream/core';
-import { memo, useState } from 'react';
+import { MobileUnit } from '@downstream/core';
+import { memo } from 'react';
 import { TaskView } from '../task-view';
 import { TaskItemProps } from '../task-item';
 

--- a/frontend/src/components/quest-task/kinds/task-inventory.tsx
+++ b/frontend/src/components/quest-task/kinds/task-inventory.tsx
@@ -1,0 +1,45 @@
+import { QuestTask, MobileUnit } from '@downstream/core';
+import { memo, useState } from 'react';
+import { TaskView } from '../task-view';
+
+export const TaskInventory = memo(
+    ({
+        isFirst,
+        task,
+        mobileUnits,
+        setAllCompleted,
+    }: {
+        isFirst: boolean;
+        task: QuestTask;
+        mobileUnits: MobileUnit[];
+        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
+    }) => {
+        console.log(`evaluating TaskInventory`);
+
+        let isCompleted = false;
+
+        const taskItemSlot = task.node.itemSlot;
+        if (taskItemSlot) {
+            const itemCount =
+                mobileUnits.reduce((playerTotal, unit) => {
+                    if (!unit.bags) return playerTotal;
+                    return (
+                        playerTotal +
+                        unit.bags.reduce((bagTotal, bagSlot) => {
+                            return (
+                                bagTotal +
+                                bagSlot.bag.slots.reduce((slotTotal, itemSlot) => {
+                                    return itemSlot.item.id == taskItemSlot.item.id
+                                        ? slotTotal + itemSlot.balance
+                                        : slotTotal;
+                                }, 0)
+                            );
+                        }, 0)
+                    );
+                }, 0) || 0;
+            isCompleted = itemCount >= taskItemSlot.balance;
+        }
+
+        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+    }
+);

--- a/frontend/src/components/quest-task/kinds/task-inventory.tsx
+++ b/frontend/src/components/quest-task/kinds/task-inventory.tsx
@@ -1,19 +1,16 @@
-import { QuestTask, MobileUnit } from '@downstream/core';
-import { memo, useState } from 'react';
+import { MobileUnit } from '@downstream/core';
+import { memo } from 'react';
 import { TaskView } from '../task-view';
+import { TaskItemProps } from '../task-item';
 
 export const TaskInventory = memo(
     ({
-        isFirst,
         task,
         mobileUnits,
-        setAllCompleted,
+        setTaskCompletion,
     }: {
-        isFirst: boolean;
-        task: QuestTask;
         mobileUnits: MobileUnit[];
-        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
-    }) => {
+    } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         console.log(`evaluating TaskInventory`);
 
         let isCompleted = false;
@@ -40,6 +37,6 @@ export const TaskInventory = memo(
             isCompleted = itemCount >= taskItemSlot.balance;
         }
 
-        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-message.tsx
+++ b/frontend/src/components/quest-task/kinds/task-message.tsx
@@ -1,19 +1,16 @@
-import { Log, QuestTask } from '@downstream/core';
-import { memo, useState } from 'react';
+import { Log } from '@downstream/core';
+import { memo } from 'react';
 import { TaskView } from '../task-view';
+import { TaskItemProps } from '../task-item';
 
 export const TaskMessage = memo(
     ({
-        isFirst,
         task,
         questMessages,
-        setAllCompleted,
+        setTaskCompletion,
     }: {
-        isFirst: boolean;
-        task: QuestTask;
         questMessages?: Log[];
-        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
-    }) => {
+    } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         console.log(`evaluating TaskMessage`);
 
         const pluginMessages =
@@ -23,6 +20,6 @@ export const TaskMessage = memo(
             [];
         const isCompleted = pluginMessages.some((m) => m.text == task.node.message?.value);
 
-        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-message.tsx
+++ b/frontend/src/components/quest-task/kinds/task-message.tsx
@@ -1,0 +1,28 @@
+import { Log, QuestTask } from '@downstream/core';
+import { memo, useState } from 'react';
+import { TaskView } from '../task-view';
+
+export const TaskMessage = memo(
+    ({
+        isFirst,
+        task,
+        questMessages,
+        setAllCompleted,
+    }: {
+        isFirst: boolean;
+        task: QuestTask;
+        questMessages?: Log[];
+        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
+    }) => {
+        console.log(`evaluating TaskMessage`);
+
+        const pluginMessages =
+            (task.node.buildingKind &&
+                questMessages &&
+                questMessages.filter((m) => m.name === `questMessages: ${task.node.buildingKind?.id}`)) ||
+            [];
+        const isCompleted = pluginMessages.some((m) => m.text == task.node.message?.value);
+
+        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+    }
+);

--- a/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
@@ -1,5 +1,5 @@
-import { QuestTask, QuestFragment } from '@downstream/core';
-import { memo, useState } from 'react';
+import { QuestFragment } from '@downstream/core';
+import { memo } from 'react';
 import { TaskView } from '../task-view';
 import { TaskItemProps } from '../task-item';
 

--- a/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
@@ -1,0 +1,22 @@
+import { QuestTask, QuestFragment } from '@downstream/core';
+import { memo, useState } from 'react';
+import { TaskView } from '../task-view';
+
+export const TaskQuestAccept = memo(
+    ({
+        isFirst,
+        task,
+        quests,
+        setAllCompleted,
+    }: {
+        isFirst: boolean;
+        task: QuestTask;
+        quests?: QuestFragment[];
+        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
+    }) => {
+        console.log(`evaluating TaskQuestAccept`);
+        const isCompleted = !!quests?.some((q) => q.node.id == task.node.quest?.id);
+
+        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+    }
+);

--- a/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
@@ -1,22 +1,19 @@
 import { QuestTask, QuestFragment } from '@downstream/core';
 import { memo, useState } from 'react';
 import { TaskView } from '../task-view';
+import { TaskItemProps } from '../task-item';
 
 export const TaskQuestAccept = memo(
     ({
-        isFirst,
         task,
         quests,
-        setAllCompleted,
+        setTaskCompletion,
     }: {
-        isFirst: boolean;
-        task: QuestTask;
         quests?: QuestFragment[];
-        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
-    }) => {
+    } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         console.log(`evaluating TaskQuestAccept`);
         const isCompleted = !!quests?.some((q) => q.node.id == task.node.quest?.id);
 
-        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-quest-complete.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-complete.tsx
@@ -1,0 +1,24 @@
+import { QuestTask, QuestFragment, QUEST_STATUS_COMPLETED } from '@downstream/core';
+import { memo, useState } from 'react';
+import { TaskView } from '../task-view';
+
+export const TaskQuestComplete = memo(
+    ({
+        isFirst,
+        task,
+        quests,
+        setAllCompleted,
+    }: {
+        isFirst: boolean;
+        task: QuestTask;
+        quests?: QuestFragment[];
+        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
+    }) => {
+        console.log(`evaluating TaskQuestCompleted`);
+        const isCompleted = !!quests?.some(
+            (q) => q.node.id == task.node.quest?.id && q.status == QUEST_STATUS_COMPLETED
+        );
+
+        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+    }
+);

--- a/frontend/src/components/quest-task/kinds/task-quest-complete.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-complete.tsx
@@ -1,24 +1,21 @@
-import { QuestTask, QuestFragment, QUEST_STATUS_COMPLETED } from '@downstream/core';
-import { memo, useState } from 'react';
+import { QuestFragment, QUEST_STATUS_COMPLETED } from '@downstream/core';
+import { memo } from 'react';
 import { TaskView } from '../task-view';
+import { TaskItemProps } from '../task-item';
 
 export const TaskQuestComplete = memo(
     ({
-        isFirst,
         task,
         quests,
-        setAllCompleted,
+        setTaskCompletion,
     }: {
-        isFirst: boolean;
-        task: QuestTask;
         quests?: QuestFragment[];
-        setAllCompleted: ReturnType<typeof useState<boolean>>[1];
-    }) => {
+    } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         console.log(`evaluating TaskQuestCompleted`);
         const isCompleted = !!quests?.some(
             (q) => q.node.id == task.node.quest?.id && q.status == QUEST_STATUS_COMPLETED
         );
 
-        return <TaskView isFirst={isFirst} isCompleted={isCompleted} task={task} setAllCompleted={setAllCompleted} />;
+        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
     }
 );

--- a/frontend/src/components/quest-task/task-item.tsx
+++ b/frontend/src/components/quest-task/task-item.tsx
@@ -9,70 +9,36 @@ import { TaskQuestComplete } from './kinds/task-quest-complete';
 import { TaskView } from './task-view';
 
 export interface TaskItemProps {
-    isFirst: boolean;
     task: QuestTask;
     player: Player;
     questMessages?: Log[];
-    setAllCompleted: ReturnType<typeof useState<boolean>>[1];
+    setTaskCompletion: ReturnType<typeof useState<{ [key: string]: boolean }>>[1];
 }
 
-export const TaskItem: FunctionComponent<TaskItemProps> = ({
-    isFirst,
-    task,
-    player,
-    questMessages,
-    setAllCompleted,
-}) => {
+export const TaskItem: FunctionComponent<TaskItemProps> = ({ task, player, questMessages, setTaskCompletion }) => {
     // const calculation = useMemo(() => expensiveCalculation(count), [count]);
 
     const taskKind = task.node.keys[0];
     switch (taskKind) {
         case taskCoord:
             return (
-                <TaskCoord
-                    isFirst={isFirst}
-                    task={task}
-                    mobileUnits={player.mobileUnits || []}
-                    setAllCompleted={setAllCompleted}
-                />
+                <TaskCoord task={task} mobileUnits={player.mobileUnits || []} setTaskCompletion={setTaskCompletion} />
             );
         case taskInventory:
             return (
                 <TaskInventory
-                    isFirst={isFirst}
                     task={task}
                     mobileUnits={player.mobileUnits || []}
-                    setAllCompleted={setAllCompleted}
+                    setTaskCompletion={setTaskCompletion}
                 />
             );
         case taskMessage:
-            return (
-                <TaskMessage
-                    isFirst={isFirst}
-                    task={task}
-                    questMessages={questMessages}
-                    setAllCompleted={setAllCompleted}
-                />
-            );
+            return <TaskMessage task={task} questMessages={questMessages} setTaskCompletion={setTaskCompletion} />;
         case taskQuestAccept:
-            return (
-                <TaskQuestAccept
-                    isFirst={isFirst}
-                    task={task}
-                    quests={player.quests}
-                    setAllCompleted={setAllCompleted}
-                />
-            );
+            return <TaskQuestAccept task={task} quests={player.quests} setTaskCompletion={setTaskCompletion} />;
         case taskQuestComplete:
-            return (
-                <TaskQuestComplete
-                    isFirst={isFirst}
-                    task={task}
-                    quests={player.quests}
-                    setAllCompleted={setAllCompleted}
-                />
-            );
+            return <TaskQuestComplete task={task} quests={player.quests} setTaskCompletion={setTaskCompletion} />;
         default:
-            return <TaskView isFirst={isFirst} task={task} isCompleted={false} setAllCompleted={setAllCompleted} />;
+            return <TaskView task={task} isCompleted={false} setTaskCompletion={setTaskCompletion} />;
     }
 };

--- a/frontend/src/components/quest-task/task-item.tsx
+++ b/frontend/src/components/quest-task/task-item.tsx
@@ -1,23 +1,35 @@
-import { QuestTask, Player, Log } from '@downstream/core';
-import { useState, FunctionComponent } from 'react';
-import { taskCoord, taskInventory, taskMessage, taskQuestAccept, taskQuestComplete } from '../panels/quest-panel';
+import { QuestTask, Player, Log, TaskKinds } from '@downstream/core';
+import { FunctionComponent, Dispatch, SetStateAction } from 'react';
 import { TaskCoord } from './kinds/task-coord';
 import { TaskInventory } from './kinds/task-inventory';
 import { TaskMessage } from './kinds/task-message';
 import { TaskQuestAccept } from './kinds/task-quest-accept';
 import { TaskQuestComplete } from './kinds/task-quest-complete';
 import { TaskView } from './task-view';
+import { id as keccak256UTF8 } from 'ethers';
+
+// TODO: Generate these
+const taskCoord = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.coord))).toString(16);
+const taskMessage = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.message))).toString(16);
+const taskInventory = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.inventory))).toString(16);
+const taskQuestAccept = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.questAccept))).toString(16);
+const taskQuestComplete = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.questComplete))).toString(16);
+// const taskCombat = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.combat))).toString(16);
+// const taskCombatWinAttack = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.combatWinAttack))).toString(16);
+// const taskCombatWinDefense = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.combatWinDefense))).toString(16);
 
 export interface TaskItemProps {
     task: QuestTask;
     player: Player;
     questMessages?: Log[];
-    setTaskCompletion: ReturnType<typeof useState<{ [key: string]: boolean }>>[1];
+    setTaskCompletion: Dispatch<
+        SetStateAction<{
+            [key: string]: boolean;
+        }>
+    >;
 }
 
 export const TaskItem: FunctionComponent<TaskItemProps> = ({ task, player, questMessages, setTaskCompletion }) => {
-    // const calculation = useMemo(() => expensiveCalculation(count), [count]);
-
     const taskKind = task.node.keys[0];
     switch (taskKind) {
         case taskCoord:

--- a/frontend/src/components/quest-task/task-item.tsx
+++ b/frontend/src/components/quest-task/task-item.tsx
@@ -1,0 +1,78 @@
+import { QuestTask, Player, Log } from '@downstream/core';
+import { useState, FunctionComponent } from 'react';
+import { taskCoord, taskInventory, taskMessage, taskQuestAccept, taskQuestComplete } from '../panels/quest-panel';
+import { TaskCoord } from './kinds/task-coord';
+import { TaskInventory } from './kinds/task-inventory';
+import { TaskMessage } from './kinds/task-message';
+import { TaskQuestAccept } from './kinds/task-quest-accept';
+import { TaskQuestComplete } from './kinds/task-quest-complete';
+import { TaskView } from './task-view';
+
+export interface TaskItemProps {
+    isFirst: boolean;
+    task: QuestTask;
+    player: Player;
+    questMessages?: Log[];
+    setAllCompleted: ReturnType<typeof useState<boolean>>[1];
+}
+
+export const TaskItem: FunctionComponent<TaskItemProps> = ({
+    isFirst,
+    task,
+    player,
+    questMessages,
+    setAllCompleted,
+}) => {
+    // const calculation = useMemo(() => expensiveCalculation(count), [count]);
+
+    const taskKind = task.node.keys[0];
+    switch (taskKind) {
+        case taskCoord:
+            return (
+                <TaskCoord
+                    isFirst={isFirst}
+                    task={task}
+                    mobileUnits={player.mobileUnits || []}
+                    setAllCompleted={setAllCompleted}
+                />
+            );
+        case taskInventory:
+            return (
+                <TaskInventory
+                    isFirst={isFirst}
+                    task={task}
+                    mobileUnits={player.mobileUnits || []}
+                    setAllCompleted={setAllCompleted}
+                />
+            );
+        case taskMessage:
+            return (
+                <TaskMessage
+                    isFirst={isFirst}
+                    task={task}
+                    questMessages={questMessages}
+                    setAllCompleted={setAllCompleted}
+                />
+            );
+        case taskQuestAccept:
+            return (
+                <TaskQuestAccept
+                    isFirst={isFirst}
+                    task={task}
+                    quests={player.quests}
+                    setAllCompleted={setAllCompleted}
+                />
+            );
+        case taskQuestComplete:
+            return (
+                <TaskQuestComplete
+                    isFirst={isFirst}
+                    task={task}
+                    quests={player.quests}
+                    setAllCompleted={setAllCompleted}
+                />
+            );
+        default:
+            return <TaskView isFirst={isFirst} task={task} isCompleted={false} setAllCompleted={setAllCompleted} />;
+    }
+};

--- a/frontend/src/components/quest-task/task-view.tsx
+++ b/frontend/src/components/quest-task/task-view.tsx
@@ -1,5 +1,5 @@
-import { QuestTask } from '@downstream/core';
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent } from 'react';
+import { TaskItemProps } from './task-item';
 
 const tickSvg = (
     <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
@@ -7,14 +7,15 @@ const tickSvg = (
     </svg>
 );
 
-export const TaskView: FunctionComponent<{
-    isFirst: boolean;
-    isCompleted: boolean;
-    task: QuestTask;
-    setAllCompleted: ReturnType<typeof useState<boolean>>[1];
-}> = ({ isFirst, isCompleted, task, setAllCompleted }) => {
-    setAllCompleted((allCompleted) => {
-        return (allCompleted || isFirst) && isCompleted;
+export const TaskView: FunctionComponent<
+    {
+        isCompleted: boolean;
+    } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>
+> = ({ isCompleted, task, setTaskCompletion }) => {
+    setTaskCompletion((oldObj) => {
+        const newObj = oldObj ? { ...oldObj } : {};
+        newObj[task.node.id] = isCompleted;
+        return newObj;
     });
 
     return (

--- a/frontend/src/components/quest-task/task-view.tsx
+++ b/frontend/src/components/quest-task/task-view.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 import { TaskItemProps } from './task-item';
 
 const tickSvg = (
@@ -12,11 +12,14 @@ export const TaskView: FunctionComponent<
         isCompleted: boolean;
     } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>
 > = ({ isCompleted, task, setTaskCompletion }) => {
-    setTaskCompletion((oldObj) => {
-        const newObj = oldObj ? { ...oldObj } : {};
-        newObj[task.node.id] = isCompleted;
-        return newObj;
-    });
+    const taskId = task.node.id;
+    useEffect(() => {
+        setTaskCompletion((oldObj) => {
+            const newObj = oldObj ? { ...oldObj } : {};
+            newObj[taskId] = isCompleted;
+            return newObj;
+        });
+    }, [taskId, isCompleted, setTaskCompletion]);
 
     return (
         <div className="taskItem">

--- a/frontend/src/components/quest-task/task-view.tsx
+++ b/frontend/src/components/quest-task/task-view.tsx
@@ -1,0 +1,26 @@
+import { QuestTask } from '@downstream/core';
+import { FunctionComponent, useState } from 'react';
+
+const tickSvg = (
+    <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
+        <path d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z" />
+    </svg>
+);
+
+export const TaskView: FunctionComponent<{
+    isFirst: boolean;
+    isCompleted: boolean;
+    task: QuestTask;
+    setAllCompleted: ReturnType<typeof useState<boolean>>[1];
+}> = ({ isFirst, isCompleted, task, setAllCompleted }) => {
+    setAllCompleted((allCompleted) => {
+        return (allCompleted || isFirst) && isCompleted;
+    });
+
+    return (
+        <div className="taskItem">
+            <div className="tickBox">{isCompleted && tickSvg}</div>
+            <p>{task.node.name?.value}</p>
+        </div>
+    );
+};

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -243,7 +243,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
             <div className="hud-container">
                 <div className="top-left">
                     {player && <QuestPanel player={player} />}
-                    <Logs className="logs" />
+                    {/* <Logs className="logs" /> */}
                 </div>
                 <div className="bottom-left">
                     <ItemPluginPanel />

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -27,6 +27,7 @@ import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { pipe, subscribe } from 'wonka';
 import { styles } from './shell.styles';
+import { QuestPanel } from '@app/components/panels/quest-panel';
 
 export interface ShellProps extends ComponentProps {}
 
@@ -241,7 +242,8 @@ export const Shell: FunctionComponent<ShellProps> = () => {
             <NavPanel />
             <div className="hud-container">
                 <div className="top-left">
-                    <Logs className="logs" />
+                    {/* <Logs className="logs" /> */}
+                    {player && <QuestPanel quests={player.quests} />}
                 </div>
                 <div className="bottom-left">
                     <ItemPluginPanel />

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -242,8 +242,8 @@ export const Shell: FunctionComponent<ShellProps> = () => {
             <NavPanel />
             <div className="hud-container">
                 <div className="top-left">
-                    {/* <Logs className="logs" /> */}
                     {player && <QuestPanel player={player} />}
+                    <Logs className="logs" />
                 </div>
                 <div className="bottom-left">
                     <ItemPluginPanel />

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -243,7 +243,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
             <div className="hud-container">
                 <div className="top-left">
                     {/* <Logs className="logs" /> */}
-                    {player && <QuestPanel quests={player.quests} />}
+                    {player && <QuestPanel player={player} />}
                 </div>
                 <div className="bottom-left">
                     <ItemPluginPanel />

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -7,7 +7,6 @@ import { MobileUnits } from '@app/components/map/MobileUnit';
 import { Tiles } from '@app/components/map/Tile';
 import { TileGoos } from '@app/components/map/TileGoo';
 import { trackEvent } from '@app/components/organisms/analytics';
-import { Logs } from '@app/components/organisms/logs';
 import { Onboarding } from '@app/components/organisms/onboarding';
 import { ItemPluginPanel } from '@app/components/panels/item-plugin-panel';
 import { MobileUnitPanel } from '@app/components/panels/mobile-unit-panel';


### PR DESCRIPTION
# What

- A basic quest system where data is represented as `Quest` and `Task` nodes.
- Quests along with each of their tasks are defined in [yaml](https://github.com/playmint/ds/blob/91e6fe9d09448c019098f92b2d03289cb33bd138/contracts/src/fixtures/quests/intro.yaml) using our current manifest system
- Tasks come in different kinds which have different completion criteria for example the `location` kind of task evaluates completion by checking the player's unit location against the location associated with the task.
- Quests can be linked together so that when a quest is completed, a set of up to 5 quests can be auto accepted
- Accepted quests are displayed in a quest panel with their associated tasks displaying their current completion state
- When the frontend determines a quest as complete, a button will appear to 'complete quest' which will validate the task completion on chain and if satisfied will set the quest status to `completed`
	- Quest status is stored as the weight on the `hasQuest` edge which connects a `Player` node to a `Quest` node
	    - `NONE = 0`, `ACCEPTED = 1`, `COMPLETED = 2` 

## The panel
The panel supports multiple quests with a crude accordion implementation
![image](https://github.com/playmint/ds/assets/51167118/8b97606f-5f28-4cde-a9d5-1421cfb47355)