### PR TITLE
prune anvil history and limit kept blocks

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -15,7 +15,7 @@ const DEPLOYER_PRIVATE_KEY = "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff
 const commands = [
     {
         name: 'networks',
-        command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --block-time 2 --block-base-fee-per-gas 1",
+        command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --block-time 2 --block-base-fee-per-gas 1 --transaction-block-keeper 25 --prune-history",
         prefixColor: 'black',
     },
 

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -26,9 +26,10 @@ echo "+-------------------+"
 anvil \
     --block-base-fee-per-gas 1 \
     --block-time 2 \
+    --transaction-block-keeper 25 \
+    --prune-history \
 	--host 0.0.0.0 \
 	-m "${ACCOUNT_MNEMONIC}" \
-    --code-size-limit 9999999999999 \
 	&
 
 


### PR DESCRIPTION
attempt to reduce anvil's runaway memory consumption by limiting the amount of stuff it's keeping track of