### PR TITLE
player preference to pick render quality

### DIFF
--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -7,6 +7,9 @@ import styled from 'styled-components';
 import { Dialog } from '../molecules/dialog';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { GlobalUnityContext } from '@app/hooks/use-unity-instance';
+
+const g = globalThis as unknown as { __globalUnityContext: GlobalUnityContext };
 
 const AccountButton = styled.button`
     display: flex;
@@ -74,6 +77,17 @@ export const NavPanel = () => {
         window.location.reload();
     }, [clearSession]);
 
+    const canvasHeight = g.__globalUnityContext?.getCanvasHeight ? g.__globalUnityContext.getCanvasHeight() : -1;
+    const onChangeQuality = useCallback((e) => {
+        if (!e) {
+            return;
+        }
+        const newHeight = parseInt(e.target.value, 10);
+        if (g.__globalUnityContext?.setCanvasHeight) {
+            g.__globalUnityContext.setCanvasHeight(newHeight);
+        }
+    }, []);
+
     return (
         <NavContainer>
             {showAccountDialog && wallet && (
@@ -84,6 +98,22 @@ export const NavPanel = () => {
                             0x{wallet.address.slice(0, 9)}...{wallet.address.slice(-9)}
                         </p>
                         <br />
+                        <fieldset>
+                            <legend>Quality:</legend>
+                            <select onChange={onChangeQuality} value={canvasHeight}>
+                                <option value="480">Low (480p)</option>
+                                <option value="720">Medium (720p)</option>
+                                <option value="1080">High (1080p)</option>
+                                <option value="-1">
+                                    Auto ({Math.min(window.innerHeight, window.innerHeight * window.devicePixelRatio)}p)
+                                </option>
+                                <option value="-2">
+                                    Native ({Math.floor(window.innerHeight * window.devicePixelRatio)}p)
+                                </option>
+                            </select>
+                        </fieldset>
+                        <br />
+
                         <button className="action-button" onClick={disconnect}>
                             Disconnect
                         </button>


### PR DESCRIPTION
allow player to pick from a few fixed render qualities (480p, 720p 1080p) as well as "auto" (which takes the browser window size) and "native" (which takes the browser window size + packing in more pixels for hiDPI screens)

preference is persisted in localStorage

default is "auto" ... and for retina screens I think auto is going to lower the resolution from the previous default .... change to "native" if you want your full hiDPI res back

the control to set the quality is hidden in the "account" dialog (click the player icon top left in nav bar).... longer term we will move this out into a "settings" dialog or something ... but this is just a quick starting point

![Screenshot 2023-10-20 at 08 43 46](https://github.com/playmint/ds/assets/45921/984490d3-6857-4fc1-8445-a9e25dca7dac)

zooming out should no longer cause it to attempt to render a crazy high res ... zooming in however _will_ make the res worse, which is weird, but since zooming in will prettymuch break the rest of the UI anyway, I think we can live with that quirk