### PR TITLE
Header panel base style

### DIFF
--- a/frontend/src/components/organisms/onboarding/index.tsx
+++ b/frontend/src/components/organisms/onboarding/index.tsx
@@ -1,5 +1,5 @@
 import { CompoundKeyEncoder, ConnectedPlayer, NodeSelectors, WorldMobileUnitFragment } from '@app/../../core/src';
-import { BasePanelStyles, StyledHeaderPanel } from '@app/styles/base-panel.styles';
+import { StyledHeaderPanel } from '@app/styles/base-panel.styles';
 import { ActionButton } from '@app/styles/button.styles';
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';

--- a/frontend/src/components/organisms/onboarding/index.tsx
+++ b/frontend/src/components/organisms/onboarding/index.tsx
@@ -1,5 +1,5 @@
 import { CompoundKeyEncoder, ConnectedPlayer, NodeSelectors, WorldMobileUnitFragment } from '@app/../../core/src';
-import { BasePanelStyles } from '@app/styles/base-panel.styles';
+import { BasePanelStyles, StyledHeaderPanel } from '@app/styles/base-panel.styles';
 import { ActionButton } from '@app/styles/button.styles';
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
@@ -10,9 +10,10 @@ export interface OnboardingProps {
     onClickConnect: () => void;
 }
 
-const StyledOnboarding = styled.div`
-    ${BasePanelStyles}
-
+const StyledOnboarding = styled(StyledHeaderPanel)`
+    h3 {
+        margin: 0;
+    }
     button {
         margin-top: 0.5rem;
     }
@@ -40,19 +41,23 @@ export const Onboarding = ({ player, playerUnits, onClickConnect }: OnboardingPr
 
     return (
         <StyledOnboarding>
-            <h3>👁️‍🗨️ Welcome to Downstream</h3>
-            <p>✅ If you’re an approved playtester, simply connect your wallet and click ‘Spawn Unit’ to begin. </p>
-            <p>
-                If you want to join the community, check out our{' '}
-                <a href="https://discord.gg/VdXWWNaqGN">communications server!</a>
-            </p>
-            {player && playerUnits.length === 0 ? (
-                <ActionButton onClick={spawnMobileUnit} disabled={isSpawningMobileUnit}>
-                    Spawn Unit
-                </ActionButton>
-            ) : (
-                <ActionButton onClick={onClickConnect}>Connect Wallet</ActionButton>
-            )}
+            <div className="header">
+                <h3>👁️‍🗨️ Welcome to Downstream</h3>
+            </div>
+            <div className="content">
+                <p>✅ If you’re an approved playtester, simply connect your wallet and click ‘Spawn Unit’ to begin. </p>
+                <p>
+                    If you want to join the community, check out our{' '}
+                    <a href="https://discord.gg/VdXWWNaqGN">communications server!</a>
+                </p>
+                {player && playerUnits.length === 0 ? (
+                    <ActionButton onClick={spawnMobileUnit} disabled={isSpawningMobileUnit}>
+                        Spawn Unit
+                    </ActionButton>
+                ) : (
+                    <ActionButton onClick={onClickConnect}>Connect Wallet</ActionButton>
+                )}
+            </div>
         </StyledOnboarding>
     );
 };

--- a/frontend/src/components/panels/mobile-unit-panel.tsx
+++ b/frontend/src/components/panels/mobile-unit-panel.tsx
@@ -4,7 +4,7 @@ import { useGameState } from '@app/hooks/use-game-state';
 import { useUnityMap } from '@app/hooks/use-unity-map';
 import { MobileUnitInventory } from '@app/plugins/inventory/mobile-unit-inventory';
 import { useCallback, useMemo } from 'react';
-import { BasePanelStyles, StyledHeaderPanel } from '@app/styles/base-panel.styles';
+import { StyledHeaderPanel } from '@app/styles/base-panel.styles';
 import { TextButton } from '@app/styles/button.styles';
 import styled from 'styled-components';
 import { colorMap, colors } from '@app/styles/colors';

--- a/frontend/src/components/panels/mobile-unit-panel.tsx
+++ b/frontend/src/components/panels/mobile-unit-panel.tsx
@@ -4,10 +4,10 @@ import { useGameState } from '@app/hooks/use-game-state';
 import { useUnityMap } from '@app/hooks/use-unity-map';
 import { MobileUnitInventory } from '@app/plugins/inventory/mobile-unit-inventory';
 import { useCallback, useMemo } from 'react';
-import { BasePanelStyles } from '@app/styles/base-panel.styles';
+import { BasePanelStyles, StyledHeaderPanel } from '@app/styles/base-panel.styles';
 import { TextButton } from '@app/styles/button.styles';
 import styled from 'styled-components';
-import { colors } from '@app/styles/colors';
+import { colorMap, colors } from '@app/styles/colors';
 
 const StyledMobileUnitIcon = styled.div`
     --width: 6.4rem;
@@ -59,8 +59,7 @@ const MobileUnitIcon = ({ className, onClick }) => {
     );
 };
 
-const StyledMobileUnitPanel = styled.div`
-    ${BasePanelStyles}
+const StyledMobileUnitPanel = styled(StyledHeaderPanel)`
     margin-top: 3.5rem;
 
     .bags > div:last-child .slots {
@@ -85,6 +84,7 @@ const MobileUnitContainer = styled.div`
     }
 
     > .label {
+        color: ${colorMap.primaryText};
         font-size: 2.8rem;
         display: block;
         width: 100%;
@@ -98,7 +98,6 @@ const MobileUnitContainer = styled.div`
     }
 
     > .location {
-        margin-bottom: 0.5rem;
         color: ${colors.grey_3};
     }
 `;
@@ -195,7 +194,7 @@ export const MobileUnitPanel = () => {
                 playerUnits.length > 0 &&
                 (selectedMobileUnit ? (
                     <StyledMobileUnitPanel>
-                        <div className="mobile-unit-actions">
+                        <div className="header">
                             <MobileUnitContainer>
                                 <MobileUnitIcon className="unitIcon" onClick={selectAndFocusMobileUnit} />
                                 <span className="label" onDoubleClick={() => nameEntity(selectedMobileUnit?.id)}>
@@ -208,6 +207,8 @@ export const MobileUnitPanel = () => {
                                     </div>
                                 )}
                             </MobileUnitContainer>
+                        </div>
+                        <div className="content">
                             <MobileUnitInventory mobileUnit={selectedMobileUnit} bags={world?.bags || []} />
                         </div>
                     </StyledMobileUnitPanel>

--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -17,7 +17,7 @@ import { useInventory } from '@app/plugins/inventory/inventory-provider';
 import { TileInventory } from '@app/plugins/inventory/tile-inventory';
 import { MobileUnitList } from '@app/plugins/mobile-unit-list';
 import { getBagsAtEquipee, getBuildingAtTile, getMobileUnitsAtTile } from '@downstream/core/src/utils';
-import { BasePanelStyles } from '@app/styles/base-panel.styles';
+import { StyledHeaderPanel } from '@app/styles/base-panel.styles';
 import { FunctionComponent, useCallback, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { colors } from '@app/styles/colors';
@@ -30,9 +30,7 @@ const byKey = (a: KeyedThing, b: KeyedThing) => {
     return a.key > b.key ? 1 : -1;
 };
 
-const Panel = styled.div`
-    ${BasePanelStyles}
-
+const StyledTileInfoPanel = styled(StyledHeaderPanel)`
     margin-bottom: 1.2rem;
     width: 30rem;
 
@@ -101,7 +99,7 @@ const Panel = styled.div`
         }
     }
 
-    > .label {
+    > .content > .label {
         width: 12rem;
         height: 1.7rem;
         white-space: nowrap;
@@ -169,81 +167,89 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, kinds, w
     });
 
     return (
-        <Panel>
-            <h3>{name}</h3>
-            {description && <span className="sub-title">{description}</span>}
-            {content && (
-                <PluginContent canUse={canUse} content={content}>
-                    {mobileUnit && (
-                        <>
-                            {inputs.length > 0 && inputBag && (
-                                <div ref={inputsRef} className="ingredients">
-                                    <Bag
-                                        bag={inputBag}
-                                        bagId={inputBag.id}
-                                        equipIndex={0}
-                                        ownerId={building.id}
-                                        isInteractable={canUse}
-                                        recipe={inputs}
-                                        numBagSlots={inputs.length}
-                                        showIcon={false}
-                                    />
-                                </div>
-                            )}
-                            {outputs.length > 0 && outputBag && (
-                                <div className="process">
-                                    {/* <img src="/icons/downarrow.png" alt="output" className="arrow" /> */}
-                                    <div className="arrow" />
-                                </div>
-                            )}
-                            {outputs.length > 0 && outputBag && (
-                                <div ref={outputsRef} className="ingredients">
-                                    <Bag
-                                        bag={outputBag}
-                                        bagId={outputBag.id}
-                                        equipIndex={1}
-                                        ownerId={building.id}
-                                        isInteractable={canUse}
-                                        recipe={outputs}
-                                        numBagSlots={outputs.length}
-                                        showIcon={false}
-                                    />
-                                </div>
-                            )}
-                        </>
-                    )}
-                </PluginContent>
-            )}
-            {selectedTile && <TileInventory tile={selectedTile} bags={world?.bags || []} />}
-            <span className="label" style={{ width: '100%', marginTop: '2rem' }}>
-                <strong>COORDINATES:</strong> {`${q}, ${r}, ${s}`}
-            </span>
-            {gooRatesInNameOrder.map((goo) => (
-                <span key={goo?.name} className="label" style={{ width: '30%' }}>
-                    <strong>{goo?.name.toUpperCase().slice(0, 1)}:</strong>{' '}
-                    {`${Math.floor((goo?.gooPerSec || 0) * 3600)}/h`}
+        <StyledTileInfoPanel>
+            <div className="header">
+                <h3>{name}</h3>
+                {description && <span className="sub-title">{description}</span>}
+            </div>
+            <div className="content">
+                {content && (
+                    <PluginContent canUse={canUse} content={content}>
+                        {mobileUnit && (
+                            <>
+                                {inputs.length > 0 && inputBag && (
+                                    <div ref={inputsRef} className="ingredients">
+                                        <Bag
+                                            bag={inputBag}
+                                            bagId={inputBag.id}
+                                            equipIndex={0}
+                                            ownerId={building.id}
+                                            isInteractable={canUse}
+                                            recipe={inputs}
+                                            numBagSlots={inputs.length}
+                                            showIcon={false}
+                                        />
+                                    </div>
+                                )}
+                                {outputs.length > 0 && outputBag && (
+                                    <div className="process">
+                                        {/* <img src="/icons/downarrow.png" alt="output" className="arrow" /> */}
+                                        <div className="arrow" />
+                                    </div>
+                                )}
+                                {outputs.length > 0 && outputBag && (
+                                    <div ref={outputsRef} className="ingredients">
+                                        <Bag
+                                            bag={outputBag}
+                                            bagId={outputBag.id}
+                                            equipIndex={1}
+                                            ownerId={building.id}
+                                            isInteractable={canUse}
+                                            recipe={outputs}
+                                            numBagSlots={outputs.length}
+                                            showIcon={false}
+                                        />
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </PluginContent>
+                )}
+                {selectedTile && <TileInventory tile={selectedTile} bags={world?.bags || []} />}
+                <span className="label" style={{ width: '100%', marginTop: '2rem' }}>
+                    <strong>COORDINATES:</strong> {`${q}, ${r}, ${s}`}
                 </span>
-            ))}
-            {author && (
-                <span className="label">
-                    <strong>AUTHOR:</strong> {author.addr}
-                </span>
-            )}
-            {owner && (
-                <span className="label">
-                    <strong>OWNER:</strong> {owner.addr}
-                </span>
-            )}
-        </Panel>
+                {gooRatesInNameOrder.map((goo) => (
+                    <span key={goo?.name} className="label" style={{ width: '30%' }}>
+                        <strong>{goo?.name.toUpperCase().slice(0, 1)}:</strong>{' '}
+                        {`${Math.floor((goo?.gooPerSec || 0) * 3600)}/h`}
+                    </span>
+                ))}
+                {author && (
+                    <span className="label">
+                        <strong>AUTHOR:</strong> {author.addr}
+                    </span>
+                )}
+                {owner && (
+                    <span className="label">
+                        <strong>OWNER:</strong> {owner.addr}
+                    </span>
+                )}
+            </div>
+        </StyledTileInfoPanel>
     );
 };
 
 const TileUndiscovered: FunctionComponent<unknown> = (_props) => {
     return (
-        <Panel>
-            <h3>Undiscovered Tile</h3>
-            <span className="sub-title">You can&apos;t make out this tile. Scouting should help!</span>
-        </Panel>
+        <StyledTileInfoPanel>
+            <div className="header">
+                <h3>Undiscovered Tile</h3>
+            </div>
+            <div className="content">
+                <span className="sub-title">You can&apos;t make out this tile. Scouting should help!</span>
+            </div>
+        </StyledTileInfoPanel>
     );
 };
 
@@ -291,22 +297,26 @@ const TileAvailable: FunctionComponent<TileAvailableProps> = ({ player, mobileUn
         : undefined;
 
     return (
-        <Panel>
-            <h3 style={{ marginBottom: '2rem' }}>{tileName}</h3>
-            <div className="description">{tileDescription}</div>
-            {tileMobileUnits.length > 0 && (
-                <MobileUnitList mobileUnits={visibleUnits} player={player} tile={selectedTile} bags={bags} />
-            )}
-            <span className="label" style={{ width: '100%' }}>
-                <strong>COORDINATES:</strong> {`${q}, ${r}, ${s}`}
-            </span>
-            {gooRatesInNameOrder.map((goo) => (
-                <span key={goo?.name} className="label" style={{ width: '30%' }}>
-                    <strong>{goo?.name.toUpperCase().slice(0, 1)}:</strong>{' '}
-                    {`${Math.floor((goo?.gooPerSec || 0) * 3600)}/h`}
+        <StyledTileInfoPanel>
+            <div className="header">
+                <h3>{tileName}</h3>
+                <div className="description">{tileDescription}</div>
+            </div>
+            <div className="content">
+                {tileMobileUnits.length > 0 && (
+                    <MobileUnitList mobileUnits={visibleUnits} player={player} tile={selectedTile} bags={bags} />
+                )}
+                <span className="label" style={{ width: '100%' }}>
+                    <strong>COORDINATES:</strong> {`${q}, ${r}, ${s}`}
                 </span>
-            ))}
-        </Panel>
+                {gooRatesInNameOrder.map((goo) => (
+                    <span key={goo?.name} className="label" style={{ width: '30%' }}>
+                        <strong>{goo?.name.toUpperCase().slice(0, 1)}:</strong>{' '}
+                        {`${Math.floor((goo?.gooPerSec || 0) * 3600)}/h`}
+                    </span>
+                ))}
+            </div>
+        </StyledTileInfoPanel>
     );
 };
 

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -28,7 +28,7 @@ import { pipe, subscribe } from 'wonka';
 import { styles } from './shell.styles';
 import { QuestPanel } from '@app/components/panels/quest-panel';
 import { getBagsAtEquipee, getBuildingAtTile, getSessionsAtTile } from '@downstream/core/src/utils';
-import { StyledBasePanel } from '@app/styles/base-panel.styles';
+import { StyledBasePanel, StyledHeaderPanel } from '@app/styles/base-panel.styles';
 
 export interface ShellProps extends ComponentProps {}
 
@@ -300,30 +300,34 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                         </StyledBasePanel>
                     )}
                     {selectedRewardBags && selectedRewardBags.length > 0 && (
-                        <StyledBasePanel>
-                            <h3>Combat rewards</h3>
-                            {selectedRewardBags.map((selectedBag) => {
-                                return (
-                                    <BagInventory
-                                        key={selectedBag.equipIndex}
-                                        bag={selectedBag.bag}
-                                        equipIndex={selectedBag.equipIndex}
-                                        ownerId={selectedBag.ownerId}
-                                        isInteractable={
-                                            !!(
-                                                selectedMobileUnit &&
-                                                selectedMobileUnit.nextLocation &&
-                                                getTileDistance(
-                                                    selectedMobileUnit.nextLocation.tile,
-                                                    selectedBag.parentTile
-                                                ) < 2
-                                            )
-                                        }
-                                        showIcon={true}
-                                    />
-                                );
-                            })}
-                        </StyledBasePanel>
+                        <StyledHeaderPanel>
+                            <div className="header">
+                                <h3>Combat rewards</h3>
+                            </div>
+                            <div className="content">
+                                {selectedRewardBags.map((selectedBag) => {
+                                    return (
+                                        <BagInventory
+                                            key={selectedBag.equipIndex}
+                                            bag={selectedBag.bag}
+                                            equipIndex={selectedBag.equipIndex}
+                                            ownerId={selectedBag.ownerId}
+                                            isInteractable={
+                                                !!(
+                                                    selectedMobileUnit &&
+                                                    selectedMobileUnit.nextLocation &&
+                                                    getTileDistance(
+                                                        selectedMobileUnit.nextLocation.tile,
+                                                        selectedBag.parentTile
+                                                    ) < 2
+                                                )
+                                            }
+                                            showIcon={true}
+                                        />
+                                    );
+                                })}
+                            </div>
+                        </StyledHeaderPanel>
                     )}
                 </div>
             </div>

--- a/frontend/src/plugins/combat/combat-summary/combat-summary.styles.ts
+++ b/frontend/src/plugins/combat/combat-summary/combat-summary.styles.ts
@@ -2,7 +2,6 @@
 
 import { css } from 'styled-components';
 import { CombatSummaryProps } from './index';
-import { BasePanelStyles } from '@app/styles/base-panel.styles';
 
 /**
  * Base styles for the mobileUnit list component
@@ -11,13 +10,12 @@ import { BasePanelStyles } from '@app/styles/base-panel.styles';
  * @return Base styles for the mobileUnit list component
  */
 const baseStyles = (_: Partial<CombatSummaryProps>) => css`
-    ${BasePanelStyles}
-
     width: 30rem;
 
     > .header {
         display: flex;
         align-items: center;
+        justify-content: space-between;
 
         .icon {
             width: 5rem;

--- a/frontend/src/plugins/combat/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat/combat-summary/index.tsx
@@ -12,6 +12,7 @@ import styled from 'styled-components';
 import { CombatModal } from '../combat-modal';
 import { styles } from './combat-summary.styles';
 import { ActionButton } from '@app/styles/button.styles';
+import { StyledHeaderPanel } from '@app/styles/base-panel.styles';
 
 export interface CombatSummaryProps extends ComponentProps {
     selectedTiles: WorldTileFragment[];
@@ -21,7 +22,7 @@ export interface CombatSummaryProps extends ComponentProps {
     selectedMobileUnit?: WorldMobileUnitFragment;
 }
 
-const StyledCombatSummary = styled('div')`
+const StyledCombatSummary = styled(StyledHeaderPanel)`
     ${styles}
 `;
 
@@ -81,8 +82,8 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
                 </Dialog>
             )}
             <div className="header">
-                <img src="/combat-header.png" alt="" className="icon" />
                 <h3 className="title">Tile in combat</h3>
+                <img src="/combat-header.png" alt="" className="icon" />
             </div>
             {actions && (
                 <div className="content">

--- a/frontend/src/styles/base-panel.styles.ts
+++ b/frontend/src/styles/base-panel.styles.ts
@@ -3,11 +3,12 @@ import { colorMap, colors } from './colors';
 
 export const BasePanelStyles = css`
     --panel-padding: 1.5rem;
+    --panel-border-radius: 1.2rem;
 
     position: relative;
     background: ${colorMap.primaryBackground};
     color: ${colorMap.primaryText};
-    border-radius: 1.2rem;
+    border-radius: var(--panel-border-radius);
     padding: var(--panel-padding);
     border: ${colorMap.primaryBorderColor} 3px solid;
 `;
@@ -16,10 +17,10 @@ export const StyledBasePanel = styled.div`
     ${BasePanelStyles}
 `;
 export const StyledHeaderPanel = styled(StyledBasePanel)`
-    overflow: hidden;
     flex-shrink: 0;
     padding: 0;
     > .header {
+        border-radius: var(--panel-border-radius) var(--panel-border-radius) 0 0;
         padding: var(--panel-padding);
         background: ${colorMap.secondaryBackground};
         color: ${colors.grey_3};

--- a/frontend/src/styles/base-panel.styles.ts
+++ b/frontend/src/styles/base-panel.styles.ts
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { colorMap } from './colors';
+import { colorMap, colors } from './colors';
 
 export const BasePanelStyles = css`
     --panel-padding: 1.5rem;
@@ -14,4 +14,24 @@ export const BasePanelStyles = css`
 
 export const StyledBasePanel = styled.div`
     ${BasePanelStyles}
+`;
+export const StyledHeaderPanel = styled(StyledBasePanel)`
+    overflow: hidden;
+    padding: 0;
+    > .header {
+        padding: var(--panel-padding);
+        background: ${colorMap.secondaryBackground};
+        color: ${colors.grey_3};
+
+        h1,
+        h2,
+        h3,
+        h4 {
+            color: ${colorMap.primaryText};
+        }
+    }
+
+    > .content {
+        padding: var(--panel-padding);
+    }
 `;

--- a/frontend/src/styles/base-panel.styles.ts
+++ b/frontend/src/styles/base-panel.styles.ts
@@ -17,6 +17,7 @@ export const StyledBasePanel = styled.div`
 `;
 export const StyledHeaderPanel = styled(StyledBasePanel)`
     overflow: hidden;
+    flex-shrink: 0;
     padding: 0;
     > .header {
         padding: var(--panel-padding);
@@ -28,6 +29,10 @@ export const StyledHeaderPanel = styled(StyledBasePanel)`
         h3,
         h4 {
             color: ${colorMap.primaryText};
+        }
+
+        > *:last-child {
+            margin-bottom: 0;
         }
     }
 


### PR DESCRIPTION
# What

Added a new type of base panel called `HeaderPanel`. These panels are expected to have 2 divs within them with the class names `header` and `content` which allows them to be styled with a light grey header like so:

![image](https://github.com/playmint/ds/assets/51167118/fd4ad11e-d5af-4355-9921-4fa3d9741456)
![image](https://github.com/playmint/ds/assets/51167118/76b44c13-e44a-4a32-930a-d83179a5c507)
![image](https://github.com/playmint/ds/assets/51167118/253c4189-691f-4ac3-b340-e37ee3995024)
![image](https://github.com/playmint/ds/assets/51167118/202745c0-8c95-4b46-93f3-c1f3bf503721)

# Why

Of the panels that were in the Figma, most had the common theme of a light grey header. 
