### PR TITLE
Seeker selection and tile sharing updates

### DIFF
--- a/frontend/src/components/map/MobileUnit.tsx
+++ b/frontend/src/components/map/MobileUnit.tsx
@@ -197,17 +197,39 @@ export const MobileUnits = memo(
         const unitIcons = useMemo(
             () =>
                 units.map((u) => {
-                    if (u.isPlayer && unitPositions[u.id]?.isVisible) {
-                        const isSelected = selectedMobileUnitID === u.id;
-                        return (
-                            <Icon
-                                key={u.id}
-                                count={u.counter.count}
-                                iconMask={`url('/icons/UnitIcon.svg')`}
-                                position={unitPositions[u.id]}
-                                isSelected={isSelected}
-                            />
-                        );
+                    if (unitPositions[u.id]?.isVisible) {
+                        if (u.isPlayer) {
+                            const isSelected = selectedMobileUnitID === u.id;
+                            return (
+                                <Icon
+                                    key={u.id}
+                                    count={u.counter.count}
+                                    iconMask={`url('/icons/UnitIcon.svg')`}
+                                    position={unitPositions[u.id]}
+                                    isSelected={isSelected}
+                                />
+                            );
+                        } else if (
+                            u.counter.count > 1 &&
+                            !units.some(
+                                (unit) =>
+                                    unit.id !== u.id &&
+                                    unit.isPlayer &&
+                                    unit.coords.q === u.coords.q &&
+                                    unit.coords.r === u.coords.r &&
+                                    unit.coords.s === u.coords.s
+                            )
+                        ) {
+                            return (
+                                <Icon
+                                    key={u.id}
+                                    count={u.counter.count}
+                                    iconMask={`url('/icons/UnitIcon.svg')`}
+                                    position={unitPositions[u.id]}
+                                    isSelected={false}
+                                />
+                            );
+                        }
                     } else {
                         return null;
                     }

--- a/frontend/src/components/map/MobileUnit.tsx
+++ b/frontend/src/components/map/MobileUnit.tsx
@@ -229,6 +229,8 @@ export const MobileUnits = memo(
                                     isSelected={false}
                                 />
                             );
+                        } else {
+                            return null;
                         }
                     } else {
                         return null;

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -189,7 +189,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
             if (!selectMobileUnit || !selectTiles || !selectMapElement || !player) {
                 return;
             }
-            if (player.mobileUnits.find((u) => u.id === id) != null) {
+            if (world?.mobileUnits.find((u) => u.id === id)?.owner?.id === player.id) {
                 selectMobileUnit(id);
                 selectTiles(undefined);
             } else {

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -186,22 +186,24 @@ export const Shell: FunctionComponent<ShellProps> = () => {
 
     const mobileUnitClick = useCallback(
         (id) => {
-            if (!selectMobileUnit || !selectTiles || !selectMapElement) {
+            if (!selectMobileUnit || !selectTiles || !selectMapElement || !player) {
                 return;
             }
-
-            selectMobileUnit(id);
-
-            selectTiles(undefined);
+            if (player.mobileUnits.find((u) => u.id === id) != null) {
+                selectMobileUnit(id);
+                selectTiles(undefined);
+            } else {
+                const tileId = world?.mobileUnits.find((u) => u.id === id)?.nextLocation?.tile.id;
+                if (tileId) selectTiles([tileId]);
+            }
             selectMapElement(undefined);
         },
-        [selectMapElement, selectMobileUnit, selectTiles]
+        [world, player, selectMapElement, selectMobileUnit, selectTiles]
     );
 
     const deselectAll = useCallback(() => {
         mapElementClick();
-        mobileUnitClick(null);
-    }, [mobileUnitClick, mapElementClick]);
+    }, [mapElementClick]);
 
     const noop = useCallback(() => {}, []);
 


### PR DESCRIPTION
In this PR, the player can no longer deselect their Unit once it has been selected.
Clicking a non-player Unit will now select the tile beneath that Unit and thus show that Unit's inventory.
Multiple non-player Units sharing a tile will show a counter above their heads.