### PR TITLE
Drop combat reward on defeated tile

### DIFF
--- a/frontend/src/components/map/Bag.tsx
+++ b/frontend/src/components/map/Bag.tsx
@@ -75,7 +75,8 @@ export const Bags = memo(
                         (selectedMobileUnitID &&
                             tileSessions.flatMap((cs) => {
                                 return getBagsAtEquipee(world?.bags || [], cs).filter((bag) => {
-                                    if (!cs.attackTile || cs.attackTile.tile.id !== t.id) {
+                                    // TODO: We make the assumption that the defender was defeated as there are no rewards when attackers are defeated
+                                    if (!cs.defenceTile || cs.defenceTile.tile.id !== t.id) {
                                         return false;
                                     }
                                     // reward containing bags have an ID that is made up of 16bits of sessionID and 48bits of MobileUnitID


### PR DESCRIPTION
# What 

Combat rewards now appear on defence tile which is assumed to be the defeated tile. This works as there are no rewards when defenders win.

Why not make the checks to see which sides actually won? Currently requires calculating the combat state by decoding the annotated state and running through the combat logic. It's an unecessary overhead for a system that will be scrapped when we come to implement the full version of combat.

# Why

It didn't make sense that the reward bag appeared on the attack tile as it is supposed to be 'dropped' by the building/enemy that was defeated

solves: #743