### PR TITLE
Vault html links

### DIFF
--- a/contracts/src/fixtures/Creation/VaultOfKnowledge.js
+++ b/contracts/src/fixtures/Creation/VaultOfKnowledge.js
@@ -72,8 +72,10 @@ export default async function update({ selected, world, player }) {
 
 
     if (!squircleQuest) buttonList.push(creationQuestButton);
+    /*
     buttonList.push(docButton);
     buttonList.push(builderPageButton);
+    */
 
     return {
         version: 1,
@@ -85,7 +87,9 @@ export default async function update({ selected, world, player }) {
                     {
                         id: 'default',
                         type: 'inline',
-                        html: 'A wealth of information pertaining to the Details of Object Creation is accessible here',
+                        html: 'A wealth of information pertaining to the Details of Object Creation is accessible here.' + 
+                        '<br><a href="/docs/code-docs/extending-downstream" target="_blank" rel="noopener noreferrer">Docs</a>' + 
+                        '<br><a href="/docs/code-docs/extending-downstream" target="_blank" rel="noopener noreferrer">Building Creator</a>',
                         buttons: buttonList
                     }
                 ],

--- a/contracts/src/fixtures/quests/04b_ASquicleShapedHole.yaml
+++ b/contracts/src/fixtures/quests/04b_ASquicleShapedHole.yaml
@@ -2,13 +2,9 @@
 kind: Quest
 spec:
   name: A Squircle-Shaped Hole
-  description: "MORTON requests your craft a 'Squircle'. Use the Vault's knowledge to create a factory to craft one "
+  description: "MORTON requests you craft a 'Squircle'. Use the Vault's knowledge to create a factory that makes one "
   location: [-18, 2, 16]
   tasks:
-    - kind: message
-      name: "Open the Create a Building page"
-      message: createABuildingPage
-      buildingKind: Vault of Knowledge
     - kind: deployBuilding
       name: "Deploy a factory that crafts Squircles"
     - kind: inventory


### PR DESCRIPTION
- Removed the buttons to the docs, and am using HTML links instead. 
- Edited Squircle quest to not need the message sent by the Building button
- Note: Building Creator link currently goes to the docs - link can be swapped later