### PR TITLE
Item names must now be unique when registering an item.

### DIFF
--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -67,6 +67,7 @@ contract DownstreamGame is BaseGame {
         state.registerNodeType(Kind.BlockNum.selector, "BlockNum", CompoundKeyKind.UINT160);
         state.registerNodeType(Kind.Quest.selector, "Quest", CompoundKeyKind.UINT160);
         state.registerNodeType(Kind.Task.selector, "Task", CompoundKeyKind.UINT32_ARRAY);
+        state.registerNodeType(Kind.ID.selector, "ID", CompoundKeyKind.BYTES);
 
         // register the relationship ids we are using
         state.registerEdgeType(Rel.Owner.selector, "Owner", WeightKind.UINT64);
@@ -85,6 +86,7 @@ contract DownstreamGame is BaseGame {
         state.registerEdgeType(Rel.IsFinalised.selector, "IsFinalised", WeightKind.UINT64);
         state.registerEdgeType(Rel.HasQuest.selector, "HasQuest", WeightKind.UINT64);
         state.registerEdgeType(Rel.HasTask.selector, "HasTask", WeightKind.UINT64);
+        state.registerEdgeType(Rel.HasTask.selector, "ID", WeightKind.UINT64);
 
         // create a session router
         BaseRouter router = new DownstreamRouter();

--- a/contracts/src/rules/CraftingRule.sol
+++ b/contracts/src/rules/CraftingRule.sol
@@ -45,6 +45,14 @@ contract CraftingRule is Rule {
             revert("already registered");
         }
         state.setOwner(itemKind, player);
+
+        // Check the name is unique
+        bytes24 idNode = Node.ID(bytes20(keccak256(abi.encodePacked(name))));
+        if (state.getOwner(idNode) != 0x0) {
+            revert("item name already registered");
+        }
+        state.setID(itemKind, idNode);
+
         state.annotate(itemKind, "name", name);
         state.annotate(itemKind, "icon", icon);
     }

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -21,6 +21,7 @@ interface Rel {
     function IsFinalised() external;
     function HasTask() external;
     function HasQuest() external;
+    function ID() external;
 }
 
 interface Kind {
@@ -39,6 +40,7 @@ interface Kind {
     function BlockNum() external;
     function Quest() external;
     function Task() external;
+    function ID() external;
 }
 
 uint64 constant BLOCK_TIME_SECS = 2;
@@ -140,6 +142,10 @@ library Node {
 
     function Hash(bytes20 hash) internal pure returns (bytes24) {
         return CompoundKeyEncoder.BYTES(Kind.Hash.selector, hash);
+    }
+
+    function ID(bytes20 id) internal pure returns (bytes24) {
+        return CompoundKeyEncoder.BYTES(Kind.Hash.selector, id);
     }
 
     function RewardBag(bytes24 sessionID, bytes24 entityID) internal pure returns (bytes24) {
@@ -369,6 +375,15 @@ library Schema {
 
     function setHash(State state, bytes20 hash, bytes24 node, uint8 edgeIndex) internal {
         state.set(Rel.Has.selector, edgeIndex, node, Node.Hash(hash), 0);
+    }
+
+    function getID(State state, bytes24 node) internal view returns (bytes24 id) {
+        (id,) = state.get(Rel.ID.selector, 0, node);
+    }
+
+    function setID(State state, bytes24 node, bytes24 idNode) internal {
+        state.set(Rel.ID.selector, 0, node, idNode, 0);
+        state.setOwner(idNode, node);
     }
 
     function setInput(State state, bytes24 kind, uint8 slot, bytes24 item, uint64 qty) internal {

--- a/contracts/test/rules/CraftingRule.t.sol
+++ b/contracts/test/rules/CraftingRule.t.sol
@@ -46,8 +46,8 @@ contract CraftingRuleTest is Test, GameTest {
 
     function testGetAtoms() public {
         uint32[3] memory thingAtoms = [uint32(2), uint32(4), uint32(6)];
-        bytes24 thingItem = Node.Item("thing", thingAtoms, ITEM_STACKABLE);
-        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (thingItem, "thing", "icon")));
+        bytes24 thingItem = Node.Item("thing1", thingAtoms, ITEM_STACKABLE);
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (thingItem, "thing1", "icon")));
         uint32[3] memory gotAtoms = state.getAtoms(thingItem);
 
         assertEq(gotAtoms[0], thingAtoms[0], "expected getAtoms()[0] to return same atoms we put in");
@@ -66,7 +66,7 @@ contract CraftingRuleTest is Test, GameTest {
             /*uint64 outputQty*/
         ) = _getCraftRecipe();
 
-        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (outputItem, "thing", "icon")));
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (outputItem, "thing2", "icon")));
         vm.stopPrank();
 
         bytes24 registeredItem;
@@ -273,7 +273,7 @@ contract CraftingRuleTest is Test, GameTest {
             uint64 outputQty
         ) = _getCraftRecipe();
 
-        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (outputItem, "thing", "icon")));
+        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (outputItem, "thing3", "icon")));
 
         dispatcher.dispatch(
             abi.encodeCall(


### PR DESCRIPTION
# What

Item names must now be unique when registering an item. Item node IDs are formed from the item's name AND composition which meant it was possible to register two items with the same name providing they had a different composition (this was actually a feature, not a bug!). To enforce unique names across items we now attach an ID node to an item whose owner is the item node. This allows us to check if any given ID is already 'owned' by a node.

# Why not make the Item node IDs the name / hash of the name?

Because we use the Item node ID as a static store of data i.e. we decode the ID to find out the atom values of a item. If we were to change what constitutes an item ID we'd need to store the item's composition as nodes and refactor a fair amount of code which I believe is a significant risk.

# Why

We treat name annotations as if they are unique but this is not currently enforced on the contract side which causes problems when you do manage to hit a conflict

# How to test

Register a Squircle with a different composition from the one deployed as part of the fixtures:

```
---
kind: Item
spec:
  name: Squircle
  icon: 31-286
  contract:
    file: ./Squircle.sol
  goo:
    red: 11
    green: 10
    blue: 10
  stackable: true
```

Expect:

```
1 manifests failed to apply:

file: squircle.yaml
error:Error: failed commit batch tx: execution reverted: item name already registered

```