### PR TITLE
burner wallets and misc wallet fixes

### DIFF
--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -2,5 +2,10 @@
     "gameID": "DOWNSTREAM",
     "build": "dev",
     "wsEndpoint": "ws://localhost:8080/query",
-    "httpEndpoint": "http://localhost:8080/query"
+    "httpEndpoint": "http://localhost:8080/query",
+    "wallets": {
+        "metamask": true,
+        "walletconnect": true,
+        "burner": true
+    }
 }

--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -55,7 +55,7 @@ const NavLink = styled.div`
 `;
 
 export const NavPanel = () => {
-    const { connect } = useWalletProvider();
+    const { connect, disconnect: forgetProvider } = useWalletProvider();
     const { clearSession } = useSession();
     const { wallet } = useWallet();
     const player = usePlayer();
@@ -71,12 +71,14 @@ export const NavPanel = () => {
     }, []);
 
     const disconnect = useCallback(() => {
-        if (!clearSession) {
-            return;
+        if (clearSession) {
+            clearSession();
         }
-        clearSession();
+        if (forgetProvider) {
+            forgetProvider();
+        }
         window.location.reload();
-    }, [clearSession]);
+    }, [clearSession, forgetProvider]);
 
     const canvasHeight = g.__globalUnityContext?.getCanvasHeight ? g.__globalUnityContext.getCanvasHeight() : -1;
     const onChangeQuality = useCallback((e) => {

--- a/frontend/src/hooks/use-config.tsx
+++ b/frontend/src/hooks/use-config.tsx
@@ -1,10 +1,17 @@
 import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 
+export interface WalletConfig {
+    burner?: boolean;
+    walletconnect?: boolean;
+    metamask?: boolean;
+}
+
 export interface ConfigFile {
     gameID: string;
     build: string;
     wsEndpoint: string;
     httpEndpoint: string;
+    wallets?: WalletConfig;
 }
 
 export interface ConfigContextValue extends ConfigFile {

--- a/frontend/src/hooks/use-localstorage.tsx
+++ b/frontend/src/hooks/use-localstorage.tsx
@@ -1,94 +1,21 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { useEventCallback } from './use-event-callback';
-import { useEventListener } from './use-event-listener';
-
-declare global {
-    interface WindowEventMap {
-        'local-storage': CustomEvent;
-    }
-}
-
-type SetValue<T> = Dispatch<SetStateAction<T>>;
-
-export function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
-    // Get from local storage then
-    // parse stored json or return initialValue
-    const readValue = useCallback((): T => {
-        // Prevent build error "window is undefined" but keeps working
-        if (typeof window === 'undefined') {
-            return initialValue;
-        }
+export function useLocalStorage<T>(key: string, defaultValue: T): [T, (v: T) => void] {
+    const [value, setValue] = useState<T>(() => {
+        let currentValue: T;
 
         try {
-            const item = window.localStorage.getItem(key);
-            return item ? (parseJSON(item) as T) : initialValue;
+            currentValue = JSON.parse(localStorage.getItem(key) || `"${defaultValue}"`);
         } catch (error) {
-            console.warn(`Error reading localStorage key “${key}”:`, error);
-            return initialValue;
-        }
-    }, [initialValue, key]);
-
-    // State to store our value
-    // Pass initial state function to useState so logic is only executed once
-    const [storedValue, setStoredValue] = useState<T>(readValue);
-
-    // Return a wrapped version of useState's setter function that ...
-    // ... persists the new value to localStorage.
-    const setValue: SetValue<T> = useEventCallback((value) => {
-        // Prevent build error "window is undefined" but keeps working
-        if (typeof window === 'undefined') {
-            console.warn(`Tried setting localStorage key “${key}” even though environment is not a client`);
+            currentValue = defaultValue;
         }
 
-        try {
-            // Allow value to be a function so we have the same API as useState
-            const newValue = value instanceof Function ? value(storedValue) : value;
-
-            // Save to local storage
-            window.localStorage.setItem(key, JSON.stringify(newValue));
-
-            // Save state
-            setStoredValue(newValue);
-
-            // We dispatch a custom event so every useLocalStorage hook are notified
-            window.dispatchEvent(new Event('local-storage'));
-        } catch (error) {
-            console.warn(`Error setting localStorage key “${key}”:`, error);
-        }
+        return currentValue;
     });
 
     useEffect(() => {
-        setStoredValue(readValue());
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        localStorage.setItem(key, JSON.stringify(value));
+    }, [value, key]);
 
-    const handleStorageChange = useCallback(
-        (event: StorageEvent | CustomEvent) => {
-            if ((event as StorageEvent)?.key && (event as StorageEvent).key !== key) {
-                return;
-            }
-            setStoredValue(readValue());
-        },
-        [key, readValue]
-    );
-
-    // this only works for other documents, not the current one
-    useEventListener('storage', handleStorageChange);
-
-    // this is a custom event, triggered in writeValueToLocalStorage
-    // See: useLocalStorage()
-    useEventListener('local-storage', handleStorageChange);
-
-    return [storedValue, setValue];
-}
-
-// A wrapper for "JSON.parse()"" to support "undefined" value
-function parseJSON<T>(value: string | null): T | undefined {
-    try {
-        return value === 'undefined' ? undefined : JSON.parse(value ?? '');
-    } catch {
-        console.log('parsing error on', { value });
-        return undefined;
-    }
+    return [value, setValue];
 }

--- a/frontend/src/pages/building-fabricator.tsx
+++ b/frontend/src/pages/building-fabricator.tsx
@@ -1501,7 +1501,7 @@ export default function ShellPage() {
 
     return (
         <UnityMapProvider showLoading={false} display="none">
-            <WalletProviderProvider>
+            <WalletProviderProvider wallets={config?.wallets || {}}>
                 <GameStateProvider config={config}>
                     <SessionProvider>
                         <InventoryProvider>

--- a/frontend/src/pages/docs/[[...slug]].tsx
+++ b/frontend/src/pages/docs/[[...slug]].tsx
@@ -196,7 +196,7 @@ export default function Page({ doc, tree }: InferGetStaticPropsType<typeof getSt
         return <ErrorPage statusCode={404} />;
     }
     return (
-        <WalletProviderProvider>
+        <WalletProviderProvider wallets={config?.wallets || {}}>
             <GameStateProvider config={config}>
                 <SessionProvider>
                     <div className="nav-container">

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,7 +12,7 @@ export default function ShellPage() {
 
     return (
         <UnityMapProvider>
-            <WalletProviderProvider>
+            <WalletProviderProvider wallets={config?.wallets || {}}>
                 <GameStateProvider config={config}>
                     <SessionProvider>
                         <InventoryProvider>


### PR DESCRIPTION
### what

* allow enabling ephemeral "burner" wallets by setting `{wallets: {burner: true}}` in the frontend config.json
* burner key stored in localstorage so will persist past refresh, but destroyed on "disconnect"
* fix localstorage sessions getting wiped out too frequently
* only ever do session loading once
* make the QR render for wallet connect bigger, brighter, and remove the excavated image

### related

* resolves: #752 
* resolves: #766 (hopefully... please test since it always works on my phone)
* resolves: #800 