### PR TITLE
allow target=_blank links in plugin html

### DIFF
--- a/contracts/src/fixtures/Creation/VaultOfKnowledge.js
+++ b/contracts/src/fixtures/Creation/VaultOfKnowledge.js
@@ -17,7 +17,7 @@ export default async function update({ selected, world, player }) {
         );
         return questNum + 1;
     };
-    
+
     const acceptQuest = (questId) => {
         const questNum = getNextQuestNum();
         ds.dispatch({
@@ -26,28 +26,9 @@ export default async function update({ selected, world, player }) {
         });
     };
 
-    const openDocs = () => {
-        ds.sendQuestMessage("readTheDoc");
-        window.open("https://www.playmint.com"); 
-    }
-
     const openBuildingCreator = () => {
         ds.sendQuestMessage("createABuildingPage");
     }
-
-    var docButton = {
-        text: "Read the D.O.C.s",
-        type: "action",
-        action: openDocs,
-        disabled: false
-    };
-
-    var builderPageButton = { 
-        text: 'Create a Building', 
-        type: 'action', 
-        action: openBuildingCreator, 
-        disabled: false 
-    }; 
 
     var creationQuestButton = {
         text: "Accept Creation Quest",
@@ -66,14 +47,14 @@ export default async function update({ selected, world, player }) {
     const findQuestByName = (questName) => {
         return quests.find((q) => q.node.name.value == questName);
     };
-    
+
     const QUEST_NAME = "A Squircle-Shaped Hole"
     const squircleQuest = findQuestByName(QUEST_NAME);
 
 
-    if (!squircleQuest) buttonList.push(creationQuestButton);
-    buttonList.push(docButton);
-    buttonList.push(builderPageButton);
+    if (!squircleQuest) {
+        buttonList.push(creationQuestButton);
+    }
 
     return {
         version: 1,
@@ -85,7 +66,12 @@ export default async function update({ selected, world, player }) {
                     {
                         id: 'default',
                         type: 'inline',
-                        html: 'A wealth of information pertaining to the Details of Object Creation is accessible here',
+                        html: `
+                            A wealth of information pertaining
+                            to the Details of Object Creation is accessible in the
+                            <a href="/docs/how-to-create-docs">D.O.C.S</a>
+                            and tools like the <a href="/building-fabricator">Building Configurator</a>
+                        `,
                         buttons: buttonList
                     }
                 ],

--- a/frontend/src/components/organisms/tile-action/index.tsx
+++ b/frontend/src/components/organisms/tile-action/index.tsx
@@ -3,6 +3,7 @@
 import { ActionButton } from '@app/styles/button.styles';
 import { PluginStateButtonAction, PluginStateComponentContent, PluginSubmitCallValues } from '@downstream/core';
 import DOMPurify from 'dompurify';
+import { useEffect } from 'react';
 import styled, { css } from 'styled-components';
 
 const StylePluginContent = styled.div`
@@ -19,6 +20,22 @@ const StylePluginContent = styled.div`
     }
 `;
 
+// initialize DOMPurify only once
+export const initDOMPurify = () => {
+    const DP: any = DOMPurify;
+    if (DP.inited) {
+        return;
+    }
+    // force all links to open in new window with "noopener"
+    DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+        if ('target' in node) {
+            node.setAttribute('target', '_blank');
+            node.setAttribute('rel', 'noopener');
+        }
+    });
+    DP.inited = true;
+};
+
 export const PluginContent = ({
     content,
     canUse,
@@ -28,6 +45,10 @@ export const PluginContent = ({
     canUse: boolean;
     children?: any;
 }) => {
+    useEffect(() => {
+        initDOMPurify();
+    }, []);
+
     const saferHTML = { __html: content.html ? DOMPurify.sanitize(content.html) : '' };
 
     const submit = (e: React.FormEvent<HTMLFormElement>) => {

--- a/frontend/src/components/organisms/tile-action/index.tsx
+++ b/frontend/src/components/organisms/tile-action/index.tsx
@@ -18,6 +18,10 @@ const StylePluginContent = styled.div`
         margin-top: 1rem;
         width: 100%;
     }
+    a {
+        color: rgb(251, 112, 1);
+        font-weight: 800;
+    }
 `;
 
 // initialize DOMPurify only once


### PR DESCRIPTION
### what

* allow anchor tags in plugins to open links with target=_blank
* make plugin links bold and orange by default
* add links in vault of knowledge as example

### info

currently `target="_blank"` links are stripped from plugin HTML (since they are a security risk giving access to window.opener)

this forces all `<a>` and `<form>` elements in plugin html content to have `rel="noopener"` to somewhat mitigate the risk of opening another window and allow plugins to link to external content.