### PR TITLE
Fixed custom building ignoring color

### DIFF
--- a/cli/src/utils/applier.ts
+++ b/cli/src/utils/applier.ts
@@ -179,8 +179,6 @@ const buildingKindDeploymentActions = async (
             throw new Error('crafting recipe must specify at least 1 input');
         }
 
-        model = `${model}-${spec.color || 0}`;
-
         const input = encodeSlotConfig(spec.inputs || []);
         inputItems = input.items;
         inputQtys = input.quantities;
@@ -188,6 +186,11 @@ const buildingKindDeploymentActions = async (
         const output = encodeSlotConfig(spec.outputs || []);
         outputItems = output.items.slice(0, 1);
         outputQtys = output.quantities.slice(0, 1);
+    }
+
+    if(spec.category == 'factory' || spec.category == 'custom')
+    {
+        model = `${model}-${spec.color || 0}`;
     }
 
     if (spec.category == 'extractor') {

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -107,6 +107,7 @@ export const BuildingKindCustomSpec = z.object({
     name: Name,
     description: OneLiner.optional(),
     model: TotemModel,
+    color: z.number().min(0).max(5).optional(),
     contract: ContractSource.optional(),
     plugin: PluginSource.optional(),
     materials: Slot.array().nonempty().max(4),


### PR DESCRIPTION
'Custom' type buildings like the Control Tower were not using the new color variable, which had only been set up for factories. This PR adds the functionality to control custom building colors as well as factory building colors