### PR TITLE
show time remaining for combat

### DIFF
--- a/frontend/src/plugins/combat/combat-modal/index.tsx
+++ b/frontend/src/plugins/combat/combat-modal/index.tsx
@@ -110,6 +110,9 @@ const CombatState: FunctionComponent<CombatStateProps> = (props) => {
         tickCount,
     } = props;
 
+    const secondsRemaining = (MAX_TICKS - tickCount) * 2;
+    const timeRemaining = new Date(secondsRemaining * 1000).toISOString().slice(11, 19);
+
     return (
         <StyledCombatModal>
             <div className="header">
@@ -125,7 +128,11 @@ const CombatState: FunctionComponent<CombatStateProps> = (props) => {
             </div>
             <div className="footer">
                 <TickTimerProgressBar className="in-progress" every={2000} />
-                <ProgressBar maxValue={MAX_TICKS} currentValue={MAX_TICKS - tickCount} />
+                <ProgressBar
+                    maxValue={MAX_TICKS}
+                    currentValue={MAX_TICKS - tickCount}
+                    label={`TIME REMAINING ${timeRemaining}`}
+                />
             </div>
         </StyledCombatModal>
     );

--- a/frontend/src/plugins/combat/progress-bar/index.tsx
+++ b/frontend/src/plugins/combat/progress-bar/index.tsx
@@ -8,19 +8,23 @@ import { styles } from './progress-bar.styles';
 export interface ProgressBarProps extends ComponentProps {
     maxValue: number;
     currentValue: number;
+    label?: string;
 }
 
 const StyledProgressBar = styled.div`
     ${styles}
 `;
 
-export const ProgressBar: FunctionComponent<ProgressBarProps> = ({ maxValue, currentValue }: ProgressBarProps) => {
+export const ProgressBar: FunctionComponent<ProgressBarProps> = ({
+    maxValue,
+    currentValue,
+    label,
+}: ProgressBarProps) => {
+    const displayLabel = label ? label : `${currentValue}/${maxValue}`;
     return (
         <StyledProgressBar maxValue={maxValue} currentValue={currentValue}>
             <div className="progress-bar"></div>
-            <span className="label">
-                {currentValue}/{maxValue}
-            </span>
+            <span className="label">{displayLabel}</span>
         </StyledProgressBar>
     );
 };


### PR DESCRIPTION
Show "TIME REMAINING" estimate instead of the meaningless X/Y ticks value in combat modal timer.

![Screenshot 2023-10-31 at 16 33 00](https://github.com/playmint/ds/assets/45921/be9ad287-e378-4658-9bba-e2a09e48ba7e)

resolves: #675 
