### PR TITLE
squishing the HUD to better support tiny screens

### DIFF
--- a/frontend/src/components/organisms/onboarding/index.tsx
+++ b/frontend/src/components/organisms/onboarding/index.tsx
@@ -11,6 +11,7 @@ export interface OnboardingProps {
 }
 
 const StyledOnboarding = styled(StyledHeaderPanel)`
+    width: 40rem;
     h3 {
         margin: 0;
     }

--- a/frontend/src/components/panels/item-plugin-panel.tsx
+++ b/frontend/src/components/panels/item-plugin-panel.tsx
@@ -5,6 +5,7 @@ import { BasePanelStyles } from '@app/styles/base-panel.styles';
 
 const StyledItemPluginPanel = styled.div`
     ${BasePanelStyles}
+    width: 26rem;
 `;
 
 export const ItemPluginPanel = ({ ui }: { ui: PluginUpdateResponse[] }) => {

--- a/frontend/src/components/panels/mobile-unit-panel.tsx
+++ b/frontend/src/components/panels/mobile-unit-panel.tsx
@@ -60,7 +60,10 @@ const MobileUnitIcon = ({ className, onClick }) => {
 };
 
 const StyledMobileUnitPanel = styled(StyledHeaderPanel)`
-    margin-top: 3.5rem;
+    margin-top: 1rem;
+    .header {
+        padding: 1rem 1.5rem 1rem 1rem;
+    }
 
     .bags > div:last-child .slots {
         margin-bottom: 0;
@@ -69,8 +72,7 @@ const StyledMobileUnitPanel = styled(StyledHeaderPanel)`
 
 const MobileUnitContainer = styled.div`
     overflow: visible;
-    min-height: 5rem;
-    margin-top: 3rem;
+    margin-top: 0rem;
 
     position: relative;
 
@@ -79,25 +81,37 @@ const MobileUnitContainer = styled.div`
     > .unitIcon {
         position: absolute;
         cursor: pointer;
-        left: 0rem;
-        top: -8.2rem;
+        left: 1rem;
+        top: -3.75rem;
     }
 
     > .label {
+        text-align: right;
         color: ${colorMap.primaryText};
-        font-size: 2.8rem;
+        font-size: 2.3rem;
         display: block;
         width: 100%;
-
-        overflow: hidden;
         font-weight: 800;
+        position: relative;
 
-        > .hashTag {
+        > .name {
+            position: relative;
+            display: block;
+            width: 15rem;
+            left: 8rem;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .hashTag {
             color: ${colors.orange_0};
         }
     }
 
     > .location {
+        font-size: 1.25rem;
+        text-align: right;
         color: ${colors.grey_3};
     }
 `;
@@ -198,8 +212,10 @@ export const MobileUnitPanel = () => {
                             <MobileUnitContainer>
                                 <MobileUnitIcon className="unitIcon" onClick={selectAndFocusMobileUnit} />
                                 <span className="label" onDoubleClick={() => nameEntity(selectedMobileUnit?.id)}>
-                                    <span className="hashTag">#</span>
-                                    {formatNameOrId(selectedMobileUnit, 'unit')}
+                                    <span className="name">
+                                        <span className="hashTag">#</span>
+                                        {formatNameOrId(selectedMobileUnit, 'unit')}
+                                    </span>
                                 </span>
                                 {selectedMobileUnit.nextLocation?.tile && (
                                     <div className="location">

--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -5,8 +5,6 @@ import { useWalletProvider } from '@app/hooks/use-wallet-provider';
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { Dialog } from '../molecules/dialog';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { GlobalUnityContext } from '@app/hooks/use-unity-instance';
 import { ActionButton } from '@app/styles/button.styles';
 
@@ -17,10 +15,11 @@ const AccountButton = styled.button`
     justify-content: flex-end;
     align-items: center;
     border: 0;
-    border-left: 1px solid #314a7b;
     background: #050f25;
     color: #fff;
-    padding: 0 2rem 0 1rem;
+    padding: 0 1rem;
+    margin: 0;
+    border-radius: 1rem;
 
     > img {
         margin-right: 0.3rem;
@@ -38,20 +37,9 @@ const NavContainer = styled.div`
     display: flex;
     justify-content: flex-start;
     height: 5rem;
-    background: #030f25;
     user-select: none;
-    zoom: 90%;
-`;
-
-const NavLink = styled.div`
-    padding: 1.4rem;
-    &.active {
-        background: #335c90;
-    }
-    a {
-        color: white;
-        text-decoration: none;
-    }
+    margin-bottom: 1.5rem;
+    pointer-events: all;
 `;
 
 export const NavPanel = () => {
@@ -60,7 +48,9 @@ export const NavPanel = () => {
     const { wallet } = useWallet();
     const player = usePlayer();
     const [showAccountDialog, setShowAccountDialog] = useState(false);
-    const router = useRouter();
+
+    const hasConnection = player || wallet;
+    const address = player?.addr || wallet?.address || '';
 
     const closeAccountDialog = useCallback(() => {
         setShowAccountDialog(false);
@@ -93,12 +83,12 @@ export const NavPanel = () => {
 
     return (
         <NavContainer>
-            {showAccountDialog && wallet && (
+            {showAccountDialog && hasConnection && (
                 <Dialog onClose={closeAccountDialog} width="304px" height="">
                     <div style={{ padding: 15 }}>
                         <h3>PLAYER ACCOUNT</h3>
                         <p>
-                            0x{wallet.address.slice(0, 9)}...{wallet.address.slice(-9)}
+                            0x{address.slice(0, 9)}...{address.slice(-9)}
                         </p>
                         <br />
                         <fieldset>
@@ -121,19 +111,10 @@ export const NavPanel = () => {
                     </div>
                 </Dialog>
             )}
-            <AccountButton onClick={wallet ? openAccountDialog : connect}>
+            <AccountButton onClick={player ? openAccountDialog : connect}>
                 <img src="/icons/player.png" alt="" />
-                <span className="text">
-                    {!wallet ? 'connect' : !player ? 'connecting' : formatNameOrId(player, 'Player 0x..')}
-                </span>
+                <span className="text">{player ? formatNameOrId(player, 'Player 0x..') : 'connect'}</span>
             </AccountButton>
-            <div style={{ flexGrow: 1 }}></div>
-            <NavLink className={router.pathname == '/' ? 'active' : ''}>
-                <Link href={`/`}>Map</Link>
-            </NavLink>
-            <NavLink className={router.pathname.startsWith('/docs') ? 'active' : ''}>
-                <Link href={`/docs/code-docs/extending-downstream`}>Docs</Link>
-            </NavLink>
         </NavContainer>
     );
 };

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -19,7 +19,7 @@ import { colorMap, colors } from '@app/styles/colors';
 // NOTE: QuestPanel is a misnomer as it is no longer a panel but just a container. Each of the quest items are panels in their own right
 const StyledQuestPanel = styled.div`
     width: 43.5rem;
-    position: absolute;
+    position: relative;
 `;
 
 const CompleteQuestButton = styled(ActionButton)`
@@ -84,7 +84,7 @@ const FocusButton: FunctionComponent<{
 
 const QuestItemStyles = ({ expanded }: { expanded: boolean }) => css`
     position: relative;
-    padding: ${expanded ? 0 : `var(--panel-padding)`};
+    padding: ${expanded ? 0 : `1rem`};
     overflow: hidden;
     margin-bottom: 0.5rem;
 
@@ -104,11 +104,13 @@ const QuestItemStyles = ({ expanded }: { expanded: boolean }) => css`
         padding: var(--panel-padding);
 
         p {
+            font-size: 1.3rem;
             color: ${colors.grey_3};
         }
     }
 
     .taskContainer {
+        font-size: 1.4rem;
         padding: var(--panel-padding) var(--panel-padding) 0 var(--panel-padding);
     }
 
@@ -170,7 +172,7 @@ export const QuestItem: FunctionComponent<{
             {expanded ? (
                 <>
                     <div className="header">
-                        <h2>{quest.node.name?.value}</h2>
+                        <h3>{quest.node.name?.value}</h3>
                         {quest.node.location && (
                             <FocusButton location={quest.node.location} setFocusLocation={setFocusLocation} />
                         )}
@@ -202,7 +204,7 @@ export const QuestItem: FunctionComponent<{
                     )}
                 </>
             ) : (
-                <h3>{quest.node.name?.value}</h3>
+                <h4>{quest.node.name?.value}</h4>
             )}
         </StyledQuestItem>
     );

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -20,6 +20,9 @@ import { colorMap, colors } from '@app/styles/colors';
 const StyledQuestPanel = styled.div`
     width: 43.5rem;
     position: relative;
+    overflow-y: auto;
+    max-height: calc(100vh - 35rem);
+    pointer-events: all;
 `;
 
 const CompleteQuestButton = styled(ActionButton)`
@@ -261,7 +264,7 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({ world, tiles, p
     return (
         <>
             {acceptedQuests.length > 0 && (
-                <StyledQuestPanel>
+                <StyledQuestPanel className="no-scrollbars">
                     {acceptedQuests.map((quest, questIdx) => (
                         <QuestItem
                             tiles={tiles}

--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -92,7 +92,7 @@ const StyledTileInfoPanel = styled(StyledHeaderPanel)`
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        gap: 1.2rem;
+        gap: 0.5rem;
 
         .ingredients {
             margin: 0 auto;
@@ -101,9 +101,9 @@ const StyledTileInfoPanel = styled(StyledHeaderPanel)`
 
     > .content > .label {
         width: 12rem;
-        height: 1.7rem;
+        line-height: 1rem;
         white-space: nowrap;
-        font-size: 1.4rem;
+        font-size: 1.2rem;
         overflow: hidden;
         text-overflow: ellipsis;
         display: inline-block;

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -67,8 +67,8 @@ export const Shell: FunctionComponent<ShellProps> = () => {
         setContainerStyle({
             position: 'fixed',
             display: 'block',
-            width: '100vw',
-            height: '100vh',
+            width: '100%',
+            height: '100%',
             top: 0,
             left: 0,
             bottom: 0,
@@ -258,20 +258,23 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                     <CombatSessions tiles={tiles || []} sessions={world?.sessions || []} />
                 </>
             )}
-            <NavPanel />
             <div className="hud-container">
-                <div className="top-left">
-                    {world && player && <QuestPanel world={world} tiles={tiles || []} player={player} />}
-                    {/* <Logs className="logs" /> */}
-                </div>
-                <div className="bottom-left">
+                <div className="left">
+                    <div className="top-left">
+                        <NavPanel />
+                        {world && player && <QuestPanel world={world} tiles={tiles || []} player={player} />}
+                        {/* <Logs className="logs" /> */}
+                    </div>
                     <ItemPluginPanel ui={ui || []} />
-                    <MobileUnitPanel />
-                </div>
-                <div className="top-middle"></div>
-                <div className="bottom-middle">
-                    <ActionContextPanel />
-                    <ActionBar />
+                    <div className="bottom-left">
+                        <MobileUnitPanel />
+                        <div className="flex-spacer"></div>
+                        <div className="bottom-middle">
+                            <ActionContextPanel />
+                            <ActionBar />
+                        </div>
+                        <div className="flex-spacer"></div>
+                    </div>
                 </div>
                 <div className="right">
                     {(!player || (player && playerUnits.length === 0)) && mapReady && connect && !loadingSession && (

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -276,7 +276,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                         <div className="flex-spacer"></div>
                     </div>
                 </div>
-                <div className="right">
+                <div className="right no-scrollbars">
                     {(!player || (player && playerUnits.length === 0)) && mapReady && connect && !loadingSession && (
                         <Onboarding player={player} playerUnits={playerUnits} onClickConnect={connect} />
                     )}

--- a/frontend/src/components/views/shell/shell.styles.ts
+++ b/frontend/src/components/views/shell/shell.styles.ts
@@ -10,7 +10,10 @@ import { ShellProps } from './index';
  * @return Base styles for the shell component
  */
 const baseStyles = (_: Partial<ShellProps>) => css`
-    min-height: 100vh;
+    position: relative;
+    overflow: hidden;
+    height: 100%;
+    width: 100%;
     margin: 0;
     display: flex;
     flex-direction: column;
@@ -24,64 +27,85 @@ const baseStyles = (_: Partial<ShellProps>) => css`
     }
 
     > .hud-container {
+        display: flex;
+        flex-direction: row;
         position: relative;
-        max-height: calc(100vh - 5rem);
+        max-height: 100vh;
         z-index: 10;
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
-        grid-template-rows: 1fr 1fr;
         gap: 0 0;
-        grid-auto-flow: row;
-        grid-template-areas:
-            'top-left top-middle right'
-            'bottom-left bottom-middle right';
         flex-grow: 1;
         pointer-events: none;
+        justify-content: space-between;
 
-        .top-left,
-        .bottom-left,
-        .top-middle,
-        .bottom-middle,
+        .flex-spacer {
+            flex-grow: 1;
+        }
+
+        .left {
+            display: flex;
+            flex-direction: column;
+            padding: 2rem 0 2rem 2rem;
+            min-width: 40rem;
+            justify-content: space-between;
+            flex-grow: 1;
+
+            .top-left {
+                display: flex;
+                flex-direction: column;
+                justify-content: flex-start;
+            }
+
+            .bottom-left {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-between;
+                height: 24rem;
+                align-items: end;
+                gap: 1rem;
+
+                .bottom-middle {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: flex-end;
+                    flex-grow: 1;
+                    max-width: 50rem;
+                }
+            }
+        }
+
         .right {
             display: flex;
             flex-direction: column;
-            padding: 2.4rem;
-
-            > * {
-                pointer-events: all;
-            }
-        }
-
-        .top-left {
-            grid-area: top-left;
-
-            .logs {
-                pointer-events: none;
-            }
-        }
-
-        .bottom-left {
-            grid-area: bottom-left;
-            align-items: flex-start;
-            justify-content: flex-end;
-        }
-
-        .top-middle {
-            grid-area: top-middle;
-            align-items: center;
+            padding: 2rem 2rem 2rem 0;
+            min-width: 32rem;
             justify-content: flex-start;
-        }
 
-        .bottom-middle {
-            grid-area: bottom-middle;
-            align-items: center;
-            justify-content: flex-end;
-        }
-
-        .right {
-            grid-area: right;
             align-items: flex-end;
-            justify-content: flex-start;
+            overflow-y: auto;
+            position: relative;
+
+            /* START HACK TO GRACEFULLY OVERFLOW SIDEBAR */
+            --scrollbar-width: 8px;
+            --mask-height: 3rem;
+            overflow-y: auto;
+            height: 100%;
+            padding-bottom: var(--mask-height);
+            padding-right: 20px;
+            --mask-image-content: linear-gradient(
+                to bottom,
+                transparent,
+                black var(--mask-height),
+                black calc(100% - var(--mask-height)),
+                transparent
+            );
+            --mask-size-content: calc(100% - var(--scrollbar-width)) 100%;
+            --mask-image-scrollbar: linear-gradient(black, black);
+            --mask-size-scrollbar: var(--scrollbar-width) 100%;
+            mask-image: var(--mask-image-content), var(--mask-image-scrollbar);
+            mask-size: var(--mask-size-content), var(--mask-size-scrollbar);
+            mask-position: 0 0, 100% 0;
+            mask-repeat: no-repeat, no-repeat;
+            /* END HACK TO GRACEFULLY OVERFLOW SIDEBAR */
         }
     }
 `;

--- a/frontend/src/plugins/action-bar/action-bar.styles.ts
+++ b/frontend/src/plugins/action-bar/action-bar.styles.ts
@@ -11,8 +11,7 @@ import { colors } from '@app/styles/colors';
  * @return Base styles for the action bar component
  */
 const baseStyles = (_: Partial<ActionBarProps>) => css`
-    margin-bottom: 1.5rem;
-
+    pointer-events: all;
     h3 {
         margin-bottom: 0;
     }

--- a/frontend/src/plugins/action-context-panel/action-context-panel.styles.ts
+++ b/frontend/src/plugins/action-context-panel/action-context-panel.styles.ts
@@ -16,7 +16,7 @@ const baseStyles = (_: Partial<ActionContextPanelProps>) => css`
     display: flex;
     align-items: center;
     margin-bottom: 1.5rem;
-    width: 33vw;
+    max-width: 50rem;
 
     .guide {
         width: 50%;

--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -436,14 +436,14 @@ const Construct: FunctionComponent<ConstructProps> = ({
                                     onChange={() => setShowOnlyConstructable((prev) => !prev)}
                                 />
                                 <abbr title="Only show building kinds that can be constructed from materials in this unit's inventory">
-                                    Hide unconstructable
+                                    Constructable
                                 </abbr>
                             </label>
                         </div>
                     </>
                 )}
                 <ActionButton type="submit" disabled={!canConstruct}>
-                    Confirm Construction
+                    Confirm
                 </ActionButton>
                 <button onClick={clearIntent} className="cancel">
                     <i className="bi bi-x" />
@@ -574,7 +574,7 @@ const Move: FunctionComponent<MoveProps> = ({
             </div>
             <form>
                 <ActionButton type="button" onClick={move} disabled={!canMove} style={{ opacity: canMove ? 1 : 0.1 }}>
-                    Confirm Move
+                    Confirm
                 </ActionButton>
                 <button onClick={clearIntent} className="cancel">
                     <i className="bi bi-x" />
@@ -790,7 +790,7 @@ const Combat: FunctionComponent<CombatProps> = ({
             </div>
             <form>
                 <ActionButton type="button" onClick={handleJoinCombat} disabled={!canAttack}>
-                    {joining ? 'Join' : 'Confirm'} Attack
+                    {joining ? 'Join' : 'Confirm'}
                 </ActionButton>
                 <ActionButton onClick={clearIntent} className="cancel">
                     <i className="bi bi-x" />

--- a/frontend/src/plugins/combat/progress-bar/progress-bar.styles.ts
+++ b/frontend/src/plugins/combat/progress-bar/progress-bar.styles.ts
@@ -17,12 +17,12 @@ const baseStyles = ({ maxValue = 1, currentValue = 0 }: Pick<ProgressBarProps, '
         width: 100%;
         background: ${colors.grey_1};
         padding: 0 0.4rem;
-        border-radius: 1rem;
+        border-radius: 0.8rem;
         overflow: hidden;
 
         .progress-bar {
             position: absolute;
-            border-radius: 1rem;
+            border-radius: 0.8rem;
             top: 0;
             bottom: 0;
             left: 0;
@@ -31,12 +31,13 @@ const baseStyles = ({ maxValue = 1, currentValue = 0 }: Pick<ProgressBarProps, '
             transform: scaleX(${progress}%);
             transition: transform 200ms linear;
             background: ${colors.orange_0};
-            border: 3px solid ${colors.orange_1};
+            border: 2px solid ${colors.orange_1};
         }
 
         .label {
             margin-left: 0.5rem;
-            font-size: 1.1rem;
+            font-size: 1rem;
+            padding: 0.1rem;
             position: relative;
             z-index: 10;
         }

--- a/frontend/src/plugins/tooltip/tooltip.styles.ts
+++ b/frontend/src/plugins/tooltip/tooltip.styles.ts
@@ -16,16 +16,17 @@ export const TooltipTip = styled.div<{ direction?: 'top' | 'right' | 'bottom' | 
     left: 50%;
     top: 0; /* Position the tooltip at the top of its container */
     transform: translate(-50%, calc(-100% + 20px));
-    padding: 6px;
+    padding: 1rem;
     color: ${tooltipTextColor};
     background: ${tooltipBackgroundColor};
-    font-size: 14px;
-    font-family: 'Recursive', monospace;
     line-height: 1;
     z-index: 100;
     width: max-content;
-    max-width: 125px;
+    white-space: nowrap;
+    max-width: 30rem;
     white-space: pre-line;
+    opacity: 0.9;
+    font-size: 1.2rem;
 
     &::before {
         content: ' ';

--- a/frontend/src/styles/base-panel.styles.ts
+++ b/frontend/src/styles/base-panel.styles.ts
@@ -11,6 +11,7 @@ export const BasePanelStyles = css`
     border-radius: var(--panel-border-radius);
     padding: var(--panel-padding);
     border: ${colorMap.primaryBorderColor} 3px solid;
+    pointer-events: all;
 `;
 
 export const StyledBasePanel = styled.div`

--- a/frontend/src/styles/button.styles.ts
+++ b/frontend/src/styles/button.styles.ts
@@ -9,6 +9,8 @@ const BaseButtonStyle = css`
     position: relative;
     display: block;
     box-sizing: border-box;
+    pointer-events: all;
+    height: 5rem;
 
     &:disabled {
         opacity: 0.5;
@@ -41,6 +43,5 @@ export const ActionButton = styled(TextButton)`
 export const UnitActionButton = styled(TextButton)`
     border: none;
     width: 5rem;
-    height: 5.6rem;
     padding: 1.2rem 0rem 0.8rem;
 `;

--- a/frontend/src/styles/global.styles.ts
+++ b/frontend/src/styles/global.styles.ts
@@ -25,6 +25,7 @@ export const GlobalStyles = createGlobalStyle`
         -moz-osx-font-smoothing: grayscale;
         background: ${colorMap.documentBackground};
         font-size: 1.478rem;
+        user-select: none;
     }
 
     .build-version {
@@ -85,8 +86,8 @@ export const GlobalStyles = createGlobalStyle`
             select {
                 appearance: none;
                 box-sizing: border-box;
-                background-color: #143063;
-                border: 1px solid white;
+                background-color: #eee;
+                border: 1px solid #ccc;
                 border-radius: 0.5rem;
                 padding: 1rem;
                 margin: 0;
@@ -95,7 +96,7 @@ export const GlobalStyles = createGlobalStyle`
                 font-size: inherit;
                 cursor: inherit;
                 line-height: inherit;
-                color: white;
+                color: #333;
             }
 
             &:after {
@@ -107,7 +108,7 @@ export const GlobalStyles = createGlobalStyle`
                 content: "";
                 width: 0.8em;
                 height: 0.5em;
-                background-color: white;
+                background-color: #333;
                 clip-path: polygon(100% 0%, 0 0%, 50% 100%);
             }
         }

--- a/frontend/src/styles/global.styles.ts
+++ b/frontend/src/styles/global.styles.ts
@@ -36,6 +36,14 @@ export const GlobalStyles = createGlobalStyle`
         font-size: 1.3rem;
     }
 
+    .no-scrollbars {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+    .no-scrollbars::-webkit-scrollbar {
+        display: none;
+    }
+
     code {
         font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
         monospace;


### PR DESCRIPTION
### What

Shrinking, Squishing, and Shifting around HUD elements as things are not playing nicely on smaller screens:

* reduced font-sizes and padding all over the place to claim back pixels
* switched from grid to flex-box to arrange things more flexy
* removed the nav links and claimed the vertical space back for the RHS
* allow the RHS to scroll if it overflows (hacky - but better than being totally unusable)
* rearranged and squished the unit panel to use less vertical space
* the RHS bar will now allow you to scroll it if it overflows, with a fade-out effect to hint that there is more content.

Here's a scenerio of an iPad mini view of the game with too much stuff:

https://github.com/playmint/ds/assets/45921/b801c57c-af1d-4731-a762-0f88e2991363

Here's running with David's unusual aspect radio where all the vertical real estate is taken up by things like docks,bookmarks, apple menu bar etc

https://github.com/playmint/ds/assets/45921/c5ab0692-7765-47b3-9605-4c03076df7be

### Note

Squishing everything and having hidden scrolling areas isn't good! we really need a HUD design that better accommodates all the stuff so this is very much hammering that square peg in the round hole for now.

### Related

* resolves: #777
* resolves: #806 (at least improves it about as far as we can get for now without an overhaul)
