### PR TITLE
Fix to quests showing tasks that belonged to other quests

### DIFF
--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -86,7 +86,7 @@ contract DownstreamGame is BaseGame {
         state.registerEdgeType(Rel.IsFinalised.selector, "IsFinalised", WeightKind.UINT64);
         state.registerEdgeType(Rel.HasQuest.selector, "HasQuest", WeightKind.UINT64);
         state.registerEdgeType(Rel.HasTask.selector, "HasTask", WeightKind.UINT64);
-        state.registerEdgeType(Rel.HasTask.selector, "ID", WeightKind.UINT64);
+        state.registerEdgeType(Rel.ID.selector, "ID", WeightKind.UINT64);
 
         // create a session router
         BaseRouter router = new DownstreamRouter();

--- a/core/src/quest.graphql
+++ b/core/src/quest.graphql
@@ -6,11 +6,11 @@ fragment Quest on Node {
     description: annotation(name: "description") {
         value
     }
-    location: node(match: { kinds: "tile" }) {
+    location: node(match: { kinds: "Tile" }) {
         id
         coords: keys
     }
-    tasks: edges(match: { kinds: "task", via: { rel: "HasTask", dir: OUT } }) {
+    tasks: edges(match: { kinds: "Task", via: { rel: "HasTask", dir: OUT } }) {
         key
         node {
             ...QuestTask
@@ -19,6 +19,7 @@ fragment Quest on Node {
 }
 
 # TODO: Break QuestTasks into the kinds. Can I do a discriminated union using the keys?
+# HACK: combatstate is set on a 'Has' edge pointing from a task to itself
 # https://spin.atomicobject.com/2019/04/15/discriminated-unions/
 
 fragment QuestTask on Node {
@@ -27,11 +28,11 @@ fragment QuestTask on Node {
     name: annotation(name: "name") {
         value
     }
-    location: node(match: { kinds: "tile" }) {
+    location: node(match: { kinds: "Tile" }) {
         id
         coords: keys
     }
-    itemSlot: edge(match: { kinds: "item" }) {
+    itemSlot: edge(match: { kinds: "Item" }) {
         balance: weight
         item: node {
             id
@@ -40,20 +41,20 @@ fragment QuestTask on Node {
     message: annotation(name: "message") {
         value
     }
-    buildingKind: node(match: { kinds: "buildingKind" }) {
+    buildingKind: node(match: { kinds: "BuildingKind" }) {
         id
     }
-    quest: node(match: { kinds: "quest", via: { rel: "HasQuest", dir: OUT } }) {
+    quest: node(match: { kinds: "Quest", via: { rel: "HasQuest", dir: OUT } }) {
         id
     }
-    combatState: edge(match: { kinds: "task", via: { rel: "Has", dir: OUT } }) {
+    combatState: edge(match: { kinds: "Task", via: { rel: "Has", dir: OUT } }) {
         value: weight
     }
-    unitStats: edges(match: { kinds: "atom", via: { rel: "Balance", dir: OUT } }) {
+    unitStats: edges(match: { kinds: "Atom", via: { rel: "Balance", dir: OUT } }) {
         key
         weight
     }
-    craftItems: edges(match: { kinds: "item" }) {
+    craftItems: edges(match: { kinds: "Item" }) {
         key
         item: node {
             id


### PR DESCRIPTION
# What

Tasks that pointed to other quests such as the quest cmpletion task would cause the quest that was being pointed to to list that task in its own list of tasks.

This was due to a bug where I had accidentally registered 'HasTask' twice which meant that when querying the attached tasks for a quest I was also seein the inbound ones.

I have also updated the query to use the correct casing for the node kinds. It was working before because the edges were unique enough for it to no present itself as a problem.

# How to test

If you accept the orientation quest, the sub quests should each have 1 task assigned to them

resolves: #825