### PR TITLE
Hoisting the quest message buffer

### DIFF
--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -7,7 +7,7 @@ import {
     WorldTileFragment,
 } from '@app/../../core/src';
 import { Locatable, getCoords } from '@app/helpers/tile';
-import { useBuildingKinds, useQuestMessages } from '@app/hooks/use-game-state';
+import { useBuildingKinds } from '@app/hooks/use-game-state';
 import { useUnityMap } from '@app/hooks/use-unity-map';
 import { BasePanelStyles } from '@app/styles/base-panel.styles';
 import { ActionButton } from '@app/styles/button.styles';

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -1,6 +1,7 @@
 import {
     BuildingKindFragment,
     ConnectedPlayer,
+    Log,
     QuestFragment,
     WorldStateFragment,
     WorldTileFragment,
@@ -216,10 +217,10 @@ export const QuestItem: FunctionComponent<{
     tiles: WorldTileFragment[];
     player: ConnectedPlayer;
     buildingKinds: BuildingKindFragment[];
+    questMessages?: Log[];
     setFocusLocation: ReturnType<typeof useState<Location>>[1];
     onExpandClick: (questId: string) => void;
-}> = ({ expanded, world, tiles, player, buildingKinds, quest, setFocusLocation, onExpandClick }) => {
-    const questMessages = useQuestMessages(5);
+}> = ({ expanded, world, tiles, player, buildingKinds, quest, questMessages, setFocusLocation, onExpandClick }) => {
     const [taskCompletion, setTaskCompletion] = useState<{ [key: string]: boolean }>({});
     const [allCompleted, setAllCompleted] = useState<boolean>(false);
     const [completionCount, setCompletionCount] = useState<number>(0);
@@ -312,6 +313,7 @@ export interface QuestPanelProps {
     world: WorldStateFragment;
     tiles: WorldTileFragment[];
     acceptedQuests: QuestFragment[];
+    questMessages?: Log[];
 }
 
 export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
@@ -319,6 +321,7 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
     tiles,
     player,
     acceptedQuests,
+    questMessages,
 }: QuestPanelProps) => {
     const { ready: mapReady, sendMessage } = useUnityMap();
     const buildingKinds = useBuildingKinds();
@@ -368,6 +371,7 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
                     player={player}
                     world={world}
                     buildingKinds={buildingKinds || []}
+                    questMessages={questMessages}
                     setFocusLocation={setFocusLocation}
                     onExpandClick={onExpandClick}
                 />

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -13,7 +13,14 @@ import { MobileUnitPanel } from '@app/components/panels/mobile-unit-panel';
 import { NavPanel } from '@app/components/panels/nav-panel';
 import { TileInfoPanel } from '@app/components/panels/tile-info-panel';
 import { getTileDistance } from '@app/helpers/tile';
-import { useBlock, useBuildingKinds, useGameState, usePlayer, usePluginState } from '@app/hooks/use-game-state';
+import {
+    useBlock,
+    useBuildingKinds,
+    useGameState,
+    usePlayer,
+    usePluginState,
+    useQuestMessages,
+} from '@app/hooks/use-game-state';
 import { useSession } from '@app/hooks/use-session';
 import { useUnityMap } from '@app/hooks/use-unity-map';
 import { useWalletProvider } from '@app/hooks/use-wallet-provider';
@@ -60,7 +67,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
     const ui = usePluginState();
     const [questsActive, setQuestsActive] = useState<boolean>(true);
     const toggleQuestsActive = useCallback(() => setQuestsActive((prev) => !prev), []);
-
+    const questMessages = useQuestMessages(10);
     const acceptedQuests = useMemo(() => {
         return (
             (player?.quests || []).filter((q) => q.status == QUEST_STATUS_ACCEPTED).sort((a, b) => a.key - b.key) || []
@@ -280,6 +287,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                                 tiles={tiles || []}
                                 player={player}
                                 acceptedQuests={acceptedQuests}
+                                questMessages={questMessages}
                             />
                         )}
                         {/* <Logs className="logs" /> */}


### PR DESCRIPTION
# What

Hoisting the quest message buffer so that it's not a sub component of the quest panel. This allows us to hide the panel without losing the message buffer state.

![image](https://github.com/playmint/ds/assets/51167118/01eafd85-0862-4ca8-8dec-790d36c0ac11)

This can be tested by completing the tasks in the first quest, hiding the quests panel and showing it again. Previously the task that tracked the button click in the control panel was no longer complete and the player needed to refresh the game to see the button within the control tower to click it again.