### PR TITLE
Separating task view from the completion evaluation

### DIFF
--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -393,7 +393,7 @@ export enum TaskKinds {
     unitStats = 'unitStats',
 }
 
-export type QuestTask = QuestFragment['node']['tasks'][0];
+export type QuestTaskEdge = QuestFragment['node']['tasks'][0];
 
 export const QUEST_STATUS_ACCEPTED = 1;
 export const QUEST_STATUS_COMPLETED = 2;

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -15,6 +15,7 @@ import { colorMap, colors } from '@app/styles/colors';
 import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { TaskItem } from '../quest-task/task-item';
+import { TaskView } from '../quest-task/task-view';
 
 // NOTE: QuestPanel is a misnomer as it is no longer a panel but just a container. Each of the quest items are panels in their own right
 const StyledQuestPanel = styled.div`
@@ -253,6 +254,22 @@ export const QuestItem: FunctionComponent<{
 
     return (
         <StyledQuestItem expanded={expanded} onClick={expanded ? undefined : () => onExpandClick(quest.node.id)}>
+            {/* TaskItems are memos that eval the completion. */}
+            {quest.node.tasks
+                .sort((a, b) => a.key - b.key)
+                .map((task, idx) => (
+                    <TaskItem
+                        key={idx}
+                        tiles={tiles}
+                        task={task}
+                        world={world}
+                        buildingKinds={buildingKinds}
+                        player={player}
+                        questMessages={questMessages}
+                        setTaskCompletion={setTaskCompletion}
+                    />
+                ))}
+
             {expanded ? (
                 <>
                     <div className="header">
@@ -273,16 +290,7 @@ export const QuestItem: FunctionComponent<{
                         {quest.node.tasks
                             .sort((a, b) => a.key - b.key)
                             .map((task, idx) => (
-                                <TaskItem
-                                    tiles={tiles}
-                                    key={idx}
-                                    task={task}
-                                    world={world}
-                                    buildingKinds={buildingKinds}
-                                    player={player}
-                                    questMessages={questMessages}
-                                    setTaskCompletion={setTaskCompletion}
-                                />
+                                <TaskView key={idx} task={task.node} isCompleted={taskCompletion[task.node.id]} />
                             ))}
                     </div>
                     {allCompleted && (

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -190,8 +190,8 @@ const StyledProgressBar = styled.div`
             border-width: 0.2rem;
             border-style: ${p > 0 ? `solid` : `none`};
 
-            background-color: ${p >= 0.99 ? colors.green_0 : colors.orange_0};
-            border-color: ${p >= 0.99 ? colors.green_1 : colors.orange_1};
+            background-color: ${p >= 0.99 ? colors.green_0 + `!important` : colors.orange_0};
+            border-color: ${p >= 0.99 ? colors.green_1 + `!important` : colors.orange_1};
 
             transition: width 0.5s;
         }

--- a/frontend/src/components/quest-task/kinds/task-combat.tsx
+++ b/frontend/src/components/quest-task/kinds/task-combat.tsx
@@ -1,31 +1,31 @@
-import { WorldMobileUnitFragment, WorldTileFragment } from '@downstream/core';
-import { memo, useEffect } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { TaskItemProps } from '../task-item';
 import { convertCombatActions, getActions } from '@app/plugins/combat/helpers';
 import { Combat, CombatWinState, EntityState } from '@app/plugins/combat/combat';
 import { WorldCombatSessionFragment } from '@downstream/core/src/gql/graphql';
-import { getSessionsAtTile } from '@downstream/core/src/utils';
 
 const ATTACK_WIN = 0;
 // const DEFENCE_WIN = 1;
 
+const DEBOUNCE_MS = 500;
+
 export const TaskCombat = memo(
     ({
         task,
-        tiles,
         sessions,
-        mobileUnits,
+        playerUnitIDs,
         setTaskCompletion,
     }: {
         sessions: WorldCombatSessionFragment[];
-        mobileUnits?: WorldMobileUnitFragment[];
-        tiles: WorldTileFragment[];
+        playerUnitIDs: string[];
     } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
-        console.log(`evaluating TaskCombat`);
-        const isCompleted =
-            !!mobileUnits &&
-            !!tiles.some((t) => {
-                return getSessionsAtTile(sessions, t).some((s) => {
+        const [isCompleted, setIsCompleted] = useState(false);
+
+        // Logic set within a setTimeout to debounce
+        useEffect(() => {
+            const evalTimeoutID = setTimeout(() => {
+                console.log(`evaluating TaskCombat`);
+                const isCompleted = !!sessions.some((s) => {
                     if (!s.isFinalised) return false;
 
                     // TODO: WARN: This will not scale as it's searching through every combat that has ever happened looking for the player's unit.
@@ -54,10 +54,17 @@ export const TaskCombat = memo(
 
                     // We don't care if the player's unit died, they just needed to have not left the battle
                     return winnerStates.some(
-                        (participant) => participant.isPresent && mobileUnits.some((u) => u.id == participant.entityID)
+                        (participant) => participant.isPresent && playerUnitIDs.some((id) => id == participant.entityID)
                     );
                 });
-            });
+
+                setIsCompleted(isCompleted);
+            }, DEBOUNCE_MS);
+
+            return () => {
+                clearTimeout(evalTimeoutID);
+            };
+        }, [playerUnitIDs, sessions, task.node.combatState?.value]);
 
         const taskId = task.node.id;
         useEffect(() => {

--- a/frontend/src/components/quest-task/kinds/task-combat.tsx
+++ b/frontend/src/components/quest-task/kinds/task-combat.tsx
@@ -1,6 +1,5 @@
 import { WorldMobileUnitFragment, WorldTileFragment } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 import { convertCombatActions, getActions } from '@app/plugins/combat/helpers';
 import { Combat, CombatWinState, EntityState } from '@app/plugins/combat/combat';
@@ -22,7 +21,7 @@ export const TaskCombat = memo(
         mobileUnits?: WorldMobileUnitFragment[];
         tiles: WorldTileFragment[];
     } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
-        // console.log(`evaluating TaskCombat`);
+        console.log(`evaluating TaskCombat`);
         const isCompleted =
             !!mobileUnits &&
             !!tiles.some((t) => {
@@ -60,6 +59,15 @@ export const TaskCombat = memo(
                 });
             });
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+
+        return null;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-construct.tsx
+++ b/frontend/src/components/quest-task/kinds/task-construct.tsx
@@ -1,6 +1,5 @@
 import { WorldBuildingFragment, WorldTileFragment } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 import { getBuildingAtTile } from '@downstream/core/src/utils';
 
@@ -25,6 +24,15 @@ export const TaskConstruct = memo(
             );
         });
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+
+        return <></>;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-coord.tsx
+++ b/frontend/src/components/quest-task/kinds/task-coord.tsx
@@ -1,7 +1,6 @@
 import { getTileDistance } from '@app/helpers/tile';
 import { MobileUnit } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 
 export const TaskCoord = memo(
@@ -13,6 +12,7 @@ export const TaskCoord = memo(
         mobileUnits: MobileUnit[];
     } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         // console.log(`evaluating TaskCoord`);
+
         const isCompleted = mobileUnits?.some((unit) => {
             return (
                 unit.nextLocation &&
@@ -21,6 +21,15 @@ export const TaskCoord = memo(
             );
         });
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+
+        return <></>;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-deploy-building.tsx
+++ b/frontend/src/components/quest-task/kinds/task-deploy-building.tsx
@@ -1,6 +1,5 @@
 import { BuildingKindFragment } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 
 export const TaskDeployBuilding = memo(
@@ -26,6 +25,15 @@ export const TaskDeployBuilding = memo(
             );
         });
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+
+        return <></>;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-inventory.tsx
+++ b/frontend/src/components/quest-task/kinds/task-inventory.tsx
@@ -1,6 +1,5 @@
 import { BagFragment, MobileUnit } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 import { getBagsAtEquipee } from '@downstream/core/src/utils';
 
@@ -42,6 +41,15 @@ export const TaskInventory = memo(
             isCompleted = itemCount >= taskItemSlot.balance;
         }
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+
+        return <></>;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-message.tsx
+++ b/frontend/src/components/quest-task/kinds/task-message.tsx
@@ -1,6 +1,5 @@
 import { Log } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 
 export const TaskMessage = memo(
@@ -11,6 +10,8 @@ export const TaskMessage = memo(
     }: {
         questMessages?: Log[];
     } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
+        console.log(`evaluating TaskMessage`);
+
         const pluginMessages =
             (task.node.buildingKind &&
                 questMessages &&
@@ -18,6 +19,15 @@ export const TaskMessage = memo(
             [];
         const isCompleted = pluginMessages.some((m) => m.text == task.node.message?.value);
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+
+        return <></>;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
@@ -1,6 +1,5 @@
 import { QuestFragment } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 
 export const TaskQuestAccept = memo(
@@ -14,6 +13,15 @@ export const TaskQuestAccept = memo(
         // console.log(`evaluating TaskQuestAccept`);
         const isCompleted = !!quests?.some((q) => q.node.id == task.node.quest?.id);
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+
+        return <></>;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-quest-complete.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-complete.tsx
@@ -1,6 +1,5 @@
 import { QuestFragment, QUEST_STATUS_COMPLETED } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 
 export const TaskQuestComplete = memo(
@@ -16,6 +15,14 @@ export const TaskQuestComplete = memo(
             (q) => q.node.id == task.node.quest?.id && q.status == QUEST_STATUS_COMPLETED
         );
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+        return <></>;
     }
 );

--- a/frontend/src/components/quest-task/kinds/task-unit-stats.tsx
+++ b/frontend/src/components/quest-task/kinds/task-unit-stats.tsx
@@ -1,6 +1,5 @@
 import { BagFragment, MobileUnit } from '@downstream/core';
-import { memo } from 'react';
-import { TaskView } from '../task-view';
+import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 import {
     LIFE_MUL,
@@ -45,6 +44,15 @@ export const TaskUnitStats = memo(
                 );
             });
 
-        return <TaskView isCompleted={isCompleted} task={task} setTaskCompletion={setTaskCompletion} />;
+        const taskId = task.node.id;
+        useEffect(() => {
+            setTaskCompletion((oldObj) => {
+                const newObj = oldObj ? { ...oldObj } : {};
+                newObj[taskId] = isCompleted;
+                return newObj;
+            });
+        }, [taskId, isCompleted, setTaskCompletion]);
+
+        return <></>;
     }
 );

--- a/frontend/src/components/quest-task/task-item.tsx
+++ b/frontend/src/components/quest-task/task-item.tsx
@@ -13,7 +13,6 @@ import { TaskInventory } from './kinds/task-inventory';
 import { TaskMessage } from './kinds/task-message';
 import { TaskQuestAccept } from './kinds/task-quest-accept';
 import { TaskQuestComplete } from './kinds/task-quest-complete';
-import { TaskView } from './task-view';
 import { id as keccak256UTF8 } from 'ethers';
 import { TaskConstruct } from './kinds/task-construct';
 import { TaskCombat } from './kinds/task-combat';
@@ -112,7 +111,7 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
                     setTaskCompletion={setTaskCompletion}
                 />
             );
-        default:
-            return <TaskView task={task} isCompleted={false} setTaskCompletion={setTaskCompletion} />;
     }
+
+    return null;
 };

--- a/frontend/src/components/quest-task/task-view.tsx
+++ b/frontend/src/components/quest-task/task-view.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent, useEffect } from 'react';
-import { TaskItemProps } from './task-item';
+import { FunctionComponent } from 'react';
 import styled, { css } from 'styled-components';
 import { colors } from '@app/styles/colors';
+import { QuestTaskFragment } from '@downstream/core/src/gql/graphql';
 
 const tickSvg = (
     <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
@@ -45,24 +45,14 @@ const StyledTaskView = styled.div`
     `}
 `;
 
-export const TaskView: FunctionComponent<
-    {
-        isCompleted: boolean;
-    } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>
-> = ({ isCompleted, task, setTaskCompletion }) => {
-    const taskId = task.node.id;
-    useEffect(() => {
-        setTaskCompletion((oldObj) => {
-            const newObj = oldObj ? { ...oldObj } : {};
-            newObj[taskId] = isCompleted;
-            return newObj;
-        });
-    }, [taskId, isCompleted, setTaskCompletion]);
-
+export const TaskView: FunctionComponent<{
+    task: QuestTaskFragment;
+    isCompleted: boolean;
+}> = ({ isCompleted, task }) => {
     return (
         <StyledTaskView isCompleted={isCompleted}>
             <div className="tickBox">{isCompleted && tickSvg}</div>
-            <p>{task.node.name?.value}</p>
+            <p>{task.name?.value}</p>
         </StyledTaskView>
     );
 };


### PR DESCRIPTION
# What

Separating the quest task memos from the quest task views. This allows us to hide the list of tasks (when the quest is minimised) but still have the tasks evaluate. 

![image](https://github.com/playmint/ds/assets/51167118/ef4cfb53-9ccc-4b69-9dc6-56d47d191c66)

This also fixes the problem where tasks would not show their completion state until they had been maximised after hiding the quest panel.

Also for minimised quests that are completed, I have turned the bar green as a sort of call to action.

![image](https://github.com/playmint/ds/assets/51167118/b838c779-bba2-4639-8bd3-9aee90095e58)

solves: #763
solves: #835

# How to test

during the orientation meta quest, have the extraction sub quest minimised and build a red extractor somewhere. You should see the bar on the minimised quest move to 100%.

# Other details

I did a bit of work to make the Combat task not evaluate so frequently as it's the most expensive task of the lot. I'm memoising the player's unit IDs and the task object and also debouncing the completion logic. It's not perfect but it's better than it was