### PR TITLE
Show a slither of progress at 0%

### DIFF
--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -181,14 +181,14 @@ const StyledProgressBar = styled.div`
         background-color: white;
         border-radius: 1rem;
         background-color: ${colors.grey_2};
+        overflow: hidden;
 
         > .inner {
             position: absolute;
             height: 100%;
-            width: ${p * 100}%;
+            width: ${Math.max(p, 0.01) * 100}%;
             border-radius: 1rem;
-            border-width: 0.2rem;
-            border-style: ${p > 0 ? `solid` : `none`};
+            border: 0.2rem solid;
 
             background-color: ${p >= 0.99 ? colors.green_0 + `!important` : colors.orange_0};
             border-color: ${p >= 0.99 ? colors.green_1 + `!important` : colors.orange_1};


### PR DESCRIPTION
# What

<img width="444" alt="image" src="https://github.com/playmint/ds/assets/51167118/7f36bff6-de8d-453a-9d18-6d64ba5c02ec">

Achieved by always having the borders enabled and also showing a minimum of 1%.

# Why

To making it obvious to the player that it's a progress bar that will fill up