### PR TITLE
pass quest_id param for ACCEPTED_QUEST and COMPLETED_QUEST action tracking

### DIFF
--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -99,7 +99,18 @@ export const Shell: FunctionComponent<ShellProps> = () => {
         }
         const { unsubscribe } = pipe(
             player.dispatched,
-            subscribe((event) => event.actions.map((action) => trackEvent('dispatch', { action: action.name })))
+            subscribe((event) => {
+                event.actions.map((action) => {
+                    const params: any = { action: action.name };
+                    if (action.args.length > 0) {
+                        if (action.name === 'COMPLETE_QUEST' || action.name === 'ACCEPT_QUEST') {
+                            params.quest_id = `q${action.args[0]}`;
+                        }
+                    }
+                    console.log('tracking', params);
+                    trackEvent('dispatch', params);
+                });
+            })
         );
         return unsubscribe;
     }, [player]);


### PR DESCRIPTION
* passes along a `quest_id` arg for `dispatch` event tracking when action is ACCEPTED_QUEST or COMPLETED_QUEST
* resolves: #846 (hopefully)