### PR TITLE
fix onclick for focus-my-unit

### DIFF
--- a/frontend/src/components/panels/mobile-unit-panel.tsx
+++ b/frontend/src/components/panels/mobile-unit-panel.tsx
@@ -21,6 +21,7 @@ const StyledMobileUnitIcon = styled.div`
     mask-size: 100%;
     mask-position: center;
     mask-repeat: no-repeat;
+    z-index: 10;
 
     > .inner {
         position: absolute;
@@ -53,8 +54,8 @@ const StyledMobileUnitIcon = styled.div`
 
 const MobileUnitIcon = ({ className, onClick }) => {
     return (
-        <StyledMobileUnitIcon className={className} onClick={onClick}>
-            <div className="inner">
+        <StyledMobileUnitIcon className={className}>
+            <div className="inner" onClick={onClick}>
                 <div className="icon" />
             </div>
         </StyledMobileUnitIcon>


### PR DESCRIPTION
* onclick for the name label was masking the clicks to the unit icon (click to focus on unit)
* resolves: #847 