### PR TITLE
Unit stats shown in panel now include mobile unit base stats

### DIFF
--- a/frontend/src/components/panels/mobile-unit-panel.tsx
+++ b/frontend/src/components/panels/mobile-unit-panel.tsx
@@ -2,7 +2,7 @@ import { formatNameOrId } from '@app/helpers';
 import { getTileCoordsFromId } from '@app/helpers/tile';
 import { useGameState } from '@app/hooks/use-game-state';
 import { useUnityMap } from '@app/hooks/use-unity-map';
-import { getEquipmentStats } from '@app/plugins/combat/helpers';
+import { getMobileUnitStats } from '@app/plugins/combat/helpers';
 import { MobileUnitInventory } from '@app/plugins/inventory/mobile-unit-inventory';
 import { StyledHeaderPanel } from '@app/styles/base-panel.styles';
 import { TextButton } from '@app/styles/button.styles';
@@ -204,7 +204,7 @@ export const MobileUnitPanel = () => {
     );
 
     const mobileUnitBags = selectedMobileUnit ? getBagsAtEquipee(world?.bags || [], selectedMobileUnit) : [];
-    const [life, def, atk] = getEquipmentStats(mobileUnitBags);
+    const [life, def, atk] = getMobileUnitStats(selectedMobileUnit, world?.bags);
 
     return (
         <>

--- a/frontend/src/components/quest-task/kinds/task-unit-stats.tsx
+++ b/frontend/src/components/quest-task/kinds/task-unit-stats.tsx
@@ -1,26 +1,17 @@
 import { BagFragment, MobileUnit } from '@downstream/core';
 import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
-import {
-    LIFE_MUL,
-    UNIT_BASE_ATTACK,
-    UNIT_BASE_DEFENCE,
-    UNIT_BASE_LIFE,
-    NUM_STAT_KINDS,
-    getEquipmentStats,
-} from '@app/plugins/combat/helpers';
-import { ATOM_LIFE, ATOM_ATTACK, ATOM_DEFENSE } from '@app/plugins/combat/combat';
-import { getBagsAtEquipee } from '@downstream/core/src/utils';
+import { NUM_STAT_KINDS, getMobileUnitStats } from '@app/plugins/combat/helpers';
 
 export const TaskUnitStats = memo(
     ({
         task,
         mobileUnits,
-        bags,
+        worldBags,
         setTaskCompletion,
     }: {
         mobileUnits?: MobileUnit[];
-        bags: BagFragment[];
+        worldBags: BagFragment[];
     } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         // console.log(`evaluating TaskUnitStats`);
 
@@ -28,19 +19,11 @@ export const TaskUnitStats = memo(
             !!mobileUnits &&
             task.node.unitStats.length === NUM_STAT_KINDS &&
             mobileUnits.some((m) => {
-                const unitBags = getBagsAtEquipee(bags, m);
-                const stats = getEquipmentStats(unitBags);
-                stats[ATOM_LIFE] += UNIT_BASE_LIFE * LIFE_MUL;
-                stats[ATOM_DEFENSE] += UNIT_BASE_DEFENCE;
-                stats[ATOM_ATTACK] += UNIT_BASE_ATTACK;
-
-                console.log('unit stats:', stats);
+                const stats = getMobileUnitStats(m, worldBags);
 
                 // All unit's stats must be greater than or equal to the stats defined in the task
-                return task.node.unitStats.reduce(
-                    (isGTE, statEdge) =>
-                        isGTE && statEdge.key < NUM_STAT_KINDS && stats[statEdge.key] >= statEdge.weight,
-                    true
+                return task.node.unitStats.every(
+                    (statEdge) => statEdge.key < NUM_STAT_KINDS && stats[statEdge.key] >= statEdge.weight
                 );
             });
 

--- a/frontend/src/components/quest-task/task-item.tsx
+++ b/frontend/src/components/quest-task/task-item.tsx
@@ -131,7 +131,7 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
         case taskUnitStats:
             return (
                 <TaskUnitStats
-                    bags={world?.bags || []}
+                    worldBags={world?.bags || []}
                     task={taskMemo}
                     mobileUnits={playerUnits}
                     setTaskCompletion={setTaskCompletion}

--- a/frontend/src/plugins/combat/helpers.ts
+++ b/frontend/src/plugins/combat/helpers.ts
@@ -154,7 +154,7 @@ export const getEntityName = (entityID: BytesLike, world: WorldStateFragment) =>
     return formatNameOrId(unit, 'Unit ');
 };
 
-export const getEquipmentStats = (bags: BagFragment[]) => {
+export const getEquipmentStats = (bags: BagFragment[]): number[] => {
     return bags.reduce(
         (stats, bag) => {
             bag.slots.forEach((slot) => {
@@ -171,6 +171,19 @@ export const getEquipmentStats = (bags: BagFragment[]) => {
         },
         [0, 0, 0]
     );
+};
+
+export const getMobileUnitStats = (mobileUnit?: WorldMobileUnitFragment, worldBags?: BagFragment[]): number[] => {
+    if (mobileUnit === undefined || worldBags === undefined) return [0, 0, 0];
+
+    const mobileUnitBags = getBagsAtEquipee(worldBags, mobileUnit);
+    const stats = getEquipmentStats(mobileUnitBags);
+
+    stats[ATOM_LIFE] += UNIT_BASE_LIFE * LIFE_MUL;
+    stats[ATOM_DEFENSE] += UNIT_BASE_DEFENCE;
+    stats[ATOM_ATTACK] += UNIT_BASE_ATTACK;
+
+    return stats;
 };
 
 export const getMaterialStats = (materials: ItemSlotFragment[]) => {


### PR DESCRIPTION
# What

Unit stats shown in panel now reflect the actual unit stats including the base stats. The shouldn't start at 0 like before

![image](https://github.com/playmint/ds/assets/51167118/09e91de5-a803-4c29-9b37-2dc2517660ea)

# Details

Have added a new helper `getMobileUnitStats` which includes the base stats for a unit. I'm using this helper in both `task-unit-stats.tsx` and `mobile-unit-panel` for consistency

resolves: #844 