### PR TITLE
Comparing weights instead of rates to determine if a tile info displays goo name

### DIFF
--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -10,7 +10,16 @@ import {
     WorldMobileUnitFragment,
 } from '@app/../../core/src';
 import { PluginContent } from '@app/components/organisms/tile-action';
-import { GOO_BLUE, GOO_GREEN, GOO_RED, getCoords, getGooRates, getTileDistance } from '@app/helpers/tile';
+import {
+    GOO_BIG_THRESH,
+    GOO_BLUE,
+    GOO_GREEN,
+    GOO_RED,
+    GOO_SMALL_THRESH,
+    getCoords,
+    getGooRates,
+    getTileDistance,
+} from '@app/helpers/tile';
 import { usePlayer, useSelection, useWorld } from '@app/hooks/use-game-state';
 import { Bag } from '@app/plugins/inventory/bag';
 import { useInventory } from '@app/plugins/inventory/inventory-provider';
@@ -293,10 +302,11 @@ const TileAvailable: FunctionComponent<TileAvailableProps> = ({ player, mobileUn
     }
     const { q, r, s } = getCoords(lastTile);
     const gooRates = getGooRates(lastTile);
-    const topGooRate = gooRates.length > 0 ? Math.floor(gooRates[0].gooPerSec * 100) / 100 : 0;
+    // const topGooRate = gooRates.length > 0 ? Math.floor(gooRates[0].gooPerSec * 100) / 100 : 0;
+    const topGooWeight = gooRates.length > 0 ? gooRates[0].weight : 0;
     const topGooName = gooRates.length > 0 ? gooRates[0].name : '';
-    const hasSomeGoo = topGooRate >= 0.1;
-    const hasLotsGoo = topGooRate >= 0.3;
+    const hasSomeGoo = topGooWeight >= GOO_SMALL_THRESH;
+    const hasLotsGoo = topGooWeight >= GOO_BIG_THRESH;
     const gooRatesInNameOrder = [GOO_RED, GOO_GREEN, GOO_BLUE]
         .map((idx) => gooRates.find((goo) => goo.index === idx))
         .filter((goo) => !!goo);


### PR DESCRIPTION
# What

Comparing weights instead of rates to determine if a tile has some or lots of goo. By comparing weights we are applying the same logic that we use to display either a small or big goo texture.

![image](https://github.com/playmint/ds/assets/51167118/feabf827-3de1-43a1-b9e2-305754abd1ec)
![image](https://github.com/playmint/ds/assets/51167118/d7694bfd-e0e0-4255-9579-3b700aeb564e)

Below shows tile with some blue goo but the tile info doesn't show the 'some goo' text
![image](https://github.com/playmint/ds/assets/51167118/13ea952e-3fe7-40d9-b7a3-59b6eecaf735)


# Why

This solves the problem where a tile without a goo texture could say it had some goo on it. Even though this was technically true it didn't match the visuals

It might be that instead of comparing weights we make the textures display depending on rates. This would have the effect of showing more goo textures on the map. Not sure if that's what we wanted which is why I went with the weight option for now

resolves: #808