### PR TITLE
Fix to allow for items to be updated by their owner

### DIFF
--- a/contracts/src/rules/CraftingRule.sol
+++ b/contracts/src/rules/CraftingRule.sol
@@ -48,7 +48,8 @@ contract CraftingRule is Rule {
 
         // Check the name is unique
         bytes24 idNode = Node.ID(bytes20(keccak256(abi.encodePacked(name))));
-        if (state.getOwner(idNode) != 0x0) {
+        bytes24 idOwner = state.getOwner(idNode);
+        if (idOwner != 0x0 && idOwner != itemKind) {
             revert("item name already registered");
         }
         state.setID(itemKind, idNode);


### PR DESCRIPTION
# What

We weren't testing whether an ID (formed by the item name) belonged to the item we are trying to register. If we were updating (reregistering) an item then the ID from the name would have been used by that very item therefore registration would revert.