### PR TITLE
Halve output goo after summing instead of summing the halves

### DIFF
--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -370,10 +370,18 @@ contract BuildingRule is Rule {
                 } else {
                     require(inputQty[i] == 1, "equipable input item must have qty=1");
                 }
-                availableInputAtoms[0] = availableInputAtoms[0] + (inputAtoms[0] * uint32(inputQty[i])) / 2;
-                availableInputAtoms[1] = availableInputAtoms[1] + (inputAtoms[1] * uint32(inputQty[i])) / 2;
-                availableInputAtoms[2] = availableInputAtoms[2] + (inputAtoms[2] * uint32(inputQty[i])) / 2;
+                availableInputAtoms[0] += inputAtoms[0] * uint32(inputQty[i]);
+                availableInputAtoms[1] += inputAtoms[1] * uint32(inputQty[i]);
+                availableInputAtoms[2] += inputAtoms[2] * uint32(inputQty[i]);
             }
+
+            // Halve the available goo.
+            // NOTE: At a cost of some extra gas we halve the sum of atoms instead of summing the halves. Because we
+            //       are dealing with integers (5/2) + (5/2) would equal 4 instead of 5.
+            //       If we REALLY needed to gas golf perhaps bit shifting once right would be cheaper than dividing by 2?
+            availableInputAtoms[0] /= 2;
+            availableInputAtoms[1] /= 2;
+            availableInputAtoms[2] /= 2;
 
             // require that the total number of each atom in the total number of
             // output items is less than half of the total input of each atom

--- a/contracts/src/rules/CraftingRule.sol
+++ b/contracts/src/rules/CraftingRule.sol
@@ -126,9 +126,9 @@ contract CraftingRule is Rule {
 
             // check min input qty
             require(gotQty[0] >= wantQty[0], "input 0 qty does not match recipe");
-            require(gotQty[1] >= wantQty[1], "input 0 qty does not match recipe");
-            require(gotQty[2] >= wantQty[2], "input 0 qty does not match recipe");
-            require(gotQty[3] >= wantQty[3], "input 0 qty does not match recipe");
+            require(gotQty[1] >= wantQty[1], "input 1 qty does not match recipe");
+            require(gotQty[2] >= wantQty[2], "input 2 qty does not match recipe");
+            require(gotQty[3] >= wantQty[3], "input 3 qty does not match recipe");
 
             // burn that many inputs
             state.setItemSlot(inBag, 0, gotItem[0], gotQty[0] - wantQty[0]);


### PR DESCRIPTION
# What

We were summing up halves of the inputs which meant we lost all fractional parts due to working with integers so `(5/2) + (5/2) = 4`. By summing and then halving we get the expected output `(5 + 5) / 2 = 5`

# Testing

You can make a building that takes two inputs of 5 goo which should yield an output item with 5.

```

---
kind: BuildingKind
spec:
  category: factory
  name: Goo Halver
  description: Halve red goo for a laugh
  model: 01-09
  color: 4
  contract:
    file: ./basic-factory.sol
  plugin:
    file: ./basic-factory.js
  materials:
  - name: Red Goo
    quantity: 10
  - name: Green Goo
    quantity: 10
  - name: Blue Goo
    quantity: 10
  inputs:
  - name: Red Goo
    quantity: 5
  - name: Red Goo
    quantity: 5
  outputs:
  - name: Red Fiver
    quantity: 1

---
kind: Item
spec:
  name: Red Fiver
  icon: 31-16
  goo:
    red: 5
    green: 0
    blue: 0
  stackable: false

```

resolves: #695