### PR TITLE
Fix outline scale at lower resolutions

### DIFF
--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -97,7 +97,7 @@ export const NavPanel = ({
         if (!e) {
             return;
         }
-        const newHeight = parseInt(e.target.value, 10);
+        const newHeight = parseFloat(e.target.value);
         if (g.__globalUnityContext?.setCanvasHeight) {
             g.__globalUnityContext.setCanvasHeight(newHeight);
         }
@@ -195,13 +195,27 @@ export const NavPanel = ({
                         <fieldset>
                             <legend>Quality:</legend>
                             <select onChange={onChangeQuality} value={canvasHeight}>
-                                <option value="480">Low (480p)</option>
-                                <option value="720">Medium (720p)</option>
-                                <option value="1080">High (1080p)</option>
-                                <option value="-1">
+                                <option value={480 / Math.floor(window.innerHeight * window.devicePixelRatio)}>
+                                    Low (480p)
+                                </option>
+                                <option value={720 / Math.floor(window.innerHeight * window.devicePixelRatio)}>
+                                    Medium (720p)
+                                </option>
+                                <option value={1080 / Math.floor(window.innerHeight * window.devicePixelRatio)}>
+                                    High (1080p)
+                                </option>
+                                <option value={1440 / Math.floor(window.innerHeight * window.devicePixelRatio)}>
+                                    Ultra (1440p)
+                                </option>
+                                <option
+                                    value={
+                                        Math.min(window.innerHeight, window.innerHeight * window.devicePixelRatio) /
+                                        Math.floor(window.innerHeight * window.devicePixelRatio)
+                                    }
+                                >
                                     Auto ({Math.min(window.innerHeight, window.innerHeight * window.devicePixelRatio)}p)
                                 </option>
-                                <option value="-2">
+                                <option value="1">
                                     Native ({Math.floor(window.innerHeight * window.devicePixelRatio)}p)
                                 </option>
                             </select>

--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -92,7 +92,7 @@ export const NavPanel = ({
         window.location.reload();
     }, [clearSession, forgetProvider]);
 
-    const canvasHeight = g.__globalUnityContext?.getCanvasHeight ? g.__globalUnityContext.getCanvasHeight() : -1;
+    const canvasHeight = g.__globalUnityContext?.getCanvasHeight ? g.__globalUnityContext.getCanvasHeight() : 0.5;
     const onChangeQuality = useCallback((e) => {
         if (!e) {
             return;

--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -92,14 +92,14 @@ export const NavPanel = ({
         window.location.reload();
     }, [clearSession, forgetProvider]);
 
-    const canvasHeight = g.__globalUnityContext?.getCanvasHeight ? g.__globalUnityContext.getCanvasHeight() : 0.5;
+    const canvasHeight = g.__globalUnityContext?.getCanvasScale ? g.__globalUnityContext.getCanvasScale() : 0.5;
     const onChangeQuality = useCallback((e) => {
         if (!e) {
             return;
         }
         const newHeight = parseFloat(e.target.value);
-        if (g.__globalUnityContext?.setCanvasHeight) {
-            g.__globalUnityContext.setCanvasHeight(newHeight);
+        if (g.__globalUnityContext?.setCanvasScale) {
+            g.__globalUnityContext.setCanvasScale(newHeight);
         }
     }, []);
 
@@ -195,26 +195,9 @@ export const NavPanel = ({
                         <fieldset>
                             <legend>Quality:</legend>
                             <select onChange={onChangeQuality} value={canvasHeight}>
-                                <option value={480 / Math.floor(window.innerHeight * window.devicePixelRatio)}>
-                                    Low (480p)
-                                </option>
-                                <option value={720 / Math.floor(window.innerHeight * window.devicePixelRatio)}>
-                                    Medium (720p)
-                                </option>
-                                <option value={1080 / Math.floor(window.innerHeight * window.devicePixelRatio)}>
-                                    High (1080p)
-                                </option>
-                                <option value={1440 / Math.floor(window.innerHeight * window.devicePixelRatio)}>
-                                    Ultra (1440p)
-                                </option>
-                                <option
-                                    value={
-                                        Math.min(window.innerHeight, window.innerHeight * window.devicePixelRatio) /
-                                        Math.floor(window.innerHeight * window.devicePixelRatio)
-                                    }
-                                >
-                                    Auto ({Math.min(window.innerHeight, window.innerHeight * window.devicePixelRatio)}p)
-                                </option>
+                                <option value={0.25}>Low</option>
+                                <option value={0.5}>Medium</option>
+                                <option value={0.75}>High</option>
                                 <option value="1">
                                     Native ({Math.floor(window.innerHeight * window.devicePixelRatio)}p)
                                 </option>

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -4,6 +4,7 @@ import { Unity, useUnityContext } from 'react-unity-webgl';
 import { UnityContextHook } from 'react-unity-webgl/distribution/types/unity-context-hook';
 import { concat, fromValue, lazy, makeSubject, pipe, Subject, subscribe, tap } from 'wonka';
 import { useLocalStorage } from './use-localstorage';
+import { useUnityMap } from './use-unity-map';
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !!
@@ -65,28 +66,16 @@ const UnityInstance = () => {
             return;
         }
         const mapContainerBounds = mapContainer.getBoundingClientRect();
-        if (canvasHeight && canvasHeight > 0) {
-            const ratio = mapContainerBounds.width / mapContainerBounds.height;
-            const height = Math.min(mapContainerBounds.height, canvasHeight);
-            canvas.height = height;
-            canvas.width = height * ratio;
-        } else if (canvasHeight === -2) {
-            // "native" ... exactly match the browser/screen pixel density
-            // this will be the highest possible quality, but your GPU
-            // might struggle
-            canvas.height = mapContainerBounds.height * window.devicePixelRatio;
-            canvas.width = mapContainerBounds.width * window.devicePixelRatio;
-        } else {
-            // "auto" ... use the native browser pixel height for
-            // resolution, but never pack more pixels into the canvas than
-            // the actual screen pixels (ie if zoomed out or hiDPI)
-            // quirk: zooming IN will lower the res, which is weird, if you
-            // need to zoom in for some reason probably use "native"
-            canvas.height = Math.min(mapContainerBounds.height * window.devicePixelRatio, mapContainerBounds.height);
-            canvas.width = Math.min(mapContainerBounds.width * window.devicePixelRatio, mapContainerBounds.width);
-        }
+        canvas.height = mapContainerBounds.height * window.devicePixelRatio;
+        canvas.width = mapContainerBounds.width * window.devicePixelRatio;
+        if (unity.sendMessage && g.__globalUnityContext.getCanvasHeight)
+            unity.sendMessage(
+                'ResolutionManager',
+                'SetResoltion',
+                JSON.stringify(g.__globalUnityContext.getCanvasHeight())
+            );
         console.info(`canvas size updated to ${canvas.width}x${canvas.height}`);
-    }, [canvas, canvasHeight]);
+    }, [canvas, unity]);
 
     if (g.__globalUnityContext) {
         g.__globalUnityContext.setCanvasHeight = setCanvasHeight;

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -57,7 +57,7 @@ const UnityInstance = () => {
     const getCanvasHeight = useCallback(() => canvasHeight, [canvasHeight]);
 
     const onResize = useCallback(() => {
-        if (!canvas || !sendMessage) {
+        if (!canvas || !sendMessage || !canvasHeight) {
             return;
         }
         const mapContainer = typeof document !== 'undefined' ? document.getElementById('map-container') : undefined;
@@ -67,11 +67,9 @@ const UnityInstance = () => {
         const mapContainerBounds = mapContainer.getBoundingClientRect();
         canvas.height = mapContainerBounds.height * window.devicePixelRatio;
         canvas.width = mapContainerBounds.width * window.devicePixelRatio;
-        if (g.__globalUnityContext.getCanvasHeight) {
-            sendMessage('ResolutionManager', 'SetResolution', JSON.stringify(g.__globalUnityContext.getCanvasHeight()));
-        }
+        sendMessage('ResolutionManager', 'SetResolution', JSON.stringify(canvasHeight));
         console.info(`canvas size updated to ${canvas.width}x${canvas.height}`);
-    }, [canvas, sendMessage]);
+    }, [canvas, sendMessage, canvasHeight]);
 
     if (g.__globalUnityContext) {
         g.__globalUnityContext.setCanvasHeight = setCanvasHeight;

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -70,11 +70,11 @@ const UnityInstance = () => {
         if (unity.sendMessage && g.__globalUnityContext.getCanvasHeight)
             unity.sendMessage(
                 'ResolutionManager',
-                'SetResoltion',
+                'SetResolution',
                 JSON.stringify(g.__globalUnityContext.getCanvasHeight())
             );
         console.info(`canvas size updated to ${canvas.width}x${canvas.height}`);
-    }, [canvas, unity]);
+    }, [canvas, sendMessage]);
 
     if (g.__globalUnityContext) {
         g.__globalUnityContext.setCanvasHeight = setCanvasHeight;

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -67,8 +67,9 @@ const UnityInstance = () => {
         const mapContainerBounds = mapContainer.getBoundingClientRect();
         canvas.height = mapContainerBounds.height * window.devicePixelRatio;
         canvas.width = mapContainerBounds.width * window.devicePixelRatio;
-        if (g.__globalUnityContext.getCanvasHeight)
+        if (g.__globalUnityContext.getCanvasHeight) {
             sendMessage('ResolutionManager', 'SetResolution', JSON.stringify(g.__globalUnityContext.getCanvasHeight()));
+        }
         console.info(`canvas size updated to ${canvas.width}x${canvas.height}`);
     }, [canvas, sendMessage]);
 

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -4,7 +4,6 @@ import { Unity, useUnityContext } from 'react-unity-webgl';
 import { UnityContextHook } from 'react-unity-webgl/distribution/types/unity-context-hook';
 import { concat, fromValue, lazy, makeSubject, pipe, Subject, subscribe, tap } from 'wonka';
 import { useLocalStorage } from './use-localstorage';
-import { useUnityMap } from './use-unity-map';
 //
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !!

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -195,7 +195,7 @@ const UnityInstance = () => {
                 mediaMatcher.removeEventListener('change', onResize);
             }
         };
-    }, [onResize]);
+    }, [devicePixelRatio, onResize]);
 
     return (
         <Unity

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -53,7 +53,7 @@ const UnityInstance = () => {
     const { unityProvider, loadingProgression, addEventListener, removeEventListener, sendMessage } = unity;
 
     const canvas = canvasRef.current ? (canvasRef.current as HTMLCanvasElement) : null;
-    const [canvasHeight, setCanvasHeight] = useLocalStorage<number>(`ds/canvasHeight`, -1);
+    const [canvasHeight, setCanvasHeight] = useLocalStorage<number>(`ds/canvasHeight`, 0.5);
     const getCanvasHeight = useCallback(() => canvasHeight, [canvasHeight]);
 
     const onResize = useCallback(() => {
@@ -67,7 +67,7 @@ const UnityInstance = () => {
         const mapContainerBounds = mapContainer.getBoundingClientRect();
         canvas.height = mapContainerBounds.height * window.devicePixelRatio;
         canvas.width = mapContainerBounds.width * window.devicePixelRatio;
-        sendMessage('ResolutionManager', 'SetResolution', JSON.stringify(canvasHeight));
+        sendMessage('ResolutionManager', 'SetResolution', JSON.stringify(canvasHeight != -1 ? canvasHeight : 0.5));
         console.info(`canvas size updated to ${canvas.width}x${canvas.height}`);
     }, [canvas, sendMessage, canvasHeight]);
 

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -57,7 +57,7 @@ const UnityInstance = () => {
     const getCanvasHeight = useCallback(() => canvasHeight, [canvasHeight]);
 
     const onResize = useCallback(() => {
-        if (!canvas) {
+        if (!canvas || !sendMessage) {
             return;
         }
         const mapContainer = typeof document !== 'undefined' ? document.getElementById('map-container') : undefined;
@@ -67,12 +67,8 @@ const UnityInstance = () => {
         const mapContainerBounds = mapContainer.getBoundingClientRect();
         canvas.height = mapContainerBounds.height * window.devicePixelRatio;
         canvas.width = mapContainerBounds.width * window.devicePixelRatio;
-        if (unity.sendMessage && g.__globalUnityContext.getCanvasHeight)
-            unity.sendMessage(
-                'ResolutionManager',
-                'SetResolution',
-                JSON.stringify(g.__globalUnityContext.getCanvasHeight())
-            );
+        if (g.__globalUnityContext.getCanvasHeight)
+            sendMessage('ResolutionManager', 'SetResolution', JSON.stringify(g.__globalUnityContext.getCanvasHeight()));
         console.info(`canvas size updated to ${canvas.width}x${canvas.height}`);
     }, [canvas, sendMessage]);
 

--- a/frontend/src/hooks/use-unity-instance.tsx
+++ b/frontend/src/hooks/use-unity-instance.tsx
@@ -29,8 +29,8 @@ export interface UnityMessage {
 export interface GlobalUnityContext {
     ready: Subject<boolean>;
     unity: Subject<Partial<UnityContextHook>>;
-    setCanvasHeight?: (height: number) => void;
-    getCanvasHeight?: () => number;
+    setCanvasScale?: (height: number) => void;
+    getCanvasScale?: () => number;
     updateAspectRatio?: () => void;
 }
 
@@ -51,21 +51,21 @@ const UnityInstance = () => {
         productVersion: `blueprint`,
     });
     const { unityProvider, loadingProgression, addEventListener, removeEventListener, sendMessage } = unity;
-    const [canvasHeight, setCanvasHeight] = useLocalStorage<number>(`ds/canvasHeight`, 0.5);
-    const getCanvasHeight = useCallback(() => canvasHeight, [canvasHeight]);
+    const [canvasScale, setCanvasScale] = useLocalStorage<number>(`ds/canvasHeight`, 0.75);
+    const getCanvasHeight = useCallback(() => canvasScale, [canvasScale]);
     const [devicePixelRatio, setDevicePixelRatio] = useState(window.devicePixelRatio);
     const [ready, setReady] = useState(false);
 
     const onResize = useCallback(() => {
-        if (!sendMessage || !canvasHeight || !ready) {
+        if (!sendMessage || !canvasScale || !ready) {
             return;
         }
-        sendMessage('ComponentManager', 'SetResolution', canvasHeight != -1 ? canvasHeight : 0.5);
-    }, [sendMessage, canvasHeight, ready]);
+        sendMessage('ComponentManager', 'SetResolution', canvasScale < 0 || canvasScale > 1 ? 0.75 : canvasScale);
+    }, [sendMessage, canvasScale, ready]);
 
     if (g.__globalUnityContext) {
-        g.__globalUnityContext.setCanvasHeight = setCanvasHeight;
-        g.__globalUnityContext.getCanvasHeight = getCanvasHeight;
+        g.__globalUnityContext.setCanvasScale = setCanvasScale;
+        g.__globalUnityContext.getCanvasScale = getCanvasHeight;
         g.__globalUnityContext.updateAspectRatio = onResize;
     }
 

--- a/map/Assets/Scenes/MapScene.unity
+++ b/map/Assets/Scenes/MapScene.unity
@@ -200,6 +200,12 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 94391803}
   m_CullTransparentMesh: 1
+--- !u!1 &120160019 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6518314203603543956, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
+    type: 3}
+  m_PrefabInstance: {fileID: 6518314204280695803}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &324799505 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6518314204067571690, guid: 13c17ec3607f94f34a8d6fc7cf4300af,
@@ -522,6 +528,51 @@ Camera:
     type: 3}
   m_PrefabInstance: {fileID: 6518314204280695803}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &645472410
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 645472412}
+  - component: {fileID: 645472411}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &645472411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645472410}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 155f844e688464d83a56c3f779c585cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1911231969}
+--- !u!4 &645472412
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645472410}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &671949070
 GameObject:
   m_ObjectHideFlags: 0
@@ -964,6 +1015,51 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1178475790
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1178475792}
+  - component: {fileID: 1178475791}
+  m_Layer: 0
+  m_Name: ResolutionManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1178475791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1178475790}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ce761762c5a24385a34f63f760cb37a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  renderAsset: {fileID: 11400000, guid: 070e575c89e9a4df48f6c677420a6376, type: 2}
+--- !u!4 &1178475792
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1178475790}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1302764675
 GameObject:
   m_ObjectHideFlags: 0
@@ -1199,6 +1295,7 @@ MonoBehaviour:
   outlineRenderer: {fileID: -1408938807035450848, guid: 27dd91c15039b4701906e82860452235,
     type: 2}
   renderData: {fileID: 11400000, guid: 27dd91c15039b4701906e82860452235, type: 2}
+  renderAsset: {fileID: 11400000, guid: 070e575c89e9a4df48f6c677420a6376, type: 2}
   outlineMat: {fileID: 2100000, guid: 233d0c8a67eec4cadad678292f5c5bce, type: 2}
   falloffMultiplier: 15
   strokeCutoff: 0.2
@@ -1210,6 +1307,22 @@ Camera:
     type: 3}
   m_PrefabInstance: {fileID: 6518314204280695803}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1911231978
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 120160019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aa9d0374ba2644de80b1c55d4c46675, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EventMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_MaxRayIntersections: 0
 --- !u!1 &1922614420
 GameObject:
   m_ObjectHideFlags: 0
@@ -1226,7 +1339,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1922614421
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1379,7 +1492,8 @@ PrefabInstance:
       propertyPath: m_AllowMSAA
       value: 1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 1911231973, guid: 13c17ec3607f94f34a8d6fc7cf4300af, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 13c17ec3607f94f34a8d6fc7cf4300af, type: 3}
 --- !u!1 &6518314204280695804 stripped
 GameObject:

--- a/map/Assets/Scenes/MapScene.unity
+++ b/map/Assets/Scenes/MapScene.unity
@@ -1319,10 +1319,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9aa9d0374ba2644de80b1c55d4c46675, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_EventMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_MaxRayIntersections: 0
 --- !u!1 &1922614420
 GameObject:
   m_ObjectHideFlags: 0
@@ -1339,7 +1335,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1922614421
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/map/Assets/Scripts/CameraController.cs
+++ b/map/Assets/Scripts/CameraController.cs
@@ -70,7 +70,7 @@ public class CameraController : MonoBehaviour
             // Get the world position of the mouse cursor
             Ray ray = ScreenToWorld.instance.ScreenToRay(Input.mousePosition);
             float enter = 0;
-            if (m_Plane.Raycast(ray, out enter)) 
+            if (m_Plane.Raycast(ray, out enter))
             {
                 Vector3 mouseWorldPos = ray.origin + (ray.direction * enter);
 

--- a/map/Assets/Scripts/CameraController.cs
+++ b/map/Assets/Scripts/CameraController.cs
@@ -68,12 +68,11 @@ public class CameraController : MonoBehaviour
         if (Mathf.Abs(scrollInput) > Mathf.Epsilon)
         {
             // Get the world position of the mouse cursor
-            Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
-            //RaycastHit hit;
+            Ray ray = ScreenToWorld.instance.ScreenToRay(Input.mousePosition);
             float enter = 0;
-            if (m_Plane.Raycast(ray, out enter)) //  Physics.Raycast(ray, out hit))
+            if (m_Plane.Raycast(ray, out enter)) 
             {
-                Vector3 mouseWorldPos = ray.origin + (ray.direction * enter); // hit.point;
+                Vector3 mouseWorldPos = ray.origin + (ray.direction * enter);
 
                 // Calculate the new camera distance based on the scroll input
                 float currentCameraDistance = virtualCamera
@@ -169,8 +168,8 @@ public class CameraController : MonoBehaviour
         }
         if (Input.GetMouseButton(0))
         {
-            Ray mouseDownRay = mainCamera.ScreenPointToRay(mouseDownPos);
-            Ray currentMouseRay = mainCamera.ScreenPointToRay(Input.mousePosition);
+            Ray mouseDownRay = ScreenToWorld.instance.ScreenToRay(mouseDownPos);
+            Ray currentMouseRay = ScreenToWorld.instance.ScreenToRay(Input.mousePosition);
             float mouseDownDist = 0.0f;
             float currentMouseDist = 0.0f;
             m_Plane.Raycast(mouseDownRay, out mouseDownDist);
@@ -179,7 +178,7 @@ public class CameraController : MonoBehaviour
             Vector3 offset = (
                 mouseDownRay.GetPoint(mouseDownDist) - currentMouseRay.GetPoint(currentMouseDist)
             );
-            transform.position = camMouseDownPos + offset;
+            transform.position = (camMouseDownPos + offset);
             if (Vector3.Distance(camMouseDownPos, camMouseDownPos + offset) > _dragThreshold)
             {
                 hasDragged = true;

--- a/map/Assets/Scripts/Components/ComponentManager.cs
+++ b/map/Assets/Scripts/Components/ComponentManager.cs
@@ -68,6 +68,12 @@ public class ComponentManager : MonoBehaviour
         }
     }
 
+    public void SetResolution(float resolution)
+    {
+        Debug.Log($"ResolutionManager - SetResolution: {resolution}");
+        OutlineController.renderScale = Mathf.Clamp01(resolution);
+    }
+
     private IComponentManager GetManagerFor(ComponentMessage msg)
     {
         IComponentManager? manager =

--- a/map/Assets/Scripts/UI/OutlineController.cs
+++ b/map/Assets/Scripts/UI/OutlineController.cs
@@ -24,6 +24,7 @@ public class OutlineController : MonoBehaviour
 
     [SerializeField]
     UniversalRendererData? renderData;
+
     [SerializeField]
     UniversalRenderPipelineAsset renderAsset;
 
@@ -43,14 +44,22 @@ public class OutlineController : MonoBehaviour
 
     private static bool manualUpdate = false;
     private static float _renderScale = 1;
-    public static float renderScale { get { return _renderScale; } set { _renderScale = value; manualUpdate = true; } }
+    public static float renderScale
+    {
+        get { return _renderScale; }
+        set
+        {
+            _renderScale = value;
+            manualUpdate = true;
+        }
+    }
 
     int sWidth,
         sHeight;
     int currentZoom = 0;
 
     float updateTimer = 0;
-    #if !UNITY_EDITOR || CHECK_RESOLUTION_SCALE
+#if !UNITY_EDITOR || CHECK_RESOLUTION_SCALE
     private RenderTexture _screenTexture;
 #endif
     private RenderTexture _outlineTexture;

--- a/map/Assets/Scripts/Utility/CustomPhysicsRaycaster.cs
+++ b/map/Assets/Scripts/Utility/CustomPhysicsRaycaster.cs
@@ -19,7 +19,7 @@ public class CustomPhysicsRaycaster : MonoBehaviour
     void Update()
     {
         // Prepare the raycast
-        Ray ray = ScreenToWorld.instance.ScreenToRay(Input.mousePosition);// cam.ScreenPointToRay(Input.mousePosition);
+        Ray ray = ScreenToWorld.instance.ScreenToRay(Input.mousePosition); // cam.ScreenPointToRay(Input.mousePosition);
         RaycastHit hit;
 
         // Perform the raycast
@@ -64,7 +64,8 @@ public class CustomPhysicsRaycaster : MonoBehaviour
         }
     }
 
-    private GameObject GetParentWithHandler<T>(GameObject child) where T : IEventSystemHandler
+    private GameObject GetParentWithHandler<T>(GameObject child)
+        where T : IEventSystemHandler
     {
         // Check if the current hit object's parent has the event handler
         // If so, return the parent object instead
@@ -74,7 +75,8 @@ public class CustomPhysicsRaycaster : MonoBehaviour
 
     private void ProcessPointerEnter(GameObject hitObject)
     {
-        if (hitObject == null) return;
+        if (hitObject == null)
+            return;
 
         // Execute the pointer enter event
         ExecuteEvents.Execute<IPointerEnterHandler>(
@@ -86,7 +88,8 @@ public class CustomPhysicsRaycaster : MonoBehaviour
 
     private void ProcessPointerExit(GameObject lastObject)
     {
-        if (lastObject == null) return;
+        if (lastObject == null)
+            return;
 
         // Execute the pointer exit event
         ExecuteEvents.Execute<IPointerExitHandler>(
@@ -98,7 +101,8 @@ public class CustomPhysicsRaycaster : MonoBehaviour
 
     private void ProcessPointerClick(GameObject clickedObject)
     {
-        if (clickedObject == null) return;
+        if (clickedObject == null)
+            return;
 
         // Execute the pointer click event
         ExecuteEvents.Execute<IPointerClickHandler>(

--- a/map/Assets/Scripts/Utility/CustomPhysicsRaycaster.cs
+++ b/map/Assets/Scripts/Utility/CustomPhysicsRaycaster.cs
@@ -1,0 +1,110 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class CustomPhysicsRaycaster : MonoBehaviour
+{
+    private Camera cam;
+
+    // Object that the pointer is currently over
+    private GameObject currentPointerEnter;
+
+    // Object that was clicked
+    private GameObject currentPointerDown;
+
+    void Start()
+    {
+        cam = GetComponent<Camera>();
+    }
+
+    void Update()
+    {
+        // Prepare the raycast
+        Ray ray = ScreenToWorld.instance.ScreenToRay(Input.mousePosition);// cam.ScreenPointToRay(Input.mousePosition);
+        RaycastHit hit;
+
+        // Perform the raycast
+        if (Physics.Raycast(ray, out hit))
+        {
+            // Process enter and exit events
+            GameObject hitObject = hit.collider.gameObject;
+            GameObject parentHandler = GetParentWithHandler<IPointerEnterHandler>(hitObject);
+
+            if (currentPointerEnter != parentHandler)
+            {
+                // Exited the previous object
+                ProcessPointerExit(currentPointerEnter);
+
+                // Entered a new object
+                currentPointerEnter = parentHandler;
+                ProcessPointerEnter(currentPointerEnter);
+            }
+
+            // Process click events
+            if (Input.GetMouseButtonDown(0))
+            {
+                currentPointerDown = parentHandler;
+            }
+
+            if (Input.GetMouseButtonUp(0) && currentPointerDown == parentHandler)
+            {
+                ProcessPointerClick(currentPointerDown);
+            }
+        }
+        else if (currentPointerEnter)
+        {
+            // No hit, and we had an object under the pointer before
+            ProcessPointerExit(currentPointerEnter);
+            currentPointerEnter = null;
+
+            // Clear click state if needed
+            if (Input.GetMouseButtonUp(0))
+            {
+                currentPointerDown = null;
+            }
+        }
+    }
+
+    private GameObject GetParentWithHandler<T>(GameObject child) where T : IEventSystemHandler
+    {
+        // Check if the current hit object's parent has the event handler
+        // If so, return the parent object instead
+        T handler = child.GetComponentInParent<T>();
+        return handler != null ? (handler as MonoBehaviour).gameObject : child;
+    }
+
+    private void ProcessPointerEnter(GameObject hitObject)
+    {
+        if (hitObject == null) return;
+
+        // Execute the pointer enter event
+        ExecuteEvents.Execute<IPointerEnterHandler>(
+            hitObject,
+            new PointerEventData(EventSystem.current),
+            ExecuteEvents.pointerEnterHandler
+        );
+    }
+
+    private void ProcessPointerExit(GameObject lastObject)
+    {
+        if (lastObject == null) return;
+
+        // Execute the pointer exit event
+        ExecuteEvents.Execute<IPointerExitHandler>(
+            lastObject,
+            new PointerEventData(EventSystem.current),
+            ExecuteEvents.pointerExitHandler
+        );
+    }
+
+    private void ProcessPointerClick(GameObject clickedObject)
+    {
+        if (clickedObject == null) return;
+
+        // Execute the pointer click event
+        ExecuteEvents.Execute<IPointerClickHandler>(
+            clickedObject,
+            new PointerEventData(EventSystem.current),
+            ExecuteEvents.pointerClickHandler
+        );
+    }
+}

--- a/map/Assets/Scripts/Utility/CustomPhysicsRaycaster.cs.meta
+++ b/map/Assets/Scripts/Utility/CustomPhysicsRaycaster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9aa9d0374ba2644de80b1c55d4c46675
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/map/Assets/Scripts/Utility/ResolutionManager.cs
+++ b/map/Assets/Scripts/Utility/ResolutionManager.cs
@@ -7,6 +7,7 @@ public class ResolutionManager : MonoBehaviour
 {
     [SerializeField]
     UniversalRenderPipelineAsset renderAsset;
+
     [ContextMenu("Set Resolution Low")]
     public void SetLowResolution()
     {

--- a/map/Assets/Scripts/Utility/ResolutionManager.cs
+++ b/map/Assets/Scripts/Utility/ResolutionManager.cs
@@ -11,10 +11,10 @@ public class ResolutionManager : MonoBehaviour
     [ContextMenu("Set Resolution Low")]
     public void SetLowResolution()
     {
-        SetResoltion("0.1");
+        SetResolution("0.1");
     }
 
-    public void SetResoltion(string resolution)
+    public void SetResolution(string resolution)
     {
         Debug.Log($"ResolutionManager - SetResolution: {resolution}");
         OutlineController.renderScale = Mathf.Clamp01(float.Parse(resolution));

--- a/map/Assets/Scripts/Utility/ResolutionManager.cs
+++ b/map/Assets/Scripts/Utility/ResolutionManager.cs
@@ -11,12 +11,12 @@ public class ResolutionManager : MonoBehaviour
     [ContextMenu("Set Resolution Low")]
     public void SetLowResolution()
     {
-        SetResolution("0.1");
+        SetResolution(0.1f);
     }
 
-    public void SetResolution(string resolution)
+    public void SetResolution(float resolution)
     {
         Debug.Log($"ResolutionManager - SetResolution: {resolution}");
-        OutlineController.renderScale = Mathf.Clamp01(float.Parse(resolution));
+        OutlineController.renderScale = Mathf.Clamp01(resolution);
     }
 }

--- a/map/Assets/Scripts/Utility/ResolutionManager.cs
+++ b/map/Assets/Scripts/Utility/ResolutionManager.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+public class ResolutionManager : MonoBehaviour
+{
+    [SerializeField]
+    UniversalRenderPipelineAsset renderAsset;
+    [ContextMenu("Set Resolution Low")]
+    public void SetLowResolution()
+    {
+        SetResoltion("0.1");
+    }
+
+    public void SetResoltion(string resolution)
+    {
+        Debug.Log($"ResolutionManager - SetResolution: {resolution}");
+        OutlineController.renderScale = Mathf.Clamp01(float.Parse(resolution));
+    }
+}

--- a/map/Assets/Scripts/Utility/ResolutionManager.cs.meta
+++ b/map/Assets/Scripts/Utility/ResolutionManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ce761762c5a24385a34f63f760cb37a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/map/Assets/Scripts/Utility/ScreenToWorld.cs
+++ b/map/Assets/Scripts/Utility/ScreenToWorld.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ScreenToWorld : MonoBehaviour
+{
+    public static ScreenToWorld instance;
+
+    [SerializeField]
+    Camera cam;
+
+    private void Awake()
+    {
+        instance = this;
+    }
+
+    public Ray ScreenToRay(Vector3 screenPos)
+    {
+        // Convert the mouse position to normalized device coordinates (NDC)
+        screenPos.x = (screenPos.x / Screen.width) * 2f - 1f;
+        screenPos.y = (screenPos.y / Screen.height) * 2f - 1f;
+        screenPos.z = 0f; // Set to the near clip plane
+
+        // Get the view projection matrix
+        Matrix4x4 viewProjectionMatrix = cam.projectionMatrix * cam.worldToCameraMatrix;
+        // Invert the view projection matrix
+        Matrix4x4 inverseViewProjection = viewProjectionMatrix.inverse;
+
+        // Unproject the NDC to world space at the near clip plane
+        Vector3 worldNear = inverseViewProjection.MultiplyPoint(new Vector3(screenPos.x, screenPos.y, -1f));
+
+        // Unproject the NDC to world space at the far clip plane
+        Vector3 worldFar = inverseViewProjection.MultiplyPoint(new Vector3(screenPos.x, screenPos.y, 1f));
+
+        // Create the ray
+        Vector3 direction = (worldFar - worldNear).normalized;
+        return new Ray(worldNear, direction);
+    }
+}

--- a/map/Assets/Scripts/Utility/ScreenToWorld.cs
+++ b/map/Assets/Scripts/Utility/ScreenToWorld.cs
@@ -27,10 +27,14 @@ public class ScreenToWorld : MonoBehaviour
         Matrix4x4 inverseViewProjection = viewProjectionMatrix.inverse;
 
         // Unproject the NDC to world space at the near clip plane
-        Vector3 worldNear = inverseViewProjection.MultiplyPoint(new Vector3(screenPos.x, screenPos.y, -1f));
+        Vector3 worldNear = inverseViewProjection.MultiplyPoint(
+            new Vector3(screenPos.x, screenPos.y, -1f)
+        );
 
         // Unproject the NDC to world space at the far clip plane
-        Vector3 worldFar = inverseViewProjection.MultiplyPoint(new Vector3(screenPos.x, screenPos.y, 1f));
+        Vector3 worldFar = inverseViewProjection.MultiplyPoint(
+            new Vector3(screenPos.x, screenPos.y, 1f)
+        );
 
         // Create the ray
         Vector3 direction = (worldFar - worldNear).normalized;

--- a/map/Assets/Scripts/Utility/ScreenToWorld.cs.meta
+++ b/map/Assets/Scripts/Utility/ScreenToWorld.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 155f844e688464d83a56c3f779c585cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
In order to improve performance on lower-end devices, Farms added in a resolution scaling system which helped to reduce the graphical load.
This worked well, but introduced a visual issue with the map element outlines, which would appear to be thicker than they're supposed to be.

resolving the issue turned out to be trickier than i expected, but the tldr is that I switched the resolution scaling to happen directly to the camera's target texture, rather than to the canvas web element.
This did have a side effect that meant that various Built-in Unity camera functions no longer worked as expected, so I had to implement custom versions of those functions to remedy that.