### PR TITLE
Added bag next to registration tower with IDs and Letters

### DIFF
--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -23,17 +23,19 @@ export const OneLiner = z.string().min(3).max(180);
 
 export const Atom = z.number().gte(0).lt(4294967295);
 
-export const Slot = z.object({
-    name: z.string(),
-    quantity: z.number().gte(0).lte(100),
-}).superRefine(({ name, quantity }, ctx) => {
-    if (quantity && quantity > 0 && !name) {
-        ctx.addIssue({
-            code: "custom",
-            message: "Name required for item"
-        });
-    }
-});
+export const Slot = z
+    .object({
+        name: z.string(),
+        quantity: z.number().gte(0).lte(100),
+    })
+    .superRefine(({ name, quantity }, ctx) => {
+        if (quantity && quantity > 0 && !name) {
+            ctx.addIssue({
+                code: 'custom',
+                message: 'Name required for item',
+            });
+        }
+    });
 
 export const Coords = z.tuple([z.number(), z.number(), z.number()]);
 
@@ -171,6 +173,17 @@ export const Tile = z.object({
         .optional(),
 });
 
+export const BagSpec = z.object({
+    location: Coords,
+    items: Slot.array().max(4).optional(),
+});
+
+export const Bag = z.object({
+    kind: z.literal('Bag'),
+    spec: BagSpec,
+    status: z.object({}).optional(),
+});
+
 export const MobileUnitSpec = z.object({
     name: Name,
 });
@@ -286,15 +299,21 @@ export const QuestSpec = z.object({
 export const Quest = z.object({
     kind: z.literal('Quest'),
     spec: QuestSpec,
-    status: z
-        .object({
-        })
-        .optional(),
+    status: z.object({}).optional(),
 });
 
 // -- //
 
-export const Manifest = z.discriminatedUnion('kind', [BuildingKind, Item, Building, Tile, MobileUnit, Player, Quest]);
+export const Manifest = z.discriminatedUnion('kind', [
+    BuildingKind,
+    Item,
+    Building,
+    Tile,
+    MobileUnit,
+    Player,
+    Quest,
+    Bag,
+]);
 
 export const ManifestDocument = z.object({
     filename: z.string(),
@@ -316,7 +335,10 @@ export const parseManifestDocuments = (filedata: string, filename?: string): z.i
                 throw new Error(
                     result.error.issues
                         .map(
-                            (iss) => `invalid manifest ${filename}: ${content.kind || ''} ${iss.path.join('.')} field invalid: ${iss.message}`
+                            (iss) =>
+                                `invalid manifest ${filename}: ${content.kind || ''} ${iss.path.join(
+                                    '.'
+                                )} field invalid: ${iss.message}`
                         )
                         .join('\n\n')
                 );

--- a/contracts/src/fixtures/IntroOrientation/map.yaml
+++ b/contracts/src/fixtures/IntroOrientation/map.yaml
@@ -15,3 +15,13 @@ kind: Building
 spec:
   name: Deletion Supplies
   location: [-12, 16, -4]
+
+---
+kind: Bag
+spec:
+  location: [6, -2, -4]
+  items:
+    - name: Acceptance Letter
+      quantity: 100
+    - name: ID Card
+      quantity: 100

--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -72,7 +72,9 @@ contract CheatsRule is Rule {
         for (uint8 i = 0; i < slotContents.length; i++) {
             state.setItemSlot(bag, i, slotContents[i], slotBalances[i]);
         }
-        state.setOwner(bag, Node.Player(owner));
+        if (owner != address(0)) {
+            state.setOwner(bag, Node.Player(owner));
+        }
         state.setEquipSlot(equipee, equipSlot, bag);
     }
 


### PR DESCRIPTION
# What

We can now spawn bags via yaml. I am spawning a bag that contains 100 x IDs and 100 x Registration letters

![image](https://github.com/playmint/ds/assets/51167118/dbede1a7-4e59-4315-b718-326d22a2d976)

# Why

So if any pinches someone elses registration letter / ID during demonstration there are some spares they can take