### PR TITLE
Quest shows a minimum of 5% complete

### DIFF
--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -208,7 +208,7 @@ const StyledProgressBar = styled.div`
         > .inner {
             position: absolute;
             height: 100%;
-            width: ${Math.max(p, 0.01) * 100}%;
+            width: ${Math.max(p, 0.05) * 100}%;
             border-radius: 1rem;
             border: 0.2rem solid;
 


### PR DESCRIPTION
# What

We are now showing the progress bar at 5% if it's empty so that the zero state is a round orange circle

<img width="458" alt="image" src="https://github.com/playmint/ds/assets/51167118/c069fd07-e089-4368-a84b-16baccdc802a">

# Why

We want to show that the bar will fill up and so it matches the style of outlined bars it needs to be at least 5% so it's circular

resolves: #892