### PR TITLE
Fix transfer of combat rewards

### DIFF
--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -243,6 +243,7 @@ contract CombatRule is Rule {
                 // Create bag using a combination of sessionID and entityID
                 // TODO: Don't give buildings rewards? (leaving in as a sink for now)
                 state.set(Rel.Equip.selector, i, sessionID, Node.RewardBag(sessionID, winnerStates[i].entityID), 0); // Session -> Bag
+                _setBagOwner(state, Node.RewardBag(sessionID, winnerStates[i].entityID), winnerStates[i].entityID);
 
                 uint256 damagePercent = (winnerStates[i].damageInflicted * 100) / _getTotalDamageInflicted(winnerStates);
 
@@ -757,6 +758,16 @@ contract CombatRule is Rule {
     function _requirePlayerOwnedMobileUnit(State state, bytes24 mobileUnit, bytes24 player) private view {
         if (state.getOwner(mobileUnit) != player) {
             revert("MobileUnitNotOwnedByPlayer");
+        }
+    }
+
+    function _setBagOwner(State state, bytes24 bag, bytes24 entityID) private {
+        require(bytes4(bag) == Kind.Bag.selector, "Owner set fail - not a bag node");
+
+        if (bytes4(entityID) == Kind.MobileUnit.selector) {
+            state.setOwner(bag, state.getOwner(entityID));
+        } else {
+            state.setOwner(bag, entityID);
         }
     }
 

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -186,11 +186,9 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                 }
 
                 // Tile bags
-                const selectedBags: SelectedBag[] = getBagsAtEquipee(world?.bags || [], t).map(
-                    (bag, equipIndex): SelectedBag => {
-                        return { equipIndex, bag, ownerId: t.id, parentTile: t };
-                    }
-                );
+                const selectedBags: SelectedBag[] = getBagsAtEquipee(world?.bags || [], t).map((bag): SelectedBag => {
+                    return { equipIndex: bag.equipee?.key || 0, bag, ownerId: t.id, parentTile: t };
+                });
 
                 // Combat rewards
                 if (selectedMobileUnit) {
@@ -207,9 +205,9 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                                 const truncatedMobileUnitID = BigInt(selectedMobileUnit.id) & mobileUnitIdMask;
                                 return bagMobileUnitID === truncatedMobileUnitID;
                             })
-                            ?.map((bag, equipIndex): SelectedBag => {
+                            ?.map((bag): SelectedBag => {
                                 return {
-                                    equipIndex,
+                                    equipIndex: bag.equipee?.key || 0,
                                     bag,
                                     ownerId: cs.id, // Very confusing because I expected the `ownerId` to be the unit's ID
                                     parentTile: t,


### PR DESCRIPTION
# What

The bag shown for the rewards was correct however the equip slot set for the bag inventory was incorrect so rewards were being transferred out of the wrong bag.

Fixed this by using the equip key found on the equipee instead of using the array index as the order in which the bags appear in the filtered list aren't guaranteed to be in equip key order also there isn't any guarantee that the keys are consecutive. 

Reward bags didn't have their owner set i.e. they were public which is why it was possible to trasfer from a bag that wasn't yours! I have also fixed this by setting the owner of the bag to the owner of the unit if reward belongs to unit or directly to the building node if the reward belongs to the building 

# Test

Build something next to the control tower, stand on the control tower and attack the building. The rewards from the bag should be transferrable to your inventory

resolves: #899