### PR TITLE
Workshop bags

### DIFF
--- a/contracts/src/fixtures/Creation/map.yaml
+++ b/contracts/src/fixtures/Creation/map.yaml
@@ -9,3 +9,116 @@ kind: Building
 spec:
   name: Very Important Factory
   location: [-23, 2, 21]
+
+---
+kind: Bag
+spec:
+  location: [-26, 6, 20]
+  items:
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+
+---
+kind: Bag
+spec:
+  location: [-26, 5, 21]
+  items:
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+
+---
+kind: Bag
+spec:
+  location: [-26, 4, 22]
+  items:
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+
+---
+kind: Bag
+spec:
+  location: [-26, 3, 23]
+  items:
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+
+---
+kind: Bag
+spec:
+  location: [-27, 6, 20]
+  items:
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+
+---
+kind: Bag
+spec:
+  location: [-27, 5, 21]
+  items:
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+
+---
+kind: Bag
+spec:
+  location: [-27, 4, 22]
+  items:
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+
+---
+kind: Bag
+spec:
+  location: [-27, 3, 23]
+  items:
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+    - name: Very Important Stuff
+      quantity: 100
+    - name: Squircle
+      quantity: 100
+

--- a/contracts/src/fixtures/IntroOrientation/map.yaml
+++ b/contracts/src/fixtures/IntroOrientation/map.yaml
@@ -19,7 +19,7 @@ spec:
 ---
 kind: Bag
 spec:
-  location: [6, -2, -4]
+  location: [4, 0, -4]
   items:
     - name: Acceptance Letter
       quantity: 1
@@ -33,7 +33,7 @@ spec:
 ---
 kind: Bag
 spec:
-  location: [5, -2, -3]
+  location: [5, 0, -5]
   items:
     - name: Acceptance Letter
       quantity: 1
@@ -47,7 +47,7 @@ spec:
 ---
 kind: Bag
 spec:
-  location: [7, -2, -5]
+  location: [6, -1, -5]
   items:
     - name: Acceptance Letter
       quantity: 1
@@ -61,7 +61,7 @@ spec:
 ---
 kind: Bag
 spec:
-  location: [4, -1, -3]
+  location: [6, 0, -6]
   items:
     - name: Acceptance Letter
       quantity: 1


### PR DESCRIPTION
### What
1. Added bags with Very Important Stuff and Squircles near the creation quest

![image](https://github.com/playmint/ds/assets/90266137/1b2471cb-2190-4951-9994-9f7f0bbb994b)

2. Moved the id card bags into the trees

![image](https://github.com/playmint/ds/assets/90266137/8586d917-ca2d-4165-a2ec-3ea76f8d0044)

### Why
1. So workshop participants will have access to the inputs to their buildings to repeat test them after editing code
2. Its funnier to "hide" the bags with IDs in the trees


### How
Bag configs in the quests' map.yaml files