### PR TITLE
Fix forge fmt

### DIFF
--- a/.github/workflows/check-contracts-test.yaml
+++ b/.github/workflows/check-contracts-test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: setup
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
 
       - name: build
         working-directory: contracts


### PR DESCRIPTION
Matching the github action foundry version with the Dockerfile so that 'forge fmt' does not get out of sync