### PR TITLE
Example of state storage

### DIFF
--- a/contracts/src/example-plugins/StateStorage/StateStorage.js
+++ b/contracts/src/example-plugins/StateStorage/StateStorage.js
@@ -16,11 +16,14 @@ export default async function update(state) {
     //    && unitIsFriendly(state, selectedBuilding)
 
     console.log(selectedBuilding);
+
     const incrementHex = getData(selectedBuilding, "increment");
     const increment =
         typeof incrementHex === "string" && parseInt(incrementHex, 16);
 
     const unitId = getData(selectedBuilding, "actor");
+
+    const boolVal = getDataBool(selectedBuilding, "boolVal");
 
     const updateData = () => {
         const mobileUnit = getMobileUnit(state);
@@ -52,6 +55,8 @@ export default async function update(state) {
                             ${unitId ? unitId.slice(-4) : "0x0"}
                             <h3>Increment</h3>
                             ${increment}
+                            <h3>Bool val</h3>
+                            ${boolVal}
                         `,
                         buttons: [
                             {
@@ -125,6 +130,11 @@ function inputsAreCorrect(state, building) {
 
 function getData(buildingInstance, key) {
     return getKVPs(buildingInstance)[key];
+}
+
+function getDataBool(buildingInstance, key) {
+    var hexVal = getData(buildingInstance, key);
+    return typeof hexVal === "string" ? parseInt(hexVal, 16) == 1 : false;
 }
 
 function getKVPs(buildingInstance) {

--- a/contracts/src/example-plugins/StateStorage/StateStorage.js
+++ b/contracts/src/example-plugins/StateStorage/StateStorage.js
@@ -1,0 +1,181 @@
+import ds from "downstream";
+
+export default async function update(state) {
+    // uncomment this to browse the state object in browser console
+    // this will be logged when selecting a unit and then selecting an instance of this building
+    // logState(state);
+
+    const selectedTile = getSelectedTile(state);
+    const selectedBuilding =
+        selectedTile && getBuildingOnTile(state, selectedTile);
+    const canCraft =
+        selectedBuilding && inputsAreCorrect(state, selectedBuilding);
+    // uncomment this to be restrictve about which units can craft
+    // this is a client only check - to enforce it in contracts make
+    // similar changes in BasicFactory.sol
+    //    && unitIsFriendly(state, selectedBuilding)
+
+    console.log(selectedBuilding);
+    const incrementHex = getData(selectedBuilding, "increment");
+    const increment =
+        typeof incrementHex === "string" && parseInt(incrementHex, 16);
+
+    const unitId = getData(selectedBuilding, "actor");
+
+    const updateData = () => {
+        const mobileUnit = getMobileUnit(state);
+
+        if (!mobileUnit) {
+            console.log("no selected unit");
+            return;
+        }
+
+        ds.dispatch({
+            name: "BUILDING_USE",
+            args: [selectedBuilding.id, mobileUnit.id, []],
+        });
+    };
+
+    return {
+        version: 1,
+        components: [
+            {
+                id: "state-storage-test",
+                type: "building",
+                content: [
+                    {
+                        id: "default",
+                        type: "inline",
+                        html: `
+                            <p>Pressing the 'Update Data' button will set the variable 'actor' to the selected MobileUnit and will increment the variable 'increment'</p>
+                            <h3>Last called by mobile unit:</h3>
+                            ${unitId ? unitId.slice(-4) : "0x0"}
+                            <h3>Increment</h3>
+                            ${increment}
+                        `,
+                        buttons: [
+                            {
+                                text: "Update Data",
+                                type: "action",
+                                action: updateData,
+                                disabled: !canCraft,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+function getMobileUnit(state) {
+    return state?.selected?.mobileUnit;
+}
+
+function getSelectedTile(state) {
+    const tiles = state?.selected?.tiles || {};
+    return tiles && tiles.length === 1 ? tiles[0] : undefined;
+}
+
+function getBuildingOnTile(state, tile) {
+    return (state?.world?.buildings || []).find(
+        (b) => tile && b.location?.tile?.id === tile.id,
+    );
+}
+
+// returns an array of items the building expects as input
+function getRequiredInputItems(building) {
+    return building?.kind?.inputs || [];
+}
+
+// search through all the bags in the world to find those belonging to this building
+function getBuildingBags(state, building) {
+    return building
+        ? (state?.world?.bags || []).filter(
+              (bag) => bag.equipee?.node.id === building.id,
+          )
+        : [];
+}
+
+// get building input slots
+function getInputSlots(state, building) {
+    // inputs are the bag with key 0 owned by the building
+    const buildingBags = getBuildingBags(state, building);
+    const inputBag = buildingBags.find((bag) => bag.equipee.key === 0);
+
+    // slots used for crafting have sequential keys startng with 0
+    return inputBag && inputBag.slots.sort((a, b) => a.key - b.key);
+}
+
+// are the required craft input items in the input slots?
+function inputsAreCorrect(state, building) {
+    const requiredInputItems = getRequiredInputItems(building);
+    const inputSlots = getInputSlots(state, building);
+
+    return (
+        inputSlots &&
+        inputSlots.length >= requiredInputItems.length &&
+        requiredInputItems.every(
+            (requiredItem) =>
+                inputSlots[requiredItem.key].item.id == requiredItem.item.id &&
+                inputSlots[requiredItem.key].balance == requiredItem.balance,
+        )
+    );
+}
+
+function getData(buildingInstance, key) {
+    return getKVPs(buildingInstance)[key];
+}
+
+function getKVPs(buildingInstance) {
+    return buildingInstance.allData.reduce((kvps, data) => {
+        kvps[data.name] = data.value;
+        return kvps;
+    }, {});
+}
+
+function logState(state) {
+    console.log("State sent to pluging:", state);
+}
+
+const friendlyPlayerAddresses = [
+    // 0x402462EefC217bf2cf4E6814395E1b61EA4c43F7
+];
+
+function unitIsFriendly(state, selectedBuilding) {
+    const mobileUnit = getMobileUnit(state);
+    return (
+        unitIsBuildingOwner(mobileUnit, selectedBuilding) ||
+        unitIsBuildingAuthor(mobileUnit, selectedBuilding) ||
+        friendlyPlayerAddresses.some((addr) =>
+            unitOwnerConnectedToWallet(state, mobileUnit, addr),
+        )
+    );
+}
+
+function unitIsBuildingOwner(mobileUnit, selectedBuilding) {
+    //console.log('unit owner id:',  mobileUnit?.owner?.id, 'building owner id:', selectedBuilding?.owner?.id);
+    return (
+        mobileUnit?.owner?.id &&
+        mobileUnit?.owner?.id === selectedBuilding?.owner?.id
+    );
+}
+
+function unitIsBuildingAuthor(mobileUnit, selectedBuilding) {
+    //console.log('unit owner id:',  mobileUnit?.owner?.id, 'building author id:', selectedBuilding?.kind?.owner?.id);
+    return (
+        mobileUnit?.owner?.id &&
+        mobileUnit?.owner?.id === selectedBuilding?.kind?.owner?.id
+    );
+}
+
+function unitOwnerConnectedToWallet(state, mobileUnit, walletAddress) {
+    //console.log('Checking player:',  state?.player, 'controls unit', mobileUnit, walletAddress);
+    return (
+        mobileUnit?.owner?.id == state?.player?.id &&
+        state?.player?.addr == walletAddress
+    );
+}
+
+// the source for this code is on github where you can find other example buildings:
+// https://github.com/playmint/ds/tree/main/contracts/src/example-plugins

--- a/contracts/src/example-plugins/StateStorage/StateStorage.sol
+++ b/contracts/src/example-plugins/StateStorage/StateStorage.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {State} from "cog/IState.sol";
+import {Schema} from "@ds/schema/Schema.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+using Schema for State;
+
+contract BasicFactory is BuildingKind {
+    function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory /*payload*/ ) public {
+        // ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+        State state = GetState(ds);
+        state.setData(buildingInstance, "actor", bytes32(abi.encodePacked(uint64(0), actor))); // Added 64 bits (8 bytes) of padding to the 24 byte ID
+
+        uint256 increment = uint256(state.getData(buildingInstance, "increment"));
+        state.setData(buildingInstance, "increment", bytes32(increment + 1));
+        // state.annotate(buildingInstance, "testAnn", "Test annotation");
+    }
+
+    // version of use that restricts crafting to building owner, author or allow list
+    // these restrictions will not be reflected in the UI unless you make
+    // similar changes in BasicFactory.js
+    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public {
+        State state = GetState(ds);
+        CheckIsFriendlyUnit(state, actor, buildingInstance);
+
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }*/
+
+    // version of use that restricts crafting to units carrying a certain item
+    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public {
+        // require carrying an idCard
+        // you can change idCardItemId to another item id
+        CheckIsCarryingItem(state, actor, idCardItemId);
+    
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }*/
+
+    function GetState(Game ds) internal returns (State) {
+        return ds.getState();
+    }
+
+    function GetBuildingOwner(State state, bytes24 buildingInstance) internal view returns (bytes24) {
+        return state.getOwner(buildingInstance);
+    }
+
+    function GetBuildingAuthor(State state, bytes24 buildingInstance) internal view returns (bytes24) {
+        bytes24 buildingKind = state.getBuildingKind(buildingInstance);
+        return state.getOwner(buildingKind);
+    }
+
+    function CheckIsFriendlyUnit(State state, bytes24 actor, bytes24 buildingInstance) internal view {
+        require(
+            UnitOwnsBuilding(state, actor, buildingInstance) || UnitAuthoredBuilding(state, actor, buildingInstance)
+                || UnitOwnedByFriendlyPlayer(state, actor),
+            "Unit does not have permission to use this building"
+        );
+    }
+
+    function UnitOwnsBuilding(State state, bytes24 actor, bytes24 buildingInstance) internal view returns (bool) {
+        return state.getOwner(actor) == GetBuildingOwner(state, buildingInstance);
+    }
+
+    function UnitAuthoredBuilding(State state, bytes24 actor, bytes24 buildingInstance) internal view returns (bool) {
+        return state.getOwner(actor) == GetBuildingAuthor(state, buildingInstance);
+    }
+
+    address[] private friendlyPlayerAddresses = [0x402462EefC217bf2cf4E6814395E1b61EA4c43F7];
+
+    function UnitOwnedByFriendlyPlayer(State state, bytes24 actor) internal view returns (bool) {
+        address ownerAddress = state.getOwnerAddress(actor);
+        for (uint256 i = 0; i < friendlyPlayerAddresses.length; i++) {
+            if (friendlyPlayerAddresses[i] == ownerAddress) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // use cli command 'ds get items' for all current possible ids.
+    bytes24 idCardItemId = 0x6a7a67f0b29554460000000100000064000000640000004c;
+
+    function CheckIsCarryingItem(State state, bytes24 actor, bytes24 item) internal view {
+        require((UnitIsCarryingItem(state, actor, item)), "Unit must be carrying specified item");
+    }
+
+    function UnitIsCarryingItem(State state, bytes24 actor, bytes24 item) internal view returns (bool) {
+        for (uint8 bagIndex = 0; bagIndex < 2; bagIndex++) {
+            bytes24 bag = state.getEquipSlot(actor, bagIndex);
+            if (bag != 0) {
+                for (uint8 slot = 0; slot < 4; slot++) {
+                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
+                    if (resource == item) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/contracts/src/example-plugins/StateStorage/StateStorage.sol
+++ b/contracts/src/example-plugins/StateStorage/StateStorage.sol
@@ -17,27 +17,13 @@ contract BasicFactory is BuildingKind {
 
         uint256 increment = uint256(state.getData(buildingInstance, "increment"));
         state.setData(buildingInstance, "increment", bytes32(increment + 1));
-        // state.annotate(buildingInstance, "testAnn", "Test annotation");
+
+        // TODO: Why doesn't getDataBool work? I'm having trouble deploying the contract
+        // bool b = state.getDataBool(buildingInstance, "boolVal");
+
+        bool b = uint256(state.getData(buildingInstance, "boolVal")) == 1;
+        state.setData(buildingInstance, "boolVal", !b);
     }
-
-    // version of use that restricts crafting to building owner, author or allow list
-    // these restrictions will not be reflected in the UI unless you make
-    // similar changes in BasicFactory.js
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public {
-        State state = GetState(ds);
-        CheckIsFriendlyUnit(state, actor, buildingInstance);
-
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
-    }*/
-
-    // version of use that restricts crafting to units carrying a certain item
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public {
-        // require carrying an idCard
-        // you can change idCardItemId to another item id
-        CheckIsCarryingItem(state, actor, idCardItemId);
-    
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
-    }*/
 
     function GetState(Game ds) internal returns (State) {
         return ds.getState();

--- a/contracts/src/example-plugins/StateStorage/StateStorage.yaml
+++ b/contracts/src/example-plugins/StateStorage/StateStorage.yaml
@@ -1,0 +1,29 @@
+---
+kind: BuildingKind
+spec:
+  category: custom
+  name: state storage
+  description: Building used to test storage of data on buildings
+  model: 05-11
+  color: 5
+  contract:
+    file: ./StateStorage.sol
+  plugin:
+    file: ./StateStorage.js
+  materials:
+    - name: Red Goo
+      quantity: 10
+    - name: Green Goo
+      quantity: 10
+    - name: Blue Goo
+      quantity: 10
+  inputs:
+    - name: Red Goo
+      quantity: 25
+    - name: Green Goo
+      quantity: 25
+    - name: Blue Goo
+      quantity: 25
+  outputs:
+    - name: Red Goo
+      quantity: 1

--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -237,6 +237,8 @@ contract BuildingRule is Rule {
         state.setOwner(buildingInstance, Node.Player(ctx.sender));
         // set building location
         state.setFixedLocation(buildingInstance, targetTile);
+        // set construction block num
+        state.setData(buildingInstance, "constructionBlockNum", ctx.clock);
 
         // attach the inputs/output bags
         bytes24 inputBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance, "input")))));

--- a/contracts/src/rules/QuestRule.sol
+++ b/contracts/src/rules/QuestRule.sol
@@ -21,7 +21,6 @@ uint8 constant MAX_NEXT_QUESTS = 5;
  *     number instead of checking all 256 slots
  * - The player can only ever complete 256 quests. We don't have any mechanism of tidying up completed quests
  */
-
 contract QuestRule is Rule {
     constructor() {}
 

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -491,4 +491,20 @@ library Schema {
         (bytes24 quest, uint64 status) = state.get(Rel.HasQuest.selector, questNum, player);
         return (quest, QuestStatus(status));
     }
+
+    function setData(State state, bytes24 nodeID, string memory key, bool data) internal {
+        state.setData(nodeID, key, bytes32(uint256(data ? 1 : 0)));
+    }
+
+    function setData(State state, bytes24 nodeID, string memory key, uint256 data) internal {
+        state.setData(nodeID, key, bytes32(uint256(data)));
+    }
+
+    function getDataBool(State state, bytes24 nodeID, string memory key) external view returns (bool) {
+        return uint256(state.getData(nodeID, key)) == 1;
+    }
+
+    function getDataUint256(State state, bytes24 nodeID, string memory key) external view returns (uint256) {
+        return uint256(state.getData(nodeID, key));
+    }
 }

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -98,6 +98,10 @@ fragment WorldBuilding on Node {
     location: edge(match: { kinds: "Tile", via: { rel: "Location", key: 2 } }) {
         ...Location
     }
+    allData {
+        name
+        value
+    }
 }
 
 fragment WorldCombatSession on Node {

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -98,6 +98,9 @@ fragment WorldBuilding on Node {
     location: edge(match: { kinds: "Tile", via: { rel: "Location", key: 2 } }) {
         ...Location
     }
+    constructionBlockNum: data(name: "constructionBlockNum") {
+        value
+    }
     allData {
         name
         value

--- a/frontend/src/pages/tile-fabricator.tsx
+++ b/frontend/src/pages/tile-fabricator.tsx
@@ -411,6 +411,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                 },
                 timestamp: null,
                 gooReservoir: [],
+                allData: [],
             };
         };
 


### PR DESCRIPTION
# What

Added an example building which demonstrates getting and setting data on a `building` node. The WorldBuilding graphQL query has been updated so that all data for a building is fetched. I've added a basic helper function in the building example which makes getting at data by key easier

## Note

COG is currently pinned to the `node-data-storage` branch. When the COG PR meged, COG will need to be pinned to the head commit

https://github.com/playmint/cog/pull/32

## Added bonus

As needed I have added the building construction time block number to the building node. This is written as an ordinary piece of data with the key `constructionBlockNum` so it is accessible via `allData` on the node however for convenience I have also added the `constructionBlockNum` field to the WorldBuilding graphQL query.