### PR TITLE
Building construction block recorded as edge

### DIFF
--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -87,6 +87,7 @@ contract DownstreamGame is BaseGame {
         state.registerEdgeType(Rel.HasQuest.selector, "HasQuest", WeightKind.UINT64);
         state.registerEdgeType(Rel.HasTask.selector, "HasTask", WeightKind.UINT64);
         state.registerEdgeType(Rel.ID.selector, "ID", WeightKind.UINT64);
+        state.registerEdgeType(Rel.HasBlockNum.selector, "HasBlockNum", WeightKind.UINT64);
 
         // create a session router
         BaseRouter router = new DownstreamRouter();

--- a/contracts/src/example-plugins/StateStorage/StateStorage.js
+++ b/contracts/src/example-plugins/StateStorage/StateStorage.js
@@ -10,12 +10,12 @@ export default async function update(state) {
         selectedTile && getBuildingOnTile(state, selectedTile);
     const canCraft =
         selectedBuilding && inputsAreCorrect(state, selectedBuilding);
-    // uncomment this to be restrictve about which units can craft
-    // this is a client only check - to enforce it in contracts make
-    // similar changes in BasicFactory.sol
-    //    && unitIsFriendly(state, selectedBuilding)
 
     console.log(selectedBuilding);
+
+    const constructionBlockNum = selectedBuilding
+        ? selectedBuilding.contructionBlockNum.value
+        : 0;
 
     const incrementHex = getData(selectedBuilding, "increment");
     const increment =
@@ -51,6 +51,8 @@ export default async function update(state) {
                         type: "inline",
                         html: `
                             <p>Pressing the 'Update Data' button will set the variable 'actor' to the selected MobileUnit and will increment the variable 'increment'</p>
+                            <h3>Construction block num</h3>
+                            ${constructionBlockNum}
                             <h3>Last called by mobile unit:</h3>
                             ${unitId ? unitId.slice(-4) : "0x0"}
                             <h3>Increment</h3>

--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -5,7 +5,7 @@ import "cog/IGame.sol";
 import "cog/IState.sol";
 import "cog/IRule.sol";
 
-import {Schema, Node, Kind, DEFAULT_ZONE, BuildingCategory} from "@ds/schema/Schema.sol";
+import {Schema, Node, Kind, DEFAULT_ZONE, BuildingCategory, BuildingBlockNumKey} from "@ds/schema/Schema.sol";
 import {TileUtils} from "@ds/utils/TileUtils.sol";
 import {ItemUtils} from "@ds/utils/ItemUtils.sol";
 import {Actions} from "@ds/actions/Actions.sol";
@@ -238,7 +238,7 @@ contract BuildingRule is Rule {
         // set building location
         state.setFixedLocation(buildingInstance, targetTile);
         // set construction block num
-        state.setData(buildingInstance, "constructionBlockNum", ctx.clock);
+        state.setBlockNum(buildingInstance, uint8(BuildingBlockNumKey.CONSTRUCTION), ctx.clock);
 
         // attach the inputs/output bags
         bytes24 inputBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance, "input")))));
@@ -252,7 +252,7 @@ contract BuildingRule is Rule {
 
         if (category == BuildingCategory.EXTRACTOR) {
             // set initial extraction timestamp
-            state.setBlockNum(buildingInstance, 0, ctx.clock);
+            state.setBlockNum(buildingInstance, uint8(BuildingBlockNumKey.EXTRACTION), ctx.clock);
             // Set output bag owner to player so that only they can take the extracted items
             state.setOwner(outputBag, Node.Player(ctx.sender));
         }

--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "cog/IState.sol";
 import "cog/IRule.sol";
 
-import {Schema, Node, BiomeKind, BuildingCategory, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
+import {Schema, Node, BiomeKind, BuildingCategory, BuildingBlockNumKey, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 
 using Schema for State;
@@ -102,7 +102,7 @@ contract CheatsRule is Rule {
 
         if (category == BuildingCategory.EXTRACTOR) {
             // set initial extraction timestamp
-            state.setBlockNum(buildingInstance, 0, ctx.clock);
+            state.setBlockNum(buildingInstance, uint8(BuildingBlockNumKey.EXTRACTION), ctx.clock);
 
             // set inital reservoir to full
             state.setBuildingReservoirAtoms(buildingInstance, [uint64(499), uint64(499), uint64(499)]);

--- a/contracts/src/rules/ExtractionRule.sol
+++ b/contracts/src/rules/ExtractionRule.sol
@@ -17,7 +17,8 @@ import {
     BLOCK_TIME_SECS,
     GOO_GREEN,
     GOO_BLUE,
-    GOO_RED
+    GOO_RED,
+    BuildingBlockNumKey
 } from "@ds/schema/Schema.sol";
 import {BagUtils} from "@ds/utils/BagUtils.sol";
 import {Actions} from "@ds/actions/Actions.sol";
@@ -122,7 +123,7 @@ contract ExtractionRule is Rule {
             }
 
             state.setBuildingReservoirAtoms(buildingInstance, reservoirAtoms);
-            state.setBlockNum(buildingInstance, 0, ctx.clock);
+            state.setBlockNum(buildingInstance, uint8(BuildingBlockNumKey.EXTRACTION), ctx.clock);
         }
 
         state.setItemSlot(outBag, 0, outputItemID, bagBal + qty);
@@ -142,7 +143,9 @@ contract ExtractionRule is Rule {
         uint64[3] memory atoms = state.getTileAtomValues(tile);
 
         // Get time passed. TODO: Cog to expose a global clock in the state so we have some source of constant time
-        int128 elapsedSecs = Math.fromUInt((ctx.clock - state.getBlockNum(buildingInstance, 0)) * BLOCK_TIME_SECS);
+        int128 elapsedSecs = Math.fromUInt(
+            (ctx.clock - state.getBlockNum(buildingInstance, uint8(BuildingBlockNumKey.EXTRACTION))) * BLOCK_TIME_SECS
+        );
 
         for (uint256 i = 0; i < 3; i++) {
             extractedAtoms[i] = _getGooPerSec64x64(atoms[i]).mul(elapsedSecs).toUInt();

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -22,6 +22,7 @@ interface Rel {
     function HasTask() external;
     function HasQuest() external;
     function ID() external;
+    function HasBlockNum() external;
 }
 
 interface Kind {
@@ -75,6 +76,11 @@ enum QuestStatus {
     NONE,
     ACCEPTED,
     COMPLETED
+}
+
+enum BuildingBlockNumKey {
+    CONSTRUCTION,
+    EXTRACTION
 }
 
 int16 constant DEFAULT_ZONE = 0;
@@ -467,12 +473,11 @@ library Schema {
     }
 
     function setBlockNum(State state, bytes24 kind, uint8 slot, uint64 blockNum) internal {
-        // TODO: don't use generic `Has` selector as it could conflict with something else
-        return state.set(Rel.Has.selector, slot, kind, Node.BlockNum(), blockNum);
+        return state.set(Rel.HasBlockNum.selector, slot, kind, Node.BlockNum(), blockNum);
     }
 
     function getBlockNum(State state, bytes24 kind, uint8 slot) internal view returns (uint64 blockNum) {
-        ( /*bytes24 item*/ , blockNum) = state.get(Rel.Has.selector, slot, kind);
+        ( /*bytes24 item*/ , blockNum) = state.get(Rel.HasBlockNum.selector, slot, kind);
     }
 
     function getTaskKind(State, /*state*/ bytes24 task) internal pure returns (uint32) {

--- a/contracts/test/rules/ExtractionRule.t.sol
+++ b/contracts/test/rules/ExtractionRule.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "../helpers/GameTest.sol";
 
 import {GOO_PER_SEC, GOO_RESERVOIR_MAX} from "@ds/rules/ExtractionRule.sol";
+import {BuildingBlockNumKey} from "@ds/schema/Schema.sol";
 
 using Schema for State;
 
@@ -57,7 +58,7 @@ contract ExtractionRuleTest is Test, GameTest {
         bytes24 buildingInstance = _constructBuildingInstance(mockBuildingKind, aliceMobileUnit, -1, 1, 0);
         vm.stopPrank();
 
-        uint64 blockNum = state.getBlockNum(buildingInstance, 0);
+        uint64 blockNum = state.getBlockNum(buildingInstance, uint8(BuildingBlockNumKey.EXTRACTION));
         assertEq(uint64(block.number), blockNum, "Block number expected to be set on building instance");
     }
 

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -88,7 +88,7 @@ fragment WorldBuilding on Node {
     owner: node(match: { kinds: "Player", via: { rel: "Owner" } }) {
         id
     }
-    timestamp: edge(match: { kinds: ["BlockNum"], via: { rel: "Has" } }) {
+    timestamp: edge(match: { kinds: ["BlockNum"], via: { rel: "HasBlockNum", key: 1 } }) {
         blockNum: weight
     }
     gooReservoir: edges(match: { kinds: ["Atom"], via: { rel: "Balance" } }) {
@@ -98,8 +98,8 @@ fragment WorldBuilding on Node {
     location: edge(match: { kinds: "Tile", via: { rel: "Location", key: 2 } }) {
         ...Location
     }
-    constructionBlockNum: data(name: "constructionBlockNum") {
-        value
+    contructionBlockNum: edge(match: { via: { rel: "HasBlockNum", key: 0 } }) {
+        value: weight
     }
     allData {
         name


### PR DESCRIPTION
# What

Building's construction block number now recorded on a `BlockNum` edge instead of using data storage

# Why

Data storage for a node should be reserved for user data and not include any default data

# Note

We were recording block times for exaction and using a `BlockNum` node connected using a generic `Has` edge. I have added an explicit `BlockNum` edge to avoid problems where the same edge type could be used for something else. As there is now the possibility of type block numbers being recorded for a building (construction and extraction) I have added an enum for the keys where 0 is used for construction and 1 is used for extraction. 

I have updated graphQL to use the new keys and tested extraction on the map which appeared to work as it did before