### PR TITLE
Counter buildings

### DIFF
--- a/contracts/src/example-plugins/CountdownBuilding/CountdownBuilding.js
+++ b/contracts/src/example-plugins/CountdownBuilding/CountdownBuilding.js
@@ -2,7 +2,6 @@ let startTime;
 let endTime;
 
 async function getRemainingTime() {
-    console.log("UPDATING Countdown BUILDING");
     const now = Date.now();
     if(!startTime || !endTime || now>endTime)
     {

--- a/contracts/src/example-plugins/DisplayBuilding/DisplayBuilding.js
+++ b/contracts/src/example-plugins/DisplayBuilding/DisplayBuilding.js
@@ -7,7 +7,6 @@ function getRandomTwoDigit() {
 }
 
 async function getRandomNumber() {
-    console.log("UPDATING DISPLAY BUILDING");
     const now = Date.now();
     const recentlyUpdate = now - lastUpdated < UPDATE_MS;
     if (!textToDisplay || !recentlyUpdate) {
@@ -21,20 +20,7 @@ export default async function update() {
     const text2 = await getRandomNumber();
     return {
         version: 1,
-        map: [
-            {
-                type: "building",
-                id: "0x34cf8a7e000000000000000000000000000000020000fffe",
-                key: "labelText",
-                value: `${text}`,
-            },
-            {
-                type: "building",
-                id: "0x34cf8a7e000000000000000000000000000000030000fffd",
-                key: "labelText",
-                value: `${text2}`,
-            },
-        ],
+        /*map: [],*/
         components: [
             {
                 id: "display-building",

--- a/contracts/src/example-plugins/DisplayBuilding/DisplayBuilding.js
+++ b/contracts/src/example-plugins/DisplayBuilding/DisplayBuilding.js
@@ -30,7 +30,7 @@ export default async function update() {
                         id: "default",
                         type: "inline",
                         html: `
-                            <p>We supply the best drinks in Hexwood!</p>
+                            <p>Are ya winnin'?</p>
                         `,
                     },
                 ],

--- a/contracts/src/example-plugins/DisplayBuilding/DuckDisplayBuildingManifest.yaml
+++ b/contracts/src/example-plugins/DisplayBuilding/DuckDisplayBuildingManifest.yaml
@@ -1,8 +1,8 @@
 ---
 kind: BuildingKind
 spec:
-  name: Display Building
-  description: "Display something!"
+  name: Duck Display Building
+  description: "Displays the Duck score!"
   category: display
   model: default
   color: 2

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -32,6 +32,68 @@ function formatTime(timeInMs) {
     return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`;
 }
 
+function range5(state, building){
+    const range = 5;
+    const tileCoords = getTileCoords(building?.location?.tile?.coords);
+    let i = 0;
+    const foundBuildings =[];
+    for (let q = tileCoords[0] - range; q <= tileCoords[0] + range; q++) {
+        for (let r = tileCoords[1] - range; r <= tileCoords[1] + range; r++) {
+            let s = -q - r;
+            let nextTile = [q, r, s];
+            if (distance(tileCoords, nextTile) <= range) {
+                state?.world?.buildings.forEach(b => { 
+                    const buildingCoords = getTileCoords(b.location.tile.coords);
+                    if(buildingCoords[0] == nextTile[0] && buildingCoords[1] == nextTile[1] && buildingCoords[2] == nextTile[2])
+                    {
+                        foundBuildings[i] = b;
+                        i++;
+                    }
+                });
+                
+                
+            }
+        }
+    }
+    return foundBuildings;
+}
+
+function hexToSignedDecimal(hex) {
+    if (hex.startsWith('0x')) {
+        hex = hex.substr(2);
+    }
+
+    let num = parseInt(hex, 16);
+    let bits = hex.length * 4;
+    let maxVal = Math.pow(2, bits);
+
+    // Check if the highest bit is set (negative number)
+    if (num >= maxVal / 2) {
+        num -= maxVal;
+    }
+
+    return num;
+}
+
+function getTileCoords(coords)
+{
+    return [hexToSignedDecimal(coords[1]),hexToSignedDecimal(coords[2]),hexToSignedDecimal(coords[3] )];
+}
+
+function distance(tileCoords, nextTile) {
+    return Math.max(Math.abs(tileCoords[0] - nextTile[0]), Math.abs(tileCoords[1] - nextTile[1]), Math.abs(tileCoords[2] - nextTile[2]));
+}
+
+const countBuildings = (buildingsArray, kindID) => {
+    return buildingsArray.filter((b) =>
+        b.kind?.id == kindID
+    ).length;
+}
+
+let burgerCounter;
+let duckCounter;
+
+
 export default async function update(state) {
 
     const join = () => {
@@ -121,7 +183,39 @@ export default async function update(state) {
     
     const {prizePool, gameActive, endBlock} = getHQData(selectedBuilding);
 
+    //We control what these buildings are called, so we can grab 'em by name:
+    const burgerCounterKindId = 'Burger Display Building';
+    const duckCounterKindId = 'Duck Display Building';
 
+    // These fellas will need to be provided by drop down:
+    const burgerBuildingKindId = '0xbe92755c00000000000000002bbd60790000000000000003';
+    const duckBuildingKindId = '0xbe92755c0000000000000000d87342e30000000000000003';
+
+    let duckCount = 0;
+    let burgerCount = 0;
+
+    if(selectedBuilding)
+    {
+        const localBuildings = range5(state, selectedBuilding);
+        console.log(localBuildings);
+        if(!burgerCounter)
+        {
+            burgerCounter = localBuildings.find((element) => getBuildingKindsByTileLocation(state, element, burgerCounterKindId));
+        }
+        if(!duckCounter)
+        {
+            duckCounter = localBuildings.find((element) => getBuildingKindsByTileLocation(state, element, duckCounterKindId));
+        }
+    }
+    else{
+        console.log("NO SELECTED TILE");
+    }
+
+    if(state && state.world && state.world.buildings)
+    {
+        burgerCount = countBuildings(state.world?.buildings,burgerBuildingKindId);
+        duckCount = countBuildings(state.world?.buildings,duckBuildingKindId);
+    }
 
     // get contract data
     // - initially from description
@@ -178,7 +272,20 @@ export default async function update(state) {
 
     return {
         version: 1,
-        // map: []
+         map: [
+            {
+                type: "building",
+                id: `${burgerCounter? burgerCounter.id : ''}`,
+                key: "labelText",
+                value: `${burgerCount}`,
+            },
+            {
+                type: "building",
+                id: `${duckCounter? duckCounter.id : ''}`,
+                key: "labelText",
+                value: `${duckCount}`,
+            },
+         ],
         components: [
             {
                 id: 'dbhq',
@@ -207,6 +314,10 @@ function getSelectedTile(state) {
 
 function getBuildingOnTile(state, tile) {
     return (state?.world?.buildings || []).find((b) => tile && b.location?.tile?.id === tile.id);
+}
+
+function getBuildingKindsByTileLocation(state, building, kindID) {
+    return (state?.world?.buildings || []).find((b) => b.id === building.id && b.kind?.name?.value == kindID);
 }
 
 // returns an array of items the building expects as input

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -94,9 +94,7 @@ const countBuildings = (buildingsArray, kindID) => {
 let burgerCounter;
 let duckCounter;
 
-
 export default async function update(state) {
-
     const join = () => {
         const mobileUnit = getMobileUnit(state);
 
@@ -163,10 +161,31 @@ export default async function update(state) {
 
     // find all HQs
     // run this update for each of them:
+   const dvbBuildingName = 'Duck Burger HQ';
+   const selectedBuilding = state.world?.buildings.find((b) => b.kind?.name?.value == dvbBuildingName)
+   if(!selectedBuilding)
+   {
+       console.log('NO DVB BUILDING FOUND');
+       return {
+        version: 1,
+         map: [],
+        components: [
+            {
+                id: "dbhq",
+                type: "building",
+                content: [
+                    {
+                        id: "default",
+                        type: "inline",
+                        html: '',
+                        buttons: [],
+                    },
+                ],
+            },
+        ],
+    };
+   }
 
-    const selectedTile = getSelectedTile(state);
-    const selectedBuilding = selectedTile && getBuildingOnTile(state, selectedTile);
-    
     const {prizePool, gameActive, endBlock} = getHQData(selectedBuilding);
 
     //We control what these buildings are called, so we can grab 'em by name:
@@ -183,7 +202,6 @@ export default async function update(state) {
     if(selectedBuilding)
     {
         const localBuildings = range5(state, selectedBuilding);
-        console.log(localBuildings);
         if(!burgerCounter)
         {
             burgerCounter = localBuildings.find((element) => getBuildingKindsByTileLocation(state, element, burgerCounterKindId));
@@ -276,23 +294,22 @@ export default async function update(state) {
         action: reset,
         disabled: false,
     });
-
-    return {
-        version: 1,
-         map: [
-            {
-                type: "building",
-                id: `${burgerCounter? burgerCounter.id : ''}`,
-                key: "labelText",
-                value: `${burgerCount}`,
-            },
-            {
-                type: "building",
+    const mapObj = [{
+        type: "building",
+        id: `${burgerCounter? burgerCounter.id : ''}`,
+        key: "labelText",
+        value: `${burgerCount}`,
+    },
+    {
+        type: "building",
                 id: `${duckCounter? duckCounter.id : ''}`,
                 key: "labelText",
                 value: `${duckCount}`,
-            },
-         ],
+    }];
+
+    return {
+        version: 1,
+         map: mapObj,
         components: [
             {
                 id: "dbhq",
@@ -323,6 +340,8 @@ function getBuildingOnTile(state, tile) {
     return (state?.world?.buildings || []).find(
         (b) => tile && b.location?.tile?.id === tile.id,
     );
+}
+
 function getBuildingKindsByTileLocation(state, building, kindID) {
     return (state?.world?.buildings || []).find((b) => b.id === building.id && b.kind?.name?.value == kindID);
 }

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.yaml
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.yaml
@@ -9,6 +9,7 @@ spec:
     file: ./DuckBurgerHQ.sol
   plugin:
     file: ./DuckBurgerHQ.js
+    alwaysActive: true
   materials:
     - name: Green Goo
       quantity: 10

--- a/frontend/src/components/map/Buildings.tsx
+++ b/frontend/src/components/map/Buildings.tsx
@@ -106,7 +106,6 @@ export const Buildings = memo(
                             />
                         );
                     } else if (getBuildingCategory(b.kind) == BuildingCategory.DISPLAY) {
-                        console.log(b.id);
                         const labelText = randomTileProperties
                             .find((prop) => prop.id == b.id && prop.key == 'labelText')
                             ?.value.toString();

--- a/map/Assets/Addressables/DisplayBuilding/DisplayBuildingMapElement.prefab
+++ b/map/Assets/Addressables/DisplayBuilding/DisplayBuildingMapElement.prefab
@@ -819,6 +819,11 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4998567874459341052, guid: 5a81bb16bcb950f409f2f617dd28f8c3,
+        type: 3}
+      propertyPath: m_text
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 6207050419128969283, guid: 5a81bb16bcb950f409f2f617dd28f8c3,
         type: 3}
       propertyPath: m_Layer

--- a/map/Assets/Scripts/Components/DisplayBuilding/DisplayBuildingController.cs
+++ b/map/Assets/Scripts/Components/DisplayBuilding/DisplayBuildingController.cs
@@ -69,7 +69,6 @@ public class DisplayBuildingController : BaseComponentController<DisplayBuilding
                     }
                     else
                     {
-                        Debug.Log(_nextData.startTime);
                         countDownAnim.speed = 0f;
                         countDownAnim.Play("Timer_Clock", 0, _nextData.startTime);
                     }

--- a/map/Assets/Scripts/Components/DisplayBuilding/DisplayBuildingController.cs
+++ b/map/Assets/Scripts/Components/DisplayBuilding/DisplayBuildingController.cs
@@ -89,10 +89,8 @@ public class DisplayBuildingController : BaseComponentController<DisplayBuilding
 
         if (int.TryParse(_nextData.color, out colorID))
         {
-            Debug.Log("PARSED COLOR ID: " + colorID);
             if (colorID < rooves.childCount)
             {
-                Debug.Log("COLOR ID IS VALID: " + colorID);
                 rooves.GetChild(colorID).gameObject.SetActive(true);
             }
         }


### PR DESCRIPTION
This PR integrates the counter buildings into DvBHQ.

The way that we find counter buildings within a radius of the HQ building is slightly horrendous, but it does seem to get the job done. There's probably a better way to do it that I'm not aware of.

The Building Kind IDs of the duck and burger buildings currently need to be manually supplied so that the counters know what to count.

This commit also adds the ability for the DvBHQ building to find an instance of itself on the map, without having to be selected. It works, but only for a single instance. Multiple instances will need a rethink of how the plugin 'update' function is handled I think.

