### PR TITLE
Fixed transfer from buildings not at origin

### DIFF
--- a/contracts/src/rules/InventoryRule.sol
+++ b/contracts/src/rules/InventoryRule.sol
@@ -51,7 +51,7 @@ contract InventoryRule is Rule {
         }
 
         // get acting mobileUnit location
-        bytes24 location = state.getCurrentLocation(actor, atTime);
+        bytes24 location = BagUtils.getCurrentLocation(state, actor, atTime);
 
         // check equipees are either the acting mobileUnit
         // at the same location as the acting mobileUnit

--- a/contracts/src/utils/BagUtils.sol
+++ b/contracts/src/utils/BagUtils.sol
@@ -8,12 +8,12 @@ import {TileUtils} from "@ds/utils/TileUtils.sol";
 using Schema for State;
 
 library BagUtils {
-    function requireEquipeeLocation(State state, bytes24 equipee, bytes24 mobileUnit, bytes24 location, uint64 atTime)
+    function requireEquipeeLocation(State state, bytes24 equipee, bytes24 actor, bytes24 location, uint64 atTime)
         internal
         view
     {
-        if (equipee == mobileUnit) {
-            return; // all good, it's the acting mobileUnit's bag so locations match
+        if (equipee == actor) {
+            return; // all good, it's the actor's bag so locations match
         } else if (bytes4(equipee) == Kind.Tile.selector) {
             // located on a tile
             if (TileUtils.distance(location, equipee) > 1 || !TileUtils.isDirect(location, equipee)) {
@@ -29,7 +29,7 @@ library BagUtils {
                 revert("NoTransferNotSameLocation");
             }
         } else if (bytes4(equipee) == Kind.MobileUnit.selector) {
-            // location on another mobileUnit, check same loc
+            // location a mobileUnit, check same loc
             bytes24 otherMobileUnitLocation = state.getCurrentLocation(equipee, atTime);
             if (
                 TileUtils.distance(location, otherMobileUnitLocation) > 1

--- a/contracts/test/rules/InventoryRule.t.sol
+++ b/contracts/test/rules/InventoryRule.t.sol
@@ -122,6 +122,24 @@ contract InventoryRuleTest is Test, GameTest {
         vm.stopPrank();
     }
 
+    function testTransferItemBuildingBagNotAtOriginToMobileUnit() public {
+        vm.startPrank(players[0].addr);
+        bytes24 mobileUnit = _spawnMobileUnitWithResources(1);
+        moveMobileUnit(1, 2, 0, -2);
+        (int16 q, int16 r, int16 s) = (3, 0, -3);
+        (bytes24 buildingInstance, address buildingImplementation) =
+            _constructBuilding(players[0].addr, BUILDING_KIND_ID_1, mobileUnit, q, r, s);
+        vm.stopPrank();
+
+        vm.startPrank(buildingImplementation);
+        _testTransferItemBetweenEquipees(
+            buildingInstance, // mobileUnit perfoming the action
+            buildingInstance, // location of from-bag
+            mobileUnit // location to to-bag
+        );
+        vm.stopPrank();
+    }
+
     function testTransferItemFailNotOwner() public {
         vm.startPrank(players[0].addr);
         bytes24 mobileUnit = _spawnMobileUnit(1, 0, 0, 0);


### PR DESCRIPTION
### What
Fixed a bug. Previously, transferring items as a building, from a building instance that is not at origin would fail with "NoTransferUnsupportedEquipeeKind". 

### How
The inventory rule now correctly handles buildings as actors and  uses the generic actor location function from BagUtils rather than the base schema version that only works if actor is a mobileUnit

Test has been added to that failed before and passes after this fix