### PR TITLE
Duck burger - Only count buildings constructed during game play

### DIFF
--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -116,8 +116,8 @@ const countBuildings = (buildingsArray, kindID, startBlock, endBlock) => {
     return buildingsArray.filter(
         (b) =>
             b.kind?.id == kindID &&
-            b.contructionBlockNum.value >= startBlock &&
-            b.contructionBlockNum.value <= endBlock,
+            b.constructionBlockNum.value >= startBlock &&
+            b.constructionBlockNum.value <= endBlock,
     ).length;
 };
 

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -116,8 +116,8 @@ const countBuildings = (buildingsArray, kindID, startBlock, endBlock) => {
     return buildingsArray.filter(
         (b) =>
             b.kind?.id == kindID &&
-            b.contructionBlockNum >= startBlock &&
-            b.contructionBlockNum <= endBlock,
+            b.contructionBlockNum.value >= startBlock &&
+            b.contructionBlockNum.value <= endBlock,
     ).length;
 };
 
@@ -234,7 +234,7 @@ export default async function update(state) {
     // uncomment this to browse the state object in browser console
     // this will be logged when selecting a unit and then selecting an instance of this building
     // very spammy for a plugin marked as alwaysActive
-    //logState(state);
+    // logState(state);
 
     // find all HQs
     // run this update for each of them:

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
@@ -146,6 +146,11 @@ contract DuckBurgerState is BuildingKind {
             )
         );
 
+        // todo if the game length is a parameter, we could calculate this from the endBlock
+        dispatcher.dispatch(
+            abi.encodeCall(Actions.SET_DATA_ON_BUILDING, (buildingId, "startBlock", bytes32(uint256(block.number))))
+        );
+
         // set endblock to now plus 10 minutes
         // todo do we take time as a param
         dispatcher.dispatch(
@@ -261,6 +266,9 @@ contract DuckBurgerState is BuildingKind {
         // todo - do we check if all claims have been made ?
 
         // set state to joining (gameActive ?)
+        dispatcher.dispatch(
+            abi.encodeCall(Actions.SET_DATA_ON_BUILDING, (buildingId, "startBlock", bytes32(uint256(block.number))))
+        );
         dispatcher.dispatch(
             abi.encodeCall(Actions.SET_DATA_ON_BUILDING, (buildingId, "endBlock", bytes32(uint256(block.number))))
         );

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
@@ -305,12 +305,15 @@ contract DuckBurgerState is BuildingKind {
         return uint64(teamDuckUnits.length + teamBurgerUnits.length) * joinFee;
     }
 
-    function getBuildingCounts(State state, bytes24 buildingInstance) public view returns (uint24, uint24) {
+    function getBuildingCounts(State state, bytes24 buildingInstance)
+        public
+        view
+        returns (uint24 ducks, uint24 burgers)
+    {
         bytes24 duckBuildingKind = bytes24(state.getData(buildingInstance, "buildingKindIdDuck"));
         bytes24 burgerBuildingKind = bytes24(state.getData(buildingInstance, "buildingKindIdBurger"));
-
-        uint24 ducks = 0;
-        uint24 burgers = 0;
+        uint256 endBlock = uint256(state.getData(buildingInstance, "endBlock"));
+        uint256 startBlock = uint256(state.getData(buildingInstance, "startBlock"));
 
         bytes24 tile = state.getFixedLocation(buildingInstance);
         bytes24[99] memory arenaTiles = range5(tile);
@@ -319,12 +322,17 @@ contract DuckBurgerState is BuildingKind {
                 DEFAULT_ZONE, coords(arenaTiles[i])[1], coords(arenaTiles[i])[2], coords(arenaTiles[i])[3]
             );
             if (state.getBuildingKind(arenaBuildingID) == duckBuildingKind) {
-                ducks++;
+                uint64 constructionBlockNum = state.getBuildingConstructionBlockNum(arenaBuildingID);
+                if (constructionBlockNum >= startBlock && constructionBlockNum <= endBlock) {
+                    ducks++;
+                }
             } else if (state.getBuildingKind(arenaBuildingID) == burgerBuildingKind) {
-                burgers++;
+                uint64 constructionBlockNum = state.getBuildingConstructionBlockNum(arenaBuildingID);
+                if (constructionBlockNum >= startBlock && constructionBlockNum <= endBlock) {
+                    burgers++;
+                }
             }
         }
-        return (ducks, burgers);
     }
 
     function coords(bytes24 tile) internal pure returns (int16[4] memory keys) {

--- a/contracts/src/example-plugins/StateStorage/StateStorage.js
+++ b/contracts/src/example-plugins/StateStorage/StateStorage.js
@@ -14,7 +14,7 @@ export default async function update(state) {
     console.log(selectedBuilding);
 
     const constructionBlockNum = selectedBuilding
-        ? selectedBuilding.contructionBlockNum.value
+        ? selectedBuilding.constructionBlockNum.value
         : 0;
 
     const incrementHex = getData(selectedBuilding, "increment");

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -481,6 +481,14 @@ library Schema {
         ( /*bytes24 item*/ , blockNum) = state.get(Rel.HasBlockNum.selector, slot, kind);
     }
 
+    function setBuildingConstructionBlockNum(State state, bytes24 buildingID, uint64 blockNum) internal {
+        state.setBlockNum(buildingID, uint8(BuildingBlockNumKey.CONSTRUCTION), blockNum);
+    }
+
+    function getBuildingConstructionBlockNum(State state, bytes24 buildingID) internal view returns (uint64) {
+        return state.getBlockNum(buildingID, uint8(BuildingBlockNumKey.CONSTRUCTION));
+    }
+
     function getTaskKind(State, /*state*/ bytes24 task) internal pure returns (uint32) {
         return uint32(uint192(task) >> 32 & type(uint32).max);
     }

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -98,7 +98,7 @@ fragment WorldBuilding on Node {
     location: edge(match: { kinds: "Tile", via: { rel: "Location", key: 2 } }) {
         ...Location
     }
-    contructionBlockNum: edge(match: { via: { rel: "HasBlockNum", key: 0 } }) {
+    constructionBlockNum: edge(match: { via: { rel: "HasBlockNum", key: 0 } }) {
         value: weight
     }
     allData {


### PR DESCRIPTION
# What

When counting up the buildings, the building's `constructionBlockNum` is checked that it falls within the gameplay time.

# Why

This prevents any Duck/Burger buildings that were built either before or after the match was started from being counted towards the final score