### PR TITLE
Only counts local ducks and burgers for local units

### DIFF
--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -318,13 +318,13 @@ export default async function update(state) {
     }
     if (state && state.world && state.world.buildings) {
         duckCount = countBuildings(
-            state.world?.buildings,
+            localBuildings,
             buildingKindIdDuck,
             startBlock,
             endBlock,
         );
         burgerCount = countBuildings(
-            state.world?.buildings,
+            localBuildings,
             buildingKindIdBurger,
             startBlock,
             endBlock,


### PR DESCRIPTION
This PR makes the DvBHQ only count duck and burger buildings that are inside its 5 tile radius.
