### PR TITLE
1kx cli publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ cli: node_modules core/dist/core.js
 	(cd cli && $(NPM) run build && $(NPM) install -g --force .)
 
 publish: cli
-	(cd cli && $(NPM) version patch && $(NPM) publish)
+	(cd cli && $(NPM) version prerelease --preid=1kx && $(NPM) publish)
 
 release: contracts node_modules cli
 	./scripts/release.mjs -i --max-connections 10

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playmint/ds-cli",
-  "version": "0.0.16",
+  "version": "0.0.17-1kx.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playmint/ds-cli",
-      "version": "0.0.16",
+      "version": "0.0.17-1kx.0",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/ethereum-provider": "^2.9.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playmint/ds-cli",
-  "version": "0.0.16",
+  "version": "0.0.17-1kx.0",
   "description": "cli client for interacting with downstream.game",
   "main": "index.js",
   "bin": {

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
@@ -35,7 +35,6 @@ contract DuckBurgerHQ is BuildingKind {
     function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes calldata payload) public {
         State state = GetState(ds);
 
-
         // decode payload and call one of _join, _start, _claim or _reset
         if ((bytes4)(payload) == this.join.selector) {
             _join(ds, state, actor, buildingInstance);
@@ -79,7 +78,7 @@ contract DuckBurgerHQ is BuildingKind {
                 (buildingId, "lastKnownPrizeBalance", bytes32(uint256(currentPrizeBalance)))
             )
         );
-        
+
         for (uint256 i = 0; i < teamDuckUnits.length; i++) {
             if (teamDuckUnits[i] == unitId) revert("Already joined");
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "cli": {
       "name": "@playmint/ds-cli",
-      "version": "0.0.16",
+      "version": "0.0.17-1kx.0",
       "license": "MIT",
       "dependencies": {
         "@downstream/core": "file:core",


### PR DESCRIPTION
### What 

make publish hacked to make a pre-release version labelled as 1kx (for display-buildings branch)

To use this cli on Hexwoods deployed from display-buildings or 1kx-hackathon run 
`npm install @playmint/ds-cli@0.0.17-1kx.0`

### Why

The 1kx hackathon is happening in code from display-buildings which uses a new version of cog so the cli (v0.0.16) published from main is incompatible

