### PR TITLE
timer always shows time, timer is correct when refreshed

### DIFF
--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -10,6 +10,7 @@ const burgerBuildingTopId = "17";
 const burgerCounterKindId = "Burger Display Building";
 const duckCounterKindId = "Duck Display Building";
 const countdownBuildingKindId = "Countdown Building";
+const countdownTotalTime = 60000;
 
 let burgerCounter;
 let duckCounter;
@@ -17,7 +18,7 @@ let countdownBuilding;
 let startTime;
 let endTime;
 
-export default async function update(state) {
+export default async function update(state, block) {
     
     //
     // Action handler functions
@@ -278,11 +279,11 @@ export default async function update(state) {
         `;
     }
 
-    const nowBlock = state?.world?.block;
+    const nowBlock = block;
     const blocksLeft = endBlock > nowBlock ? endBlock - nowBlock : 0;
-    const blocksFromStart = startBlock < nowBlock ? nowBlock - startBlock : 30;
+    const blocksFromStart =  nowBlock - startBlock ;
     const timeLeftMs = blocksLeft * 2 * 1000;
-    const timeSinceStartMs = blocksFromStart * 2 * 1000;
+    const timeSinceStartMs = startBlock <= nowBlock ? blocksFromStart * 2 * 1000 : countdownTotalTime;
 
     if (gameActive) {
         // Display selected team buildings
@@ -301,10 +302,13 @@ export default async function update(state) {
 
         `;
 
+        const now = Date.now();
+        if(!startTime)
+            startTime = now-timeSinceStartMs;
+        if(!endTime)
+            endTime = now+timeLeftMs;
+        
         if (blocksLeft > 0) {
-            const now = Date.now();
-            if (!startTime) startTime = now - timeSinceStartMs;
-            if (!endTime) endTime = now + timeLeftMs;
             htmlBlock += `<p>time remaining: ${formatTime(timeLeftMs)}</p>`;
         } else {
             // End of game
@@ -384,7 +388,7 @@ export default async function update(state) {
             type: "building",
             id: `${countdownBuilding ? countdownBuilding.id : ""}`,
             key: "labelText",
-            value: "",
+            value: `${formatTime(countdownTotalTime)}`,
         });
     }
 
@@ -485,7 +489,7 @@ function formatTime(timeInMs) {
     let formattedMinutes = String(minutes).padStart(2, "0");
     let formattedSeconds = String(seconds).padStart(2, "0");
 
-    return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`;
+    return `${formattedMinutes}:${formattedSeconds}`;
 }
 
 const countBuildings = (buildingsArray, kindID, startBlock, endBlock) => {

--- a/frontend/src/components/map/DisplayBuilding.tsx
+++ b/frontend/src/components/map/DisplayBuilding.tsx
@@ -94,7 +94,7 @@ export const DisplayBuilding = memo(
         useEffect(() => {
             const timer = setInterval(() => {
                 setTimeLeft(calculateTimeLeft());
-            }, 1000);
+            }, 10);
 
             return () => clearInterval(timer);
         }, [calculateTimeLeft]);

--- a/map/Assets/Addressables/DisplayBuilding/DisplayBuildingMapElement.prefab
+++ b/map/Assets/Addressables/DisplayBuilding/DisplayBuildingMapElement.prefab
@@ -265,6 +265,11 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 8
       objectReference: {fileID: 0}
+    - target: {fileID: 1591274849109309950, guid: 815359b724caf5445907d0d36c00cad7,
+        type: 3}
+      propertyPath: m_text
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 2471721019490362611, guid: 815359b724caf5445907d0d36c00cad7,
         type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
The countdown display was blank when not counting down, and sometimes incorrectly showed 9:58 or 10:00.
Also after refreshing the page, the displayed time would get out of sync with the actual round time left.

This PR fixes those issues. The countdown display will appear blank until it is registered by the DvBHQ building. It will then show the amount of time specified in the DvBHQ js file until the countdown begins.

The number used for the current block number has been changed from state.world.block to the block that is passed into the update function as a parameter. This solves the issue with the countdown timer getting out of sync after a refresh.