### PR TITLE
Configurable starting quest

### DIFF
--- a/cli/src/utils/applier.ts
+++ b/cli/src/utils/applier.ts
@@ -546,6 +546,26 @@ export const getOpsForManifests = async (
         });
     }
 
+    // add AutoQuests
+    opn++;
+    opsets[opn] = [];
+    for (const doc of docs) {
+        if (doc.manifest.kind != 'AutoQuest') {
+            continue;
+        }
+        const spec = doc.manifest.spec;
+        opsets[opn].push({
+            doc,
+            actions: [
+                {
+                    name: 'AUTO_QUEST',
+                    args: [spec.name, spec.index],
+                },
+            ],
+            note: `added auto-quest ${spec.name}`,
+        });
+    }
+
     return opsets;
 };
 

--- a/cli/src/utils/applier.ts
+++ b/cli/src/utils/applier.ts
@@ -559,7 +559,7 @@ export const getOpsForManifests = async (
             actions: [
                 {
                     name: 'AUTO_QUEST',
-                    args: [spec.name, spec.index],
+                    args: [spec.name],
                 },
             ],
             note: `added auto-quest ${spec.name}`,

--- a/cli/src/utils/applier.ts
+++ b/cli/src/utils/applier.ts
@@ -559,7 +559,7 @@ export const getOpsForManifests = async (
             actions: [
                 {
                     name: 'AUTO_QUEST',
-                    args: [spec.name],
+                    args: [spec.name, spec.index],
                 },
             ],
             note: `added auto-quest ${spec.name}`,

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -318,7 +318,6 @@ export const Quest = z.object({
 
 export const AutoQuestSpec = z.object({
     name: Name,
-    index: z.number(),
 });
 
 export const AutoQuest = z.object({

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -318,6 +318,7 @@ export const Quest = z.object({
 
 export const AutoQuestSpec = z.object({
     name: Name,
+    index: z.number(),
 });
 
 export const AutoQuest = z.object({

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -316,6 +316,17 @@ export const Quest = z.object({
     status: z.object({}).optional(),
 });
 
+export const AutoQuestSpec = z.object({
+    name: Name,
+    index: z.number(),
+});
+
+export const AutoQuest = z.object({
+    kind: z.literal('AutoQuest'),
+    spec: AutoQuestSpec,
+    status: z.object({}).optional(),
+});
+
 // -- //
 
 export const Manifest = z.discriminatedUnion('kind', [
@@ -327,6 +338,7 @@ export const Manifest = z.discriminatedUnion('kind', [
     Player,
     Quest,
     Bag,
+    AutoQuest,
 ]);
 
 export const ManifestDocument = z.object({

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -37,7 +37,7 @@ interface Actions {
     function SCOUT_MOBILE_UNIT(uint32 sid, int16 q, int16 r, int16 s) external;
 
     // action to set the type of quest the player should begin with
-    function AUTO_QUEST(string calldata name, uint8 index) external;
+    function AUTO_QUEST(string calldata name) external;
 
     // transfer a qty of items from itemSlot[0] in equipees[0]'s equipSlots[0] bag
     // to itemSlot[1] in equipees[1]'s equipSlots[1] bag

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -36,6 +36,9 @@ interface Actions {
     // to scout location
     function SCOUT_MOBILE_UNIT(uint32 sid, int16 q, int16 r, int16 s) external;
 
+    // action to set the type of quest the player should begin with
+    function AUTO_QUEST(string calldata name, uint8 index) external;
+
     // transfer a qty of items from itemSlot[0] in equipees[0]'s equipSlots[0] bag
     // to itemSlot[1] in equipees[1]'s equipSlots[1] bag
     // bags must be at same location as mobileUnit

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -37,7 +37,7 @@ interface Actions {
     function SCOUT_MOBILE_UNIT(uint32 sid, int16 q, int16 r, int16 s) external;
 
     // action to set the type of quest the player should begin with
-    function AUTO_QUEST(string calldata name) external;
+    function AUTO_QUEST(string calldata name, uint8 index) external;
 
     // transfer a qty of items from itemSlot[0] in equipees[0]'s equipSlots[0] bag
     // to itemSlot[1] in equipees[1]'s equipSlots[1] bag

--- a/contracts/src/fixtures/auto-quest.yaml
+++ b/contracts/src/fixtures/auto-quest.yaml
@@ -1,0 +1,5 @@
+---
+kind: AutoQuest
+spec:
+  name: 'Report to Control'
+  index: 0

--- a/contracts/src/fixtures/auto-quest.yaml
+++ b/contracts/src/fixtures/auto-quest.yaml
@@ -2,3 +2,4 @@
 kind: AutoQuest
 spec:
   name: 'Report to Control'
+  index: 0

--- a/contracts/src/fixtures/auto-quest.yaml
+++ b/contracts/src/fixtures/auto-quest.yaml
@@ -2,4 +2,3 @@
 kind: AutoQuest
 spec:
   name: 'Report to Control'
-  index: 0

--- a/contracts/src/maps/tiny/auto-quest.yaml
+++ b/contracts/src/maps/tiny/auto-quest.yaml
@@ -1,0 +1,8 @@
+---
+kind: AutoQuest
+spec:
+  name: Example Quest
+---
+kind: AutoQuest
+spec:
+  name: Another Example Quest

--- a/contracts/src/maps/tiny/auto-quest.yaml
+++ b/contracts/src/maps/tiny/auto-quest.yaml
@@ -2,7 +2,9 @@
 kind: AutoQuest
 spec:
   name: Example Quest
+  index: 0
 ---
 kind: AutoQuest
 spec:
   name: Another Example Quest
+  index: 1

--- a/contracts/src/maps/tiny/quests/00_ExampleQuest.yaml
+++ b/contracts/src/maps/tiny/quests/00_ExampleQuest.yaml
@@ -1,0 +1,11 @@
+---
+kind: Quest
+spec:
+  name: Example Quest
+  description: "Welcome new user. Please report to the control tower for further instructions. The target button above will show you where it is."
+  location: [-6, 5, 1]
+  tasks:
+    - kind: coord
+      name: Move your unit so that you are standing next to the Control Tower
+      location: [-6, 5, 1]
+  next: ["Verification Error"]

--- a/contracts/src/maps/tiny/quests/01_ExampleQuest2.yaml
+++ b/contracts/src/maps/tiny/quests/01_ExampleQuest2.yaml
@@ -1,0 +1,11 @@
+---
+kind: Quest
+spec:
+  name: Another Example Quest
+  description: "Welcome new user. Please report to the control tower for further instructions. The target button above will show you where it is."
+  location: [-6, 5, 1]
+  tasks:
+    - kind: coord
+      name: Move your unit so that you are standing next to the Control Tower
+      location: [-6, 5, 1]
+  next: ["Verification Error"]

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -13,8 +13,7 @@ using Schema for State;
 
 contract NewPlayerRule is Rule {
     bool allowListEnabled;
-    string name;
-    uint8 index;
+    string[] name;
     mapping(address => uint256) spawnable;
 
     constructor(address[] memory allowlist) {
@@ -67,12 +66,14 @@ contract NewPlayerRule is Rule {
             state.setItemSlot(bag1, 2, ItemUtils.RedGoo(), 100);
 
             // Accept the first quest in the chain
-            state.setQuestAccepted(Node.Quest(name), Node.Player(ctx.sender), 0);
+            for (uint8 i = 0; i < name.length; i++) {
+                state.setQuestAccepted(Node.Quest(name[i]), Node.Player(ctx.sender), i);
+            }
         }
 
         if(bytes4(action) == Actions.AUTO_QUEST.selector)
         {
-            (name, index) = abi.decode(action[4:], (string, uint8));
+            name.push(abi.decode(action[4:], (string)));
         }
 
         return state;

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -72,7 +72,7 @@ contract NewPlayerRule is Rule {
             }
         }
 
-        if(bytes4(action) == Actions.AUTO_QUEST.selector)
+        if (bytes4(action) == Actions.AUTO_QUEST.selector)
         {
             (string memory name, uint8 index) = abi.decode(action[4:], (string, uint8));
             names.push(name);

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -72,8 +72,7 @@ contract NewPlayerRule is Rule {
             }
         }
 
-        if (bytes4(action) == Actions.AUTO_QUEST.selector)
-        {
+        if (bytes4(action) == Actions.AUTO_QUEST.selector) {
             (string memory name, uint8 index) = abi.decode(action[4:], (string, uint8));
             names.push(name);
             indexes.push(index);

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -13,7 +13,8 @@ using Schema for State;
 
 contract NewPlayerRule is Rule {
     bool allowListEnabled;
-    string[] name;
+    string[] names;
+    uint8[] indexes;
     mapping(address => uint256) spawnable;
 
     constructor(address[] memory allowlist) {
@@ -66,14 +67,16 @@ contract NewPlayerRule is Rule {
             state.setItemSlot(bag1, 2, ItemUtils.RedGoo(), 100);
 
             // Accept the first quest in the chain
-            for (uint8 i = 0; i < name.length; i++) {
-                state.setQuestAccepted(Node.Quest(name[i]), Node.Player(ctx.sender), i);
+            for (uint8 i = 0; i < names.length; i++) {
+                state.setQuestAccepted(Node.Quest(names[i]), Node.Player(ctx.sender), indexes[i]);
             }
         }
 
         if(bytes4(action) == Actions.AUTO_QUEST.selector)
         {
-            name.push(abi.decode(action[4:], (string)));
+            (string memory name, uint8 index) = abi.decode(action[4:], (string, uint8));
+            names.push(name);
+            indexes.push(index);
         }
 
         return state;

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -13,6 +13,8 @@ using Schema for State;
 
 contract NewPlayerRule is Rule {
     bool allowListEnabled;
+    string name;
+    uint8 index;
     mapping(address => uint256) spawnable;
 
     constructor(address[] memory allowlist) {
@@ -65,7 +67,12 @@ contract NewPlayerRule is Rule {
             state.setItemSlot(bag1, 2, ItemUtils.RedGoo(), 100);
 
             // Accept the first quest in the chain
-            state.setQuestAccepted(Node.Quest("Report to Control"), Node.Player(ctx.sender), 0);
+            state.setQuestAccepted(Node.Quest(name), Node.Player(ctx.sender), 0);
+        }
+
+        if(bytes4(action) == Actions.AUTO_QUEST.selector)
+        {
+            (name, index) = abi.decode(action[4:], (string, uint8));
         }
 
         return state;


### PR DESCRIPTION
This PR allows you to define a starting quest or quests for each map type, by including an 'auto-quest.yaml' file in the map's folder.
Note that any quests you define (and their associated items, buildings, etc) will also have to exist within the map's folder as the fixtures folder is no longer loaded by default.

The quests you add in the quest folder require a name which identifies which quest to use, and an index which defines which order they should appear in the player's UI.

I have put a couple of example quests and an auto-quest yaml in the tiny map folder for demonstration, as well as an auto-quest yaml in the fixtures folder for the default behavior.