### PR TITLE
Buildings can now be deployed without supplying the kind manifest

### DIFF
--- a/cli/src/utils/applier.ts
+++ b/cli/src/utils/applier.ts
@@ -367,18 +367,13 @@ const questDeploymentActions = async (
 };
 
 const getBuildingKindIDByName = (existingBuildingKinds, pendingBuildingKinds, name: string) => {
-    const foundBuildingKinds = existingBuildingKinds.filter(
-        ({ kind, spec }) => kind === 'BuildingKind' && spec.name === name
-    );
+    const foundBuildingKinds = existingBuildingKinds.filter((buildingKind) => buildingKind.name?.value === name);
     if (foundBuildingKinds.length === 1) {
-        const manifest = foundBuildingKinds[0];
-        if (manifest.kind !== 'BuildingKind') {
-            throw new Error(`unexpect kind`);
-        }
-        if (!manifest.status || !manifest.status.id) {
+        const buildingKind = foundBuildingKinds[0];
+        if (!buildingKind.id) {
             throw new Error(`missing status.id field for BuildingKind ${name}`);
         }
-        return manifest.status.id;
+        return buildingKind.id;
     } else if (foundBuildingKinds.length > 1) {
         throw new Error(
             `BuildingKind ${name} is ambiguous, found ${foundBuildingKinds.length} existing BuildingKinds with that name`


### PR DESCRIPTION
# What

Fixes the problem where buildings couldn't be deployed unless the `buildingKind` for that that building was deployed at the same time (and existed in the pendingManifest list).

# Fix

This was due to the passed in `existingBuildingKinds` in the `getBuildingKindIDByName` function being treated as specs when they were the graphQL fragments

# Test

I tested this by deploying some small rocks:

```
---
kind: Building
spec:
  name: Small Rocks
  location: [1, 0, -1]

```

fixes: #1013 