### PR TITLE
Hide units if they haven't moved for 30 minutes

### DIFF
--- a/frontend/src/components/map/ExtractorBuilding.tsx
+++ b/frontend/src/components/map/ExtractorBuilding.tsx
@@ -1,3 +1,4 @@
+import { BLOCK_TIME_SECS } from '@app/fixtures/block-time-secs';
 import { getGooPerSec } from '@app/helpers/tile';
 import { useBlock } from '@app/hooks/use-game-state';
 import { UnityComponentProps, useUnityComponentManager } from '@app/hooks/use-unity-component-manager';
@@ -57,7 +58,7 @@ export const ExtractorBuilding = memo(
 
         // Calculate extracted goo and sum with previously extracted goo
         const GOO_RESERVOIR_MAX = 500;
-        const BLOCK_TIME_SECS = 2;
+
         const elapsedSecs = lastExtraction && blockNumber ? (blockNumber - lastExtraction) * BLOCK_TIME_SECS : 0;
         const extractedGoo = atoms
             .map((atomVal) => Math.floor(getGooPerSec(atomVal) * elapsedSecs))

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -287,6 +287,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                         randomTileProperties={tileColorsModifiedByPlugins}
                     />
                     <MobileUnits
+                        currentBlock={world?.block || 0}
                         mobileUnits={world?.mobileUnits}
                         buildings={world?.buildings || []}
                         onClickMobileUnit={mobileUnitClick}

--- a/frontend/src/fixtures/block-time-secs.ts
+++ b/frontend/src/fixtures/block-time-secs.ts
@@ -1,0 +1,1 @@
+export const BLOCK_TIME_SECS = 2;


### PR DESCRIPTION
# What

If a unit hasn't moved for ~30 minutes (900 blocks) then hide them on the map unless they are the player's unit (to allow for selection)

# Why

A map can become littered with 'dead' units if multiple game sessions have been played within one deployment

# Details

The time can be adjusted using the `UNIT_DISPLAY_TIMEOUT_SECS` constant in `src/components/map/MobileUnit.tsx`

Fixes #972 