### PR TITLE
Text on buttons show ellipses when overflowing

### DIFF
--- a/frontend/src/styles/button.styles.ts
+++ b/frontend/src/styles/button.styles.ts
@@ -34,6 +34,9 @@ export const TextButton = styled.button`
     color: ${colorMap.primaryButtonText};
     font-size: 1.6rem;
     font-weight: 800;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 `;
 
 export const ActionButton = styled(TextButton)`


### PR DESCRIPTION
# What

Before:
![image](https://github.com/playmint/ds/assets/51167118/452f8f5e-e773-472b-bfc0-7d1155d279d0)

After:
![image](https://github.com/playmint/ds/assets/51167118/c743e4d3-9f7f-4be6-ba34-02c8b0b4432a)

Added simple CSS to all `TextButton` classes