### PR TITLE
Performance - Gracefully Handle OOM

### DIFF
--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -67,6 +67,12 @@ const chaosUnit = {
             [q,r,s] = validNeighbours[Math.floor(Math.random() * validNeighbours.length)] || [0,0,0];
 
             await player.dispatch({ name: 'MOVE_MOBILE_UNIT', args: [unitKey, q, r, s] }).then(res => res.wait());
+            // if (Math.random() > 0.75){
+            //     const building = Math.random() > 0.5 ? "0xbe92755c0000000000000000546391e80000000000000003" : "0xbe92755c0000000000000000444749c70000000000000003";
+            //     const args = { name: 'CONSTRUCT_BUILDING_MOBILE_UNIT', args: [unitId, building, q, r, s] };
+            //     await player.dispatchAndWait(args);
+            //     // failed to call: execution reverted: no construction bag found
+            // }
             await sleep(Math.floor(Math.random() * 2000)); // jitter
         }
     },

--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -67,12 +67,6 @@ const chaosUnit = {
             [q,r,s] = validNeighbours[Math.floor(Math.random() * validNeighbours.length)] || [0,0,0];
 
             await player.dispatch({ name: 'MOVE_MOBILE_UNIT', args: [unitKey, q, r, s] }).then(res => res.wait());
-            // if (Math.random() > 0.75){
-            //     const building = Math.random() > 0.5 ? "0xbe92755c0000000000000000546391e80000000000000003" : "0xbe92755c0000000000000000444749c70000000000000003";
-            //     const args = { name: 'CONSTRUCT_BUILDING_MOBILE_UNIT', args: [unitId, building, q, r, s] };
-            //     await player.dispatchAndWait(args);
-            //     // failed to call: execution reverted: no construction bag found
-            // }
             await sleep(Math.floor(Math.random() * 2000)); // jitter
         }
     },

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -37,6 +37,7 @@ import { getBagsAtEquipee, getBuildingAtTile } from './utils';
 import { Logger } from './logger';
 
 const active = new Map<string, ActivePlugin>();
+//
 
 /**
  * makeAvailablePlugins polls for the list of deployed plugins every now and
@@ -120,21 +121,27 @@ export function makePluginUI(
                                 }
                                 const plugin = active.has(p.id)
                                     ? active.get(p.id)
-                                    : await loadPlugin(
+                                    : state.world.buildings.some((building) => building?.kind?.id === p.kindID)
+                                    ? await loadPlugin(
                                           sandbox,
                                           dispatch,
                                           logMessage,
                                           questMessage.with({ name: p.kindID }),
                                           p,
-                                      );
+                                      )
+                                    : null;
                                 if (!plugin) {
-                                    console.warn(`failed to get or load plugin ${p.id}`);
+                                    // no longer logs this now that it plugin's that are not in the world are undefined
+                                    // console.warn(`failed to get or load plugin ${p.id}`);
                                     return null;
                                 }
                                 active.set(p.id, plugin);
                                 return plugin.update();
                             } catch (err) {
                                 console.error(`plugin ${p.id}:`, err);
+                                console.log(`Removing plugin ${p.id} from 'active' due to error`);
+                                active.delete(p.id);
+                                console.log(`removed`);
                                 return null;
                             }
                         })

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -144,6 +144,7 @@ export function makePluginUI(
                                 console.log(`removed`);
                                 // NEED TO *UNLOAD* PLUGIN FROM CONTEXT - DESTROY CONTEXT
                                 // use p.id to call from sandbox to delete context properly
+                                sandbox.deleteContext(p.id);
                                 return null;
                             }
                         })
@@ -333,12 +334,17 @@ export async function loadPlugin(
         );
 
         try {
+            const _pluginResponse = (await sandbox.hasContext(context)) === true ? pluginResponse : {};
             return {
                 config,
-                state: apiv1.normalizePluginState(pluginResponse, submitProxy),
+                state: apiv1.normalizePluginState(_pluginResponse, submitProxy),
             };
         } catch (err) {
             console.error('plugin did not return an expected response object:', err);
+            // call sandbox dispose all
+            if (String(err).includes('memory')) {
+                await sandbox.disposeRuntime();
+            }
             return {
                 config,
                 state: apiv1.normalizePluginState({}, submitProxy),

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -37,7 +37,6 @@ import { getBagsAtEquipee, getBuildingAtTile } from './utils';
 import { Logger } from './logger';
 
 const active = new Map<string, ActivePlugin>();
-//
 
 /**
  * makeAvailablePlugins polls for the list of deployed plugins every now and

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -142,6 +142,8 @@ export function makePluginUI(
                                 console.log(`Removing plugin ${p.id} from 'active' due to error`);
                                 active.delete(p.id);
                                 console.log(`removed`);
+                                // NEED TO *UNLOAD* PLUGIN FROM CONTEXT - DESTROY CONTEXT
+                                // use p.id to call from sandbox to delete context properly
                                 return null;
                             }
                         })

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -174,12 +174,8 @@ export function makePluginUI(
                                         error: 'SANDBOX_OOM',
                                     };
                                 }
-                                console.error(`plugin ${p.id}:`, err);
-                                console.log(`Removing plugin ${p.id} from 'active' due to error`);
+                                console.error(`Removing plugin ${p.id} from 'active' due to error`, err);
                                 active.delete(p.id);
-                                console.log(`removed`);
-                                // NEED TO *UNLOAD* PLUGIN FROM CONTEXT - DESTROY CONTEXT
-                                // use p.id to call from sandbox to delete context properly
                                 sandbox.deleteContext(p.id);
                                 return null;
                             }
@@ -376,9 +372,7 @@ export async function loadPlugin(
                 state: apiv1.normalizePluginState(_pluginResponse, submitProxy),
             };
         } catch (err) {
-            // call sandbox dispose all
-            if (String(err).includes('memory')) {
-                //await sandbox.disposeRuntime();
+            if (String(err).includes('SANDBOX_OOM') || String(err).includes('out of memory')) {
                 throw new Error('SANDBOX_OOM');
             }
             console.error('plugin did not return an expected response object:', err);

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -26,7 +26,6 @@ export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>;
 
 export interface Sandbox {
     init: () => Promise<void>;
-    disposeRuntime;
     newContext: (
         dispatch: PluginDispatchFunc,
         logMessage: Logger,
@@ -327,6 +326,7 @@ export interface PluginState {
 export interface PluginUpdateResponse {
     config: PluginConfig;
     state: PluginState;
+    error?: string;
 }
 
 export type PluginSubmitProxy = (ref: string, values: PluginSubmitCallValues) => Promise<void>;

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -26,12 +26,15 @@ export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>;
 
 export interface Sandbox {
     init: () => Promise<void>;
+    disposeRuntime;
     newContext: (
         dispatch: PluginDispatchFunc,
         logMessage: Logger,
         questMessage: Logger,
         config: PluginConfig,
     ) => Promise<number>;
+    deleteContext;
+    hasContext;
     evalCode: (context: number, code: string) => Promise<any>;
     setState: (state: GameStatePlugin, blk: number) => Promise<void>;
 }

--- a/frontend/src/hooks/use-game-state.tsx
+++ b/frontend/src/hooks/use-game-state.tsx
@@ -176,6 +176,12 @@ export function usePlayer(): ConnectedPlayer | undefined {
     return useSource(sources.player);
 }
 
+// This should become a function to call the reloading of the plugins
+export function usePluginReload(): number | undefined {
+    const sources = useSources();
+    return useSource(sources.block);
+}
+
 export function useWallet(): { wallet: Wallet | undefined; selectProvider: Selector<WalletProvider> | undefined } {
     const sources = useSources();
     const wallet = useSource(sources.wallet);

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -75,6 +75,7 @@ export async function init() {
 }
 
 export async function disposeRuntime() {
+    // renamed branch
     if (!runtime) return;
     console.log('%c DISPOSING CONTEXTS & RUNTIME...', 'background: #222; color: #bada55');
     const disposeContextPromises = contexts.map((ctx) => {

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -108,7 +108,7 @@ export async function disposeRuntime() {
         await init();
         console.log('%c runtime re-initialized successfully...', 'background: #222; color: #bada55');
     } catch (err) {
-        console.error('Error disposing runtime: ', err);
+        console.error('Error re-initializing runtime: ', err);
     }
 
     console.log('runtime after: ', await runtime.dumpMemoryUsage());

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -60,7 +60,7 @@ export async function init() {
 
     runtime = qjs.newRuntime();
     // runtime.setMemoryLimit(1024 * 640);
-    runtime.setMemoryLimit(50000);
+    runtime.setMemoryLimit(1024 * 640 * 20);
     runtime.setMaxStackSize(1024 * 320);
 
     pollPendingJobs();

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -77,6 +77,7 @@ export async function init() {
 export async function disposeRuntime() {
     // renamed branch
     if (!runtime) return;
+    console.log('runtime before: ', await runtime.dumpMemoryUsage());
     console.log('%c DISPOSING CONTEXTS & RUNTIME...', 'background: #222; color: #bada55');
     const disposeContextPromises = contexts.map((ctx) => {
         return new Promise((resolve, reject) => {
@@ -98,19 +99,19 @@ export async function disposeRuntime() {
     //contexts = [];
 
     try {
-        clearTimeout(pollPendingJobsTimeout);
-        console.log('%c cleared pending jobs timeout (remove this later?)...', 'background: #222; color: #bada55');
+        //clearTimeout(pollPendingJobsTimeout);
+        //console.log('%c cleared pending jobs timeout (remove this later?)...', 'background: #222; color: #bada55');
     } catch (err) {
         console.error('Error clearing pollPendingJobs timeout: ', err);
     }
     try {
-        // console.log('runtime has pending stuff? ', runtime.hasPendingJob());
-        console.log('runtime: ', runtime);
-        runtime.dispose(); // Error disposing runtime:  RuntimeError: Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at: quickjs/quickjs.c,1983,JS_FreeRuntime).
-        console.log('%c runtime disposed successfully...', 'background: #222; color: #bada55');
+        await init();
+        console.log('%c runtime re-initialized successfully...', 'background: #222; color: #bada55');
     } catch (err) {
         console.error('Error disposing runtime: ', err);
     }
+
+    console.log('runtime after: ', await runtime.dumpMemoryUsage());
 }
 
 // can also die at update time

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -6,8 +6,6 @@ import {
     PluginDispatchFunc,
     Sandbox,
 } from '@downstream/core';
-// This causes error - map doesn't load! need to find a way to call something in here
-// import { usePluginReload } from '../hooks/use-game-state';
 import * as Comlink from 'comlink';
 import { QuickJSContext, QuickJSRuntime, getQuickJS } from 'quickjs-emscripten';
 import { ethers } from 'ethers';

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -6,6 +6,8 @@ import {
     PluginDispatchFunc,
     Sandbox,
 } from '@downstream/core';
+// This causes error - map doesn't load! need to find a way to call something in here
+// import { usePluginReload } from '../hooks/use-game-state';
 import * as Comlink from 'comlink';
 import { QuickJSContext, QuickJSRuntime, getQuickJS } from 'quickjs-emscripten';
 import { ethers } from 'ethers';
@@ -13,8 +15,6 @@ import { ethers } from 'ethers';
 let runtime: QuickJSRuntime;
 
 const contexts: QuickJSContext[] = [];
-
-let pollPendingJobsTimeout;
 
 // wrapper functions loaded by the fake 'downstream' module within the guest
 // to make it feel like a "normal" library import and potentially keep compatibility
@@ -49,6 +49,8 @@ export default {
 };
 `;
 
+let pollPendingJobsTimeout: NodeJS.Timeout;
+
 function pollPendingJobs() {
     if (runtime && runtime.hasPendingJob()) {
         runtime.executePendingJobs(1);
@@ -75,6 +77,7 @@ export async function init() {
 }
 
 export async function disposeRuntime() {
+    console.log('pre dispose testing! ', usePluginReload);
     // renamed branch
     if (!runtime) return;
     console.log('runtime before: ', await runtime.dumpMemoryUsage());

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -77,7 +77,6 @@ export async function init() {
 }
 
 export async function disposeRuntime() {
-    console.log('pre dispose testing! ', usePluginReload);
     // renamed branch
     if (!runtime) return;
     console.log('runtime before: ', await runtime.dumpMemoryUsage());

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -12,7 +12,7 @@ import { ethers } from 'ethers';
 
 let runtime: QuickJSRuntime;
 
-const contexts: QuickJSContext[] = [];
+let contexts: QuickJSContext[] = [];
 
 // wrapper functions loaded by the fake 'downstream' module within the guest
 // to make it feel like a "normal" library import and potentially keep compatibility
@@ -60,7 +60,7 @@ export async function init() {
 
     runtime = qjs.newRuntime();
     // runtime.setMemoryLimit(1024 * 640);
-    runtime.setMemoryLimit(1024 * 640);
+    runtime.setMemoryLimit(50000);
     runtime.setMaxStackSize(1024 * 320);
 
     pollPendingJobs();
@@ -70,6 +70,13 @@ export async function init() {
     //     console.log('int');
     //     return ++interruptCycles > 1024;
     // });
+}
+
+function disposeRuntime() {
+    if (!runtime) return;
+    contexts.forEach((ctx) => ctx.dispose());
+    contexts = [];
+    // runtime.dispose(); // need to dipose everything inside runtime first?
 }
 
 export async function setState(newState: GameStatePlugin, newBlock: number) {


### PR DESCRIPTION
## What
While testing, we have discovered that when the sandbox has run out of memory, all plugins fall over causing indefinite errors, and plugins to fail.
We want a way of catching the out-of-memory errors as they appear, and immediately addressing them before they lead to more problems (plugins/sandbox to crash).

So far, there are certain checks similar to this:
```js
catch (err) {
                if (String(err).includes('memory')) {
                    try {
                        await disposeRuntime();
...
```
that call the disposeRuntime() function:
```js
export async function disposeRuntime() {
    // renamed branch
    if (!runtime) return;
    console.log('%c DISPOSING CONTEXTS & RUNTIME...', 'background: #222; color: #bada55');
    const disposeContextPromises = contexts.map((ctx) => {
        return new Promise((resolve, reject) => {
            try {
                ctx.dispose();
                resolve(ctx);
            } catch (err) {
                reject(err);
            }
        });
    });

    try {
        await Promise.all(disposeContextPromises);
        console.log('%c contexts disposed successfully...', 'background: #222; color: #bada55');
    } catch (err) {
        console.error('Error disposing contexts: ', err);
    }
    //contexts = [];

    try {
        clearTimeout(pollPendingJobsTimeout);
        console.log('%c cleared pending jobs timeout (remove this later?)...', 'background: #222; color: #bada55');
    } catch (err) {
        console.error('Error clearing pollPendingJobs timeout: ', err);
    }
    try {
        // console.log('runtime has pending stuff? ', runtime.hasPendingJob());
        console.log('runtime: ', runtime);
        runtime.dispose(); // Error disposing runtime:  RuntimeError: Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at: quickjs/quickjs.c,1983,JS_FreeRuntime).
        console.log('%c runtime disposed successfully...', 'background: #222; color: #bada55');
    } catch (err) {
        console.error('Error disposing runtime: ', err);
    }
}
```

The current dilemma is that executing `runtime.dispose()` is triggering this error:
_"Error disposing runtime:  RuntimeError: Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at: quickjs/quickjs.c,1983,JS_FreeRuntime)."_

I am currently working to resolve this error so I can make a way to reboot the runtime/contexts

_Edit 09/02/24_:
Worked with Farms on this issue, and we're now restarting the sandbox whenever OOM is detected!
We are still disposing and removing contexts (plugins) if they trigger an error, but the `disposeRuntime` function is no longer needed.

resolves #1001 