### PR TITLE
1kx mods

### DIFF
--- a/contracts/src/common/extractors/BlueExtractor.sol
+++ b/contracts/src/common/extractors/BlueExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract BlueExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/common/extractors/GreenExtractor.sol
+++ b/contracts/src/common/extractors/GreenExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract GreenExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/common/extractors/RedExtractor.sol
+++ b/contracts/src/common/extractors/RedExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract RedExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/example-plugins/BasicFactory/BasicFactory.sol
+++ b/contracts/src/example-plugins/BasicFactory/BasicFactory.sol
@@ -10,14 +10,14 @@ import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 using Schema for State;
 
 contract BasicFactory is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 
     // version of use that restricts crafting to building owner, author or allow list
     // these restrictions will not be reflected in the UI unless you make
     // similar changes in BasicFactory.js
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public {
+    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) override public {
         State state = GetState(ds);
         CheckIsFriendlyUnit(state, actor, buildingInstance);
 
@@ -25,7 +25,7 @@ contract BasicFactory is BuildingKind {
     }*/
 
     // version of use that restricts crafting to units carrying a certain item
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public {
+    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) override public {
         // require carrying an idCard
         // you can change idCardItemId to another item id
         CheckIsCarryingItem(state, actor, idCardItemId);

--- a/contracts/src/example-plugins/Cocktails/CocktailHut.sol
+++ b/contracts/src/example-plugins/Cocktails/CocktailHut.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract CocktailHut is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/example-plugins/DuckBurger/CountdownBuilding.sol
+++ b/contracts/src/example-plugins/DuckBurger/CountdownBuilding.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract CountdownBuilding is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/example-plugins/DuckBurger/DisplayBuilding.sol
+++ b/contracts/src/example-plugins/DuckBurger/DisplayBuilding.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract DisplayBuilding is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
@@ -25,7 +25,7 @@ contract DuckBurgerHQ is BuildingKind {
     function claim() external {}
     function reset() external {}
 
-    function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes calldata payload) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes calldata payload) public override {
         State state = GetState(ds);
 
         // decode payload and call one of _join, _start, _claim or _reset

--- a/contracts/src/example-plugins/StateStorage/StateStorage.sol
+++ b/contracts/src/example-plugins/StateStorage/StateStorage.sol
@@ -10,7 +10,7 @@ import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 using Schema for State;
 
 contract BasicFactory is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory /*payload*/ ) public override {
         State state = GetState(ds);
         // NOTE: Added 64 bits (8 bytes) of padding to the 24 byte ID
         ds.getDispatcher().dispatch(

--- a/contracts/src/ext/BuildingKind.sol
+++ b/contracts/src/ext/BuildingKind.sol
@@ -3,7 +3,12 @@ pragma solidity ^0.8.13;
 
 import "cog/IGame.sol";
 
-interface BuildingKind {
+interface IBuildingKind {
     function use(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) external;
     function construct(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) external;
+}
+
+contract BuildingKind is IBuildingKind {
+    function use(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) virtual external {}
+    function construct(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) virtual external {}
 }

--- a/contracts/src/ext/BuildingKind.sol
+++ b/contracts/src/ext/BuildingKind.sol
@@ -9,6 +9,9 @@ interface IBuildingKind {
 }
 
 contract BuildingKind is IBuildingKind {
-    function use(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) virtual external {}
-    function construct(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) virtual external {}
+    function use(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) external virtual {}
+    function construct(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload)
+        external
+        virtual
+    {}
 }

--- a/contracts/src/ext/BuildingKind.sol
+++ b/contracts/src/ext/BuildingKind.sol
@@ -5,4 +5,5 @@ import "cog/IGame.sol";
 
 interface BuildingKind {
     function use(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) external;
+    function construct(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) external;
 }

--- a/contracts/src/maps/arena-1kx/Extractors/BlueExtractor.sol
+++ b/contracts/src/maps/arena-1kx/Extractors/BlueExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract BlueExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/arena-1kx/Extractors/GreenExtractor.sol
+++ b/contracts/src/maps/arena-1kx/Extractors/GreenExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract GreenExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/arena-1kx/Extractors/RedExtractor.sol
+++ b/contracts/src/maps/arena-1kx/Extractors/RedExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract RedExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/CorruptedUser/CorruptedUser.sol
+++ b/contracts/src/maps/quest-map/CorruptedUser/CorruptedUser.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract CorruptedUser is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/CorruptedUser/IndustrialEspionage.sol
+++ b/contracts/src/maps/quest-map/CorruptedUser/IndustrialEspionage.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract IndustrialEspionage is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/CorruptedUser/ShirtShop.sol
+++ b/contracts/src/maps/quest-map/CorruptedUser/ShirtShop.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract ShirtShop is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/CorruptedUser/TieShop.sol
+++ b/contracts/src/maps/quest-map/CorruptedUser/TieShop.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract TieShop is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/Creation/VaultOfKnowledge.sol
+++ b/contracts/src/maps/quest-map/Creation/VaultOfKnowledge.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract VaultOfKnowledge is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/Creation/VeryImportantFactory.sol
+++ b/contracts/src/maps/quest-map/Creation/VeryImportantFactory.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract VeryImportantFactory is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/Fusion/BlueGooFission.sol
+++ b/contracts/src/maps/quest-map/Fusion/BlueGooFission.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract BlueGooFission is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/Fusion/BlueGooFusion.sol
+++ b/contracts/src/maps/quest-map/Fusion/BlueGooFusion.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract BlueGooFusion is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/Fusion/GreenGooFission.sol
+++ b/contracts/src/maps/quest-map/Fusion/GreenGooFission.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract GreenGooFission is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/Fusion/GreenGooFusion.sol
+++ b/contracts/src/maps/quest-map/Fusion/GreenGooFusion.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract GreenGooFusion is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/Fusion/RedGooFission.sol
+++ b/contracts/src/maps/quest-map/Fusion/RedGooFission.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract RedGooFission is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/Fusion/RedGooFusion.sol
+++ b/contracts/src/maps/quest-map/Fusion/RedGooFusion.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract RedGooFusion is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/IntroOrientation/ControlTower.sol
+++ b/contracts/src/maps/quest-map/IntroOrientation/ControlTower.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract ControlTower is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/IntroOrientation/DeletionSupplies.sol
+++ b/contracts/src/maps/quest-map/IntroOrientation/DeletionSupplies.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract DeletionSupplies is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/IntroOrientation/RegistrationOffice.sol
+++ b/contracts/src/maps/quest-map/IntroOrientation/RegistrationOffice.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract RegistrationOffice is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/quest-map/WorldCreation/WorldConstructor.sol
+++ b/contracts/src/maps/quest-map/WorldCreation/WorldConstructor.sol
@@ -6,7 +6,10 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract WorldConstructor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/team-vanilla/BlueExtractor.sol
+++ b/contracts/src/maps/team-vanilla/BlueExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract BlueExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/team-vanilla/GooReclaim/BurgerGooHub/BurgerGooHub.sol
+++ b/contracts/src/maps/team-vanilla/GooReclaim/BurgerGooHub/BurgerGooHub.sol
@@ -11,7 +11,7 @@ import {ItemUtils} from "@ds/utils/ItemUtils.sol";
 using Schema for State;
 
 contract Locker is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24 mobileUnit, bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24 mobileUnit, bytes memory /*payload*/ ) public override {
         // Decode the function
         State state = ds.getState();
         bytes24 buildingBag = state.getEquipSlot(buildingInstance, 0);

--- a/contracts/src/maps/team-vanilla/GooReclaim/DuckGooHub/DuckGooHub.sol
+++ b/contracts/src/maps/team-vanilla/GooReclaim/DuckGooHub/DuckGooHub.sol
@@ -11,7 +11,7 @@ import {ItemUtils} from "@ds/utils/ItemUtils.sol";
 using Schema for State;
 
 contract Locker is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24 mobileUnit, bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24 mobileUnit, bytes memory /*payload*/ ) public override {
         // Decode the function
         State state = ds.getState();
         bytes24 buildingBag = state.getEquipSlot(buildingInstance, 0);

--- a/contracts/src/maps/team-vanilla/GreenExtractor.sol
+++ b/contracts/src/maps/team-vanilla/GreenExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract GreenExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/maps/team-vanilla/RedExtractor.sol
+++ b/contracts/src/maps/team-vanilla/RedExtractor.sol
@@ -6,7 +6,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 contract RedExtractor is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.EXTRACT, (buildingInstance)));
     }
 }

--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -231,6 +231,16 @@ contract BuildingRule is Rule {
         if (TileUtils.distance(mobileUnitTile, targetTile) > 1 || !TileUtils.isDirect(mobileUnitTile, targetTile)) {
             revert("BuildingMustBeAdjacentToMobileUnit");
         }
+
+        // calls the preflight hook in the building implementation to add the possibility to make conditional builds 
+        // or consume inventory while building
+        BuildingKind buildingImplementation = BuildingKind(state.getImplementation(buildingKind));
+        // if no implementation set, then this is a no-op
+        if (address(buildingImplementation) == address(0)) {
+            return;
+        }
+        buildingImplementation.construct(game, buildingKind, mobileUnit, abi.encode(coords));
+
         bytes24 buildingInstance = Node.Building(DEFAULT_ZONE, coords[0], coords[1], coords[2]);
         // burn resources from given towards construction
         _payConstructionFee(state, buildingKind, buildingInstance);

--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -236,10 +236,9 @@ contract BuildingRule is Rule {
         // or consume inventory while building
         BuildingKind buildingImplementation = BuildingKind(state.getImplementation(buildingKind));
         // if no implementation set, then this is a no-op
-        if (address(buildingImplementation) == address(0)) {
-            return;
+        if (address(buildingImplementation) != address(0)) {
+            buildingImplementation.construct(game, buildingKind, mobileUnit, abi.encode(coords));
         }
-        buildingImplementation.construct(game, buildingKind, mobileUnit, abi.encode(coords));
 
         bytes24 buildingInstance = Node.Building(DEFAULT_ZONE, coords[0], coords[1], coords[2]);
         // burn resources from given towards construction

--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -232,7 +232,7 @@ contract BuildingRule is Rule {
             revert("BuildingMustBeAdjacentToMobileUnit");
         }
 
-        // calls the preflight hook in the building implementation to add the possibility to make conditional builds 
+        // calls the preflight hook in the building implementation to add the possibility to make conditional builds
         // or consume inventory while building
         BuildingKind buildingImplementation = BuildingKind(state.getImplementation(buildingKind));
         // if no implementation set, then this is a no-op

--- a/contracts/test/rules/BagRule.t.sol
+++ b/contracts/test/rules/BagRule.t.sol
@@ -315,7 +315,7 @@ contract MockBuildingKind is BuildingKind {
 
     UseArgs[] public useCalls;
 
-    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) public {
+    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) override public {
         UseArgs storage call = useCalls.push();
         call.game = game;
         call.building = building;

--- a/contracts/test/rules/BagRule.t.sol
+++ b/contracts/test/rules/BagRule.t.sol
@@ -315,7 +315,7 @@ contract MockBuildingKind is BuildingKind {
 
     UseArgs[] public useCalls;
 
-    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) override public {
+    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) public override {
         UseArgs storage call = useCalls.push();
         call.game = game;
         call.building = building;

--- a/contracts/test/rules/BuildingRule.t.sol
+++ b/contracts/test/rules/BuildingRule.t.sol
@@ -332,7 +332,7 @@ contract MockBuildingKind is BuildingKind {
 
     UseArgs[] public useCalls;
 
-    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) public {
+    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) override public {
         UseArgs storage call = useCalls.push();
         call.game = game;
         call.building = building;

--- a/contracts/test/rules/BuildingRule.t.sol
+++ b/contracts/test/rules/BuildingRule.t.sol
@@ -332,7 +332,7 @@ contract MockBuildingKind is BuildingKind {
 
     UseArgs[] public useCalls;
 
-    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) override public {
+    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) public override {
         UseArgs storage call = useCalls.push();
         call.game = game;
         call.building = building;

--- a/contracts/test/rules/CraftingRule.t.sol
+++ b/contracts/test/rules/CraftingRule.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../helpers/GameTest.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 using Schema for State;
 
@@ -10,8 +11,11 @@ uint8 constant MAX_CRAFT_INPUT_ITEMS = 4;
 bool constant ITEM_STACKABLE = true;
 bool constant ITEM_EQUIPABLE = false;
 
-contract MockCraftBuildingContract {
-    function use(Game, /*ds*/ bytes24, /*buildingInstance*/ bytes24, /*mobileUnit*/ bytes memory /*payload*/ ) public {}
+contract MockCraftBuildingContract is BuildingKind {
+    function use(Game, /*ds*/ bytes24, /*buildingInstance*/ bytes24, /*mobileUnit*/ bytes memory /*payload*/ )
+        public
+        override
+    {}
 }
 
 contract CraftingRuleTest is Test, GameTest {

--- a/contracts/test/rules/ExtractionRule.t.sol
+++ b/contracts/test/rules/ExtractionRule.t.sol
@@ -5,6 +5,7 @@ import "../helpers/GameTest.sol";
 
 import {GOO_PER_SEC, GOO_RESERVOIR_MAX} from "@ds/rules/ExtractionRule.sol";
 import {BuildingBlockNumKey} from "@ds/schema/Schema.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 
 using Schema for State;
 
@@ -14,8 +15,11 @@ uint64 constant BLOCKS_TO_MAX_RESERVOIR = ((GOO_RESERVOIR_MAX * 100) / (GOO_PER_
 bool constant ITEM_STACKABLE = true;
 bool constant ITEM_EQUIPABLE = false;
 
-contract MockCraftBuildingContract {
-    function use(Game, /*ds*/ bytes24, /*buildingInstance*/ bytes24, /*mobileUnit*/ bytes memory /*payload*/ ) public {}
+contract MockCraftBuildingContract is BuildingKind {
+    function use(Game, /*ds*/ bytes24, /*buildingInstance*/ bytes24, /*mobileUnit*/ bytes memory /*payload*/ )
+        public
+        override
+    {}
 }
 
 contract ExtractionRuleTest is Test, GameTest {

--- a/contracts/test/rules/InventoryRule.t.sol
+++ b/contracts/test/rules/InventoryRule.t.sol
@@ -17,7 +17,7 @@ uint64 constant BUILDING_KIND_ID_1 = 20;
 uint64 constant BUILDING_KIND_ID_2 = 21;
 
 contract MockBuildingKind is BuildingKind {
-    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) public {}
+    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) override public {}
 }
 
 contract InventoryRuleTest is Test, GameTest {

--- a/contracts/test/rules/InventoryRule.t.sol
+++ b/contracts/test/rules/InventoryRule.t.sol
@@ -17,7 +17,7 @@ uint64 constant BUILDING_KIND_ID_1 = 20;
 uint64 constant BUILDING_KIND_ID_2 = 21;
 
 contract MockBuildingKind is BuildingKind {
-    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) override public {}
+    function use(Game game, bytes24 building, bytes24 mobileUnit, bytes memory payload) public override {}
 }
 
 contract InventoryRuleTest is Test, GameTest {


### PR DESCRIPTION
# What

The mod 1kx did to add a `construct` hook to buildings which get's called by the Building rule when the building is constructed

A new virtual base class `BuildingKind` has been created which allows the builder to override either `use` or `construct` if they wish to use them. This has meant that all our existing contracts have had to have `override` added to their use functions as they are now overriding this new base class instead of implementing an interface as before. 

# Changes to Duck Burger

I had to make adjustments to `DuckerBurgerHQ` to bring it under 24kb as it wasn't compiling after inheriting from the base `BuildingKind` contract. The changes were essentially refactoring all the set data action dispatches to use an internal function instead.

fixes #993 