### PR TITLE
BasicFatory.sol exported from fabricator matches example code

### DIFF
--- a/contracts/src/example-plugins/BasicFactory/BasicFactory.sol
+++ b/contracts/src/example-plugins/BasicFactory/BasicFactory.sol
@@ -17,7 +17,7 @@ contract BasicFactory is BuildingKind {
     // version of use that restricts crafting to building owner, author or allow list
     // these restrictions will not be reflected in the UI unless you make
     // similar changes in BasicFactory.js
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) override public {
+    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public override {
         State state = GetState(ds);
         CheckIsFriendlyUnit(state, actor, buildingInstance);
 
@@ -25,7 +25,7 @@ contract BasicFactory is BuildingKind {
     }*/
 
     // version of use that restricts crafting to units carrying a certain item
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) override public {
+    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public override {
         // require carrying an idCard
         // you can change idCardItemId to another item id
         CheckIsCarryingItem(state, actor, idCardItemId);

--- a/frontend/src/pages/building-fabricator.tsx
+++ b/frontend/src/pages/building-fabricator.tsx
@@ -248,14 +248,14 @@ import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 using Schema for State;
 
 contract BasicFactory is BuildingKind {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 
     // version of use that restricts crafting to building owner, author or allow list
     // these restrictions will not be reflected in the UI unless you make
     // similar changes in BasicFactory.js
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public {
+    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public override {
         State state = GetState(ds);
         CheckIsFriendlyUnit(state, actor, buildingInstance);
 
@@ -263,7 +263,7 @@ contract BasicFactory is BuildingKind {
     }*/
 
     // version of use that restricts crafting to units carrying a certain item
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public {
+    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public override {
         // require carrying an idCard
         // you can change idCardItemId to another item id
         CheckIsCarryingItem(state, actor, idCardItemId);


### PR DESCRIPTION
### What 
The building fabricator exports a hardcoded string of solidity code that should be an exact match of the examples/BasicFactory.sol

This got out of sync in #1031 

(also matched syntax for override function in commented out code - just cosmetic consistency)