### PR TITLE
race condition on deploy before anvil ready

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -38,6 +38,7 @@ async function handleStartup(){
         {
             name: 'contract',
             command: `./lib/cog/services/bin/wait-for -it localhost:8545 -t 300 \
+                && sleep 3 \
                 && forge script script/Deploy.sol:GameDeployer --broadcast --rpc-url "http://localhost:8545" \
                 && ./lib/cog/services/bin/wait-for -it localhost:8080 -t 300 \
                 && sleep 2 \

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -40,6 +40,12 @@ while ! curl -sf -X POST --data '{"jsonrpc":"2.0","method":"eth_blockNumber","pa
 	echo "waiting for evm node to respond..."
 	sleep 1
 done
+
+# theres a race where anvil is not quite ready to deploy to
+# FIXME: we need a better way than checking the eth_blockNumber response as a readyness check
+sleep 2
+
+
 forge script script/Deploy.sol:GameDeployer --broadcast --rpc-url "http://localhost:8545" --slow
 
 echo "+---------------------+"


### PR DESCRIPTION
we are starting to see intermittent failures on startup during the deployment of fresh contracts.

it's not clear yet why this is, but adding in a horrible sleep to both devstartup and the container startup to workaround it for the moment.

fixes: #1042  (hopefully 🤞 )