### PR TITLE
Location hook

### DIFF
--- a/cli/test/examples/Building.sol
+++ b/cli/test/examples/Building.sol
@@ -4,7 +4,10 @@ pragma solidity ^0.8.13;
 import "@ds/IDownstream.sol";
 
 contract HammerFactory {
-    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ ) public {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*mobileUnit*/ bytes calldata /*payload*/ )
+        public
+        override
+    {
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }
 }

--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -50,7 +50,7 @@ contract GameDeployer is Script {
         // enable rules
         BaseDispatcher dispatcher = BaseDispatcher(address(ds.getDispatcher()));
         dispatcher.registerRule(new CheatsRule(deployerAddr));
-        dispatcher.registerRule(new MovementRule());
+        dispatcher.registerRule(new MovementRule(ds));
         dispatcher.registerRule(new ScoutRule());
         dispatcher.registerRule(new InventoryRule());
         dispatcher.registerRule(new BuildingRule(ds));

--- a/contracts/src/example-plugins/Gate/Gate.js
+++ b/contracts/src/example-plugins/Gate/Gate.js
@@ -1,0 +1,152 @@
+import ds from "downstream";
+
+export default async function update(state) {
+    // uncomment this to browse the state object in browser console
+    // this will be logged when selecting a unit and then selecting an instance of this building
+    // logState(state);
+
+    const selectedTile = getSelectedTile(state);
+    const selectedBuilding =
+        selectedTile && getBuildingOnTile(state, selectedTile);
+
+    if (selectedBuilding) {
+        console.log(selectedBuilding);
+    }
+
+    return {
+        version: 1,
+        components: [
+            {
+                id: "state-storage-test",
+                type: "building",
+                content: [
+                    {
+                        id: "default",
+                        type: "inline",
+                        html: `
+                            <p>Look in console to see data on this building</p>
+                        `,
+                        buttons: [],
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+function getMobileUnit(state) {
+    return state?.selected?.mobileUnit;
+}
+
+function getSelectedTile(state) {
+    const tiles = state?.selected?.tiles || {};
+    return tiles && tiles.length === 1 ? tiles[0] : undefined;
+}
+
+function getBuildingOnTile(state, tile) {
+    return (state?.world?.buildings || []).find(
+        (b) => tile && b.location?.tile?.id === tile.id,
+    );
+}
+
+// returns an array of items the building expects as input
+function getRequiredInputItems(building) {
+    return building?.kind?.inputs || [];
+}
+
+// search through all the bags in the world to find those belonging to this building
+function getBuildingBags(state, building) {
+    return building
+        ? (state?.world?.bags || []).filter(
+              (bag) => bag.equipee?.node.id === building.id,
+          )
+        : [];
+}
+
+// get building input slots
+function getInputSlots(state, building) {
+    // inputs are the bag with key 0 owned by the building
+    const buildingBags = getBuildingBags(state, building);
+    const inputBag = buildingBags.find((bag) => bag.equipee.key === 0);
+
+    // slots used for crafting have sequential keys startng with 0
+    return inputBag && inputBag.slots.sort((a, b) => a.key - b.key);
+}
+
+// are the required craft input items in the input slots?
+function inputsAreCorrect(state, building) {
+    const requiredInputItems = getRequiredInputItems(building);
+    const inputSlots = getInputSlots(state, building);
+
+    return (
+        inputSlots &&
+        inputSlots.length >= requiredInputItems.length &&
+        requiredInputItems.every(
+            (requiredItem) =>
+                inputSlots[requiredItem.key].item.id == requiredItem.item.id &&
+                inputSlots[requiredItem.key].balance == requiredItem.balance,
+        )
+    );
+}
+
+function getData(buildingInstance, key) {
+    return getKVPs(buildingInstance)[key];
+}
+
+function getDataBool(buildingInstance, key) {
+    var hexVal = getData(buildingInstance, key);
+    return typeof hexVal === "string" ? parseInt(hexVal, 16) == 1 : false;
+}
+
+function getKVPs(buildingInstance) {
+    return buildingInstance.allData.reduce((kvps, data) => {
+        kvps[data.name] = data.value;
+        return kvps;
+    }, {});
+}
+
+function logState(state) {
+    console.log("State sent to pluging:", state);
+}
+
+const friendlyPlayerAddresses = [
+    // 0x402462EefC217bf2cf4E6814395E1b61EA4c43F7
+];
+
+function unitIsFriendly(state, selectedBuilding) {
+    const mobileUnit = getMobileUnit(state);
+    return (
+        unitIsBuildingOwner(mobileUnit, selectedBuilding) ||
+        unitIsBuildingAuthor(mobileUnit, selectedBuilding) ||
+        friendlyPlayerAddresses.some((addr) =>
+            unitOwnerConnectedToWallet(state, mobileUnit, addr),
+        )
+    );
+}
+
+function unitIsBuildingOwner(mobileUnit, selectedBuilding) {
+    //console.log('unit owner id:',  mobileUnit?.owner?.id, 'building owner id:', selectedBuilding?.owner?.id);
+    return (
+        mobileUnit?.owner?.id &&
+        mobileUnit?.owner?.id === selectedBuilding?.owner?.id
+    );
+}
+
+function unitIsBuildingAuthor(mobileUnit, selectedBuilding) {
+    //console.log('unit owner id:',  mobileUnit?.owner?.id, 'building author id:', selectedBuilding?.kind?.owner?.id);
+    return (
+        mobileUnit?.owner?.id &&
+        mobileUnit?.owner?.id === selectedBuilding?.kind?.owner?.id
+    );
+}
+
+function unitOwnerConnectedToWallet(state, mobileUnit, walletAddress) {
+    //console.log('Checking player:',  state?.player, 'controls unit', mobileUnit, walletAddress);
+    return (
+        mobileUnit?.owner?.id == state?.player?.id &&
+        state?.player?.addr == walletAddress
+    );
+}
+
+// the source for this code is on github where you can find other example buildings:
+// https://github.com/playmint/ds/tree/main/contracts/src/example-plugins

--- a/contracts/src/example-plugins/Gate/Gate.sol
+++ b/contracts/src/example-plugins/Gate/Gate.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Dispatcher} from "cog/IDispatcher.sol";
+import {State} from "cog/IState.sol";
+import {Schema} from "@ds/schema/Schema.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+using Schema for State;
+
+contract ExampleGate is BuildingKind {
+    function onUnitArrive(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID) public override {
+        _setDataOnBuilding(ds.getDispatcher(), buildingInstanceID, "unitArrive", bytes32(mobileUnitID));
+    }
+
+    function onUnitLeave(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID) public override {
+        _setDataOnBuilding(ds.getDispatcher(), buildingInstanceID, "unitLeave", bytes32(mobileUnitID));
+    }
+
+    function _setDataOnBuilding(Dispatcher dispatcher, bytes24 buildingId, string memory key, bytes32 value) internal {
+        dispatcher.dispatch(abi.encodeCall(Actions.SET_DATA_ON_BUILDING, (buildingId, key, value)));
+    }
+}

--- a/contracts/src/example-plugins/Gate/Gate.sol
+++ b/contracts/src/example-plugins/Gate/Gate.sol
@@ -4,22 +4,55 @@ pragma solidity ^0.8.13;
 import {Game} from "cog/IGame.sol";
 import {Dispatcher} from "cog/IDispatcher.sol";
 import {State} from "cog/IState.sol";
-import {Schema} from "@ds/schema/Schema.sol";
+import {Schema, Kind} from "@ds/schema/Schema.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+import {ItemUtils} from "@ds/utils/ItemUtils.sol";
 
 using Schema for State;
 
 contract ExampleGate is BuildingKind {
     function onUnitArrive(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID) public override {
-        _setDataOnBuilding(ds.getDispatcher(), buildingInstanceID, "unitArrive", bytes32(mobileUnitID));
+        // Example of logging the last unit to arrive at a building
+        _setDataOnBuilding(ds.getDispatcher(), buildingInstanceID, "lastUnitToArrive", bytes32(mobileUnitID));
+
+        // Example of not allowing a unit to stand on the building tile unless they have the ID Card item
+        ( /*uint8 bagSlot*/ , /*uint8 itemSlot*/, uint64 balance) =
+            _findItem(ds.getState(), mobileUnitID, ItemUtils.IDCard());
+        require(balance > 0, "ExampleGate: Unit does not have ID Card");
     }
 
     function onUnitLeave(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID) public override {
-        _setDataOnBuilding(ds.getDispatcher(), buildingInstanceID, "unitLeave", bytes32(mobileUnitID));
+        // Example of logging the last unit to leave a building
+        _setDataOnBuilding(ds.getDispatcher(), buildingInstanceID, "lastUnitToLeave", bytes32(mobileUnitID));
     }
 
     function _setDataOnBuilding(Dispatcher dispatcher, bytes24 buildingId, string memory key, bytes32 value) internal {
         dispatcher.dispatch(abi.encodeCall(Actions.SET_DATA_ON_BUILDING, (buildingId, key, value)));
+    }
+
+    // NOTE: This function will return the first bag/slot/balance of the first slot that has the item we're searching for.
+    // It doesn't doesn't sum the balance of all slots with the same item kind
+    function _findItem(State state, bytes24 mobileUnitID, bytes24 itemId)
+        private
+        view
+        returns (uint8 bagSlot, uint8 itemSlot, uint64 balance)
+    {
+        for (bagSlot = 0; bagSlot < 2; bagSlot++) {
+            bytes24 bagId = state.getEquipSlot(mobileUnitID, bagSlot);
+
+            require(bytes4(bagId) == Kind.Bag.selector, "_findItem(): No bag found at equip slot");
+
+            for (itemSlot = 0; itemSlot < 4; itemSlot++) {
+                bytes24 bagItemId;
+                (bagItemId, balance) = state.getItemSlot(bagId, itemSlot);
+                if (bagItemId == itemId) {
+                    // Found item
+                    return (bagSlot, itemSlot, balance);
+                }
+            }
+        }
+
+        return (0, 0, 0);
     }
 }

--- a/contracts/src/example-plugins/Gate/Gate.yaml
+++ b/contracts/src/example-plugins/Gate/Gate.yaml
@@ -1,0 +1,29 @@
+---
+kind: BuildingKind
+spec:
+  category: custom
+  name: example gate
+  description: Building used gate off areas
+  model: 05-11
+  color: 5
+  contract:
+    file: ./Gate.sol
+  plugin:
+    file: ./Gate.js
+  materials:
+    - name: Red Goo
+      quantity: 10
+    - name: Green Goo
+      quantity: 10
+    - name: Blue Goo
+      quantity: 10
+  inputs:
+    - name: Red Goo
+      quantity: 25
+    - name: Green Goo
+      quantity: 25
+    - name: Blue Goo
+      quantity: 25
+  outputs:
+    - name: Red Goo
+      quantity: 1

--- a/contracts/src/ext/BuildingKind.sol
+++ b/contracts/src/ext/BuildingKind.sol
@@ -15,22 +15,6 @@ contract BuildingKind is IBuildingKind {
         external
         virtual
     {}
-    function onUnitArrive(
-        State state,
-        bytes24 buildingInstanceID,
-        bytes24 mobileUnitID,
-        int16 zone,
-        int16 q,
-        int16 r,
-        int16 s
-    ) external virtual {}
-    function onUnitLeave(
-        State state,
-        bytes24 buildingInstanceID,
-        bytes24 mobileUnitID,
-        int16 zone,
-        int16 q,
-        int16 r,
-        int16 s
-    ) external virtual {}
+    function onUnitArrive(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID) external virtual {}
+    function onUnitLeave(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID) external virtual {}
 }

--- a/contracts/src/ext/BuildingKind.sol
+++ b/contracts/src/ext/BuildingKind.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "cog/IGame.sol";
+import "cog/IState.sol";
 
 interface IBuildingKind {
     function use(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID, bytes memory payload) external;
@@ -14,4 +15,22 @@ contract BuildingKind is IBuildingKind {
         external
         virtual
     {}
+    function onUnitArrive(
+        State state,
+        bytes24 buildingInstanceID,
+        bytes24 mobileUnitID,
+        int16 zone,
+        int16 q,
+        int16 r,
+        int16 s
+    ) external virtual {}
+    function onUnitLeave(
+        State state,
+        bytes24 buildingInstanceID,
+        bytes24 mobileUnitID,
+        int16 zone,
+        int16 q,
+        int16 r,
+        int16 s
+    ) external virtual {}
 }

--- a/contracts/src/ext/BuildingKind.sol
+++ b/contracts/src/ext/BuildingKind.sol
@@ -16,5 +16,8 @@ contract BuildingKind is IBuildingKind {
         virtual
     {}
     function onUnitArrive(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID) external virtual {}
+
+    // FIXME: This hook is useful however it could potentially trap a unit in a building if the contract code reverts!
+    //        Fine for now but we should consider a way to handle this in the future
     function onUnitLeave(Game ds, bytes24 buildingInstanceID, bytes24 mobileUnitID) external virtual {}
 }

--- a/contracts/src/rules/BuildingRule.sol
+++ b/contracts/src/rules/BuildingRule.sol
@@ -237,6 +237,8 @@ contract BuildingRule is Rule {
         BuildingKind buildingImplementation = BuildingKind(state.getImplementation(buildingKind));
         // if no implementation set, then this is a no-op
         if (address(buildingImplementation) != address(0)) {
+            // FIXME: we are passing in the buildingKind when it should be the buildingInstance.
+            //        Not fixing now as I'm unsure if contracts that already implement this hook are working around this bug
             buildingImplementation.construct(game, buildingKind, mobileUnit, abi.encode(coords));
         }
 

--- a/contracts/src/rules/MovementRule.sol
+++ b/contracts/src/rules/MovementRule.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+import "cog/IGame.sol";
 import "cog/IState.sol";
 import "cog/IRule.sol";
 import "cog/IDispatcher.sol";
@@ -13,6 +14,12 @@ import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 using Schema for State;
 
 contract MovementRule is Rule {
+    Game game;
+
+    constructor(Game g) {
+        game = g;
+    }
+
     function reduce(State state, bytes calldata action, Context calldata ctx) public returns (State) {
         if (bytes4(action) == Actions.MOVE_MOBILE_UNIT.selector) {
             // decode the action
@@ -72,7 +79,7 @@ contract MovementRule is Rule {
         if (buildingKind != bytes24(0)) {
             BuildingKind buildingImplementation = BuildingKind(state.getImplementation(buildingKind));
             if (address(buildingImplementation) != address(0)) {
-                buildingImplementation.onUnitLeave(state, building, mobileUnit, zone, q, r, s);
+                buildingImplementation.onUnitLeave(game, building, mobileUnit);
             }
         }
 
@@ -83,7 +90,7 @@ contract MovementRule is Rule {
         if (buildingKind != bytes24(0)) {
             BuildingKind buildingImplementation = BuildingKind(state.getImplementation(buildingKind));
             if (address(buildingImplementation) != address(0)) {
-                buildingImplementation.onUnitArrive(state, building, mobileUnit, zone, q, r, s);
+                buildingImplementation.onUnitArrive(game, building, mobileUnit);
             }
         }
     }

--- a/contracts/src/rules/MovementRule.sol
+++ b/contracts/src/rules/MovementRule.sol
@@ -48,6 +48,12 @@ contract MovementRule is Rule {
         //
         // fetch the mobileUnit's current location
         (bytes24 currentTile) = state.getCurrentLocation(mobileUnit, nowTime);
+
+        // check if the mobileUnit is already at the destination
+        if (currentTile == destTile) {
+            return;
+        }
+
         // check that destTile is direct 6-axis line from currentTile
         // require(TileUtils.isDirect(currentTile, destTile), "NoMoveToIndirect");
         // require(state.getBiome(currentTile) == BiomeKind.DISCOVERED, "NoMoveToUndiscovered");

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -550,4 +550,13 @@ library Schema {
     function getAttackTile(State state, bytes24 sessionID) external view returns (bytes24 tileID, uint64 startBlock) {
         return state.get(Rel.Has.selector, uint8(CombatSideKey.ATTACK), sessionID);
     }
+
+    function getTileCoords(State, /*state*/ bytes24 tile)
+        external
+        pure
+        returns (int16 zone, int16 q, int16 r, int16 s)
+    {
+        int16[4] memory keys = CompoundKeyDecoder.INT16_ARRAY(tile);
+        return (keys[0], keys[1], keys[2], keys[3]);
+    }
 }

--- a/contracts/test/helpers/GameTest.sol
+++ b/contracts/test/helpers/GameTest.sol
@@ -108,7 +108,7 @@ abstract contract GameTest {
         game = new DownstreamGame();
         dispatcher = BaseDispatcher(address(game.getDispatcher()));
         dispatcher.registerRule(new CheatsRule(address(dev)));
-        dispatcher.registerRule(new MovementRule());
+        dispatcher.registerRule(new MovementRule(game));
         dispatcher.registerRule(new ScoutRule());
         dispatcher.registerRule(new InventoryRule());
         dispatcher.registerRule(new BuildingRule(game));


### PR DESCRIPTION
# What

Two new hooks added to base `BuildingKind` contract - `onUnitArrive` and `onUnitLeave`

I've added an example in `example-plugins` which checks for an `ID Card` in the inventory of a unit and will revert if they arrive on the building's tile if they don't have one. By reverting the move action will not complete therefore blocking their movement.

# Details

These hooks are both implemented within the `MovementRule` and are pretty self explanitory.

# Known problem

If the `onUnitArrive` is used to implement a gate, the frontend doesn't know if the criteria has been met to allow them to pass therefore we cannot show a red 'you cannot go here' tile as we're currently relying on the movement reverting to block them. In my example I'm at least displaying a message stating 'you do not have an ID card' but you cannot see this unless you click the building directly, it doesn't feed into the path finding system

If the building implementation's `onUnitLeave` reverts, the unit will not be able to leave the tile! (unless they teleport using the cli). I think having a hook for leaving is more useful than not having one so I think we should keep it. Bug or Feature if we want to implement a prison! 