### PR TITLE
Performance - Increase Load (chaos-units placing buildings)

### DIFF
--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -90,7 +90,7 @@ const chaosUnit = {
             await sleep(Math.floor(Math.random() * 1000)); // jitter
             // place building
             if (buildings?.length > 0){
-                let selectedBuilding = buildings[Math.floor(Math.random() * buildings.length)];
+                const selectedBuilding = buildings[Math.floor(Math.random() * buildings.length)];
                 const targetTileID = CompoundKeyEncoder.encodeInt16(NodeSelectors.Tile, 0, q, r, s);
                 const world = await getWorld(ctx);
                 const buildingOnTargetTile = getBuildingOnTile(world.buildings, targetTileID);

--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -1,11 +1,12 @@
 import { ethers } from 'ethers';
 import { pipe, take, toPromise } from 'wonka';
-import { CompoundKeyEncoder, NodeSelectors, getCoords } from "@downstream/core";
+import { CompoundKeyEncoder, NodeSelectors, getCoords, WorldTileFragment } from "@downstream/core";
+import { getBuildingAtTile } from '@downstream/core/src/utils';
 import util from 'node:util';
 import { spawn } from 'node:child_process';
+import { getWorld } from './get';
 
 const spawnAsync = util.promisify(spawn);
-let buildings: string[];
 
 const concurrency = {
     command: 'concurrency',
@@ -25,10 +26,7 @@ const concurrency = {
     ,
     handler: async (ctx) => {
         const maxConnections: number = ctx.maxConnections || 1;
-        buildings = ctx.buildings ? ctx.buildings.split(",") : [];
-        buildings.forEach(building => {
-            console.log(`building added to array: ${building}`)
-        });
+        const buildings = ctx.buildings ? ctx.buildings : undefined;
 
         // generate wallets
         const wallets: ethers.HDNodeWallet[] = [];
@@ -43,6 +41,7 @@ const concurrency = {
             procs.push(spawnAsync('ds', [
                 '-n', `${ctx.network || 'local'}`,
                 `-k`, `${wallet.privateKey}`,
+                `-b`, `${buildings ? buildings : '0x0'}`,
                 `test`, `chaos-unit`
             ], {stdio: ['ignore', process.stdout, process.stderr]}));
         }
@@ -55,6 +54,14 @@ const concurrency = {
 const chaosUnit = {
     command: 'chaos-unit',
     describe: 'spawn a unit and keep moving it',
+    builder: (yargs) =>
+        yargs
+            .option('buildings', {
+                alias: 'b',
+                describe: 'list of BuildingKind ids to randomly place to randomly place',
+                type: 'string',
+            })
+    ,
     handler: async (ctx) => {
         const player = await ctx.player();
 
@@ -67,6 +74,7 @@ const chaosUnit = {
         const client = await ctx.client();
         const res: any = await pipe(client.query(GET_TILES, { gameID: ctx.game }, {subscribe: false}), take(1), toPromise);
         const validCoords = res.game.state.tiles.map(getCoords);
+        const buildings:string[] = ctx.buildings ? ctx.buildings.split(",") : [];
 
         // move unit around randomly
         let [q,r,s] = [0,0,0];
@@ -82,11 +90,32 @@ const chaosUnit = {
             // place building
             if (buildings?.length > 0){
                 let selectedBuilding = buildings[Math.floor(Math.random() * buildings.length)];
-                console.log(`I want to place: ${selectedBuilding}`);
+                    // WORK IN PROGRESS...
+                    // Trying to make sure there's not already a buildin on the tile
+                // console.log(`I want to place: ${selectedBuilding}`);
+                //const world = await getWorld(ctx);
+                // const coords = world.buildings[Math.floor(Math.random() * world.buildings.length)]?.location?.tile?.coords // random building in world
+                //const coords = world.buildings[5]?.location?.tile?.coords;
+
+                const tileMap = new Map<string, PassableTile>();
+                const t = tileMap.get(`${q}:${r}:${s}`);
+                console.log(t);
+                
+                //getBuildingAtTile(world.buildings, t.id);
+                //console.log(coords);
+                await player.dispatch({ name: 'DEV_SPAWN_BUILDING', args: [selectedBuilding, q, r, s] }).then(res => res.wait());
             }
         }
     },
 };
+
+interface PassableTile {
+    idx: number;
+    q: number;
+    r: number;
+    s: number;
+    tile: WorldTileFragment;
+}
 
 export const test = {
     command: 'test',

--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -37,7 +37,7 @@ const concurrency = {
         const procs: ReturnType<typeof spawnAsync>[] = [];
         for (let wallet of wallets) {
             console.log(`starting chaos-unit for ${wallet.privateKey}`);
-            let args = [
+            const args = [
                 '-n', `${ctx.network || 'local'}`,
                 `-k`, `${wallet.privateKey}`,
                 `test`, `chaos-unit`
@@ -94,8 +94,7 @@ const chaosUnit = {
                 const targetTileID = CompoundKeyEncoder.encodeInt16(NodeSelectors.Tile, 0, q, r, s);
                 const world = await getWorld(ctx);
                 const buildingOnTargetTile = getBuildingOnTile(world.buildings, targetTileID);
-                // console.log(`target tile (${targetTileID}) building: ${buildingOnTargetTile}`);
-                if (buildingOnTargetTile === undefined){
+                if (typeof buildingOnTargetTile === 'undefined'){
                     await player.dispatch({ name: 'DEV_SPAWN_BUILDING', args: [selectedBuilding, q, r, s] }).then(res => res.wait());
                 }
             }

--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -5,6 +5,7 @@ import util from 'node:util';
 import { spawn } from 'node:child_process';
 
 const spawnAsync = util.promisify(spawn);
+let buildings: string[];
 
 const concurrency = {
     command: 'concurrency',
@@ -16,9 +17,18 @@ const concurrency = {
                 describe: 'number of player connections to spawn',
                 type: 'number',
             })
+            .option('buildings', {
+                alias: 'b',
+                describe: 'list of BuildingKind ids to randomly place to randomly place',
+                type: 'string',
+            })
     ,
     handler: async (ctx) => {
         const maxConnections: number = ctx.maxConnections || 1;
+        buildings = ctx.buildings ? ctx.buildings.split(",") : [];
+        buildings.forEach(building => {
+            console.log(`building added to array: ${building}`)
+        });
 
         // generate wallets
         const wallets: ethers.HDNodeWallet[] = [];
@@ -68,6 +78,12 @@ const chaosUnit = {
 
             await player.dispatch({ name: 'MOVE_MOBILE_UNIT', args: [unitKey, q, r, s] }).then(res => res.wait());
             await sleep(Math.floor(Math.random() * 2000)); // jitter
+
+            // place building
+            if (buildings?.length > 0){
+                let selectedBuilding = buildings[Math.floor(Math.random() * buildings.length)];
+                console.log(`I want to place: ${selectedBuilding}`);
+            }
         }
     },
 };

--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -109,6 +109,7 @@ const chaosUnit = {
     },
 };
 
+// probably remove? vvv (along with other stuff)
 interface PassableTile {
     idx: number;
     q: number;


### PR DESCRIPTION
Resolves #1002 

## What
This PR adds the `-buildings` (`-b`) option to the `concurrency`/`chaos-unit` command which expects a list of BuildingKind IDs (For example: `-b 0xbe92755c0000000000000000546391e80000000000000003,0xbe92755c0000000000000000444749c70000000000000003`, which is the Weak Duck and Weak Burger building IDs).

## [Why](https://github.com/playmint/ds/issues/1002#issue-2107485231)
We would like to see a bit more "load" in the form of more buildings on the map to gain more confidence in how much data we are likely to see over time.

## How
In the code that controls the chaos-units in `test.ts`, I have added logic to select and place a random building from the provided list:
```ts
if (buildings?.length > 0){
                let selectedBuilding = buildings[Math.floor(Math.random() * buildings.length)];
```
if there is no building on the target tile already
```ts
                const targetTileID = CompoundKeyEncoder.encodeInt16(NodeSelectors.Tile, 0, q, r, s);
                const world = await getWorld(ctx);
                const buildingOnTargetTile = getBuildingOnTile(world.buildings, targetTileID);
                if (buildingOnTargetTile === undefined){
                    await player.dispatch({ name: 'DEV_SPAWN_BUILDING', args: [selectedBuilding, q, r, s] }).then(res => res.wait());
                }
```

### To test this
Run
```make
make dev MAP=performance-test ARENAS=1
```
And then
```make
make cli && ds -n local -k 0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8 test concurrency -c 1 -b 0xbe92755c0000000000000000546391e80000000000000003,0xbe92755c0000000000000000444749c70000000000000003
```
(You can change the provided BuildingKind IDs to anything deployed in your Hexwood. In this case, it's the Weak Duck and Weak Burger buildings that are created via the performance-test).