### PR TITLE
allow manually applying the generated "performance-test" map

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -9,27 +9,10 @@ const { execSync } = require("child_process");
 
 const SEQUENCER_PRIVATE_KEY = "095a37ef5b5d87db7fe50551725cb64804c8c554868d3d729c0dd17f0e664c87";
 const DEPLOYER_PRIVATE_KEY = "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8";
-
-let MAP_VAR = (process.argv[2] || "../maps/default").toLowerCase();
-// if undefined default to 1, value is capped at 25
-const ARENAS_VAR = Math.min(Number(process.argv[3] || 1), 25);
+const MAP = process.env.MAP || "default";
 
 async function handleStartup(){
-    // specific startup processes
-    if (MAP_VAR === "performance-test"){
-        const performanceTestFile = require('./scripts/performance-test.js');
-        result = await performanceTestFile.buildPerformanceTest(ARENAS_VAR);
-        MAP_VAR = result.MapName;
-        if (result.error){
-            return console.log("There was an error building the performance test: ", result.error);
-        }
-        if (ARENAS_VAR === 0){
-            return console.log("test-plugins folder deleted");
-        }
-    }
-
     // configure services to run
-
     const commands = [
         {
             name: 'networks',
@@ -43,7 +26,7 @@ async function handleStartup(){
                 && forge script script/Deploy.sol:GameDeployer --broadcast --rpc-url "http://localhost:8545" \
                 && ./lib/cog/services/bin/wait-for -it localhost:8080 -t 300 \
                 && sleep 2 \
-                && ds -k ${DEPLOYER_PRIVATE_KEY} -n local apply -R -f ./src/maps/${MAP_VAR}/ --max-connections 500 \
+                && ds -k ${DEPLOYER_PRIVATE_KEY} -n local apply -R -f ./src/maps/${MAP}/ --max-connections 500 \
                 && ds -k ${DEPLOYER_PRIVATE_KEY} -n local apply -R -f ./src/example-plugins/ --max-connections 500 \
                 && sleep 9999999`,
             prefixColor: 'black',

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ Thumbs.db
 
 # Performance test files
 contracts/src/test-plugins/
+contracts/src/maps/performance-test/

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,10 @@ debugmap:
 	$(UNITY_EDITOR) -batchmode -quit -projectPath ./map -executeMethod BuildScript.DevBuild -buildTarget WebGL -logFile -
 
 dev: all
-ifeq ($(MAP),)
 	$(NODE) .devstartup.js
-else
-	$(NODE) .devstartup.js $(MAP) $(ARENAS)
-endif
 
+contracts/src/maps/performance-test:
+	$(NODE) ./scripts/generate-perf-test-map
 
 compose: frontend/public/ds-unity/Build/ds-unity.wasm
 	docker compose up --build
@@ -91,7 +89,7 @@ clean:
 	rm -rf frontend/dist
 	rm -rf frontend/node_modules
 	rm -rf node_modules
-	rm -rf contracts/src/test-plugins
+	rm -rf contracts/src/maps/performance-test
 	$(MAKE) -C contracts/lib/cog/services clean
 
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ docker build -t ghcr.io/playmint/ds:latest .
 By Default, running `Make Dev` will spawn a one hex sized map. In order to deploy locally with a different map, there are a few options
 
 ### 1. Using Playmint's Maps
+
 Inside of the `ds/contracts/src/maps/` folder, you will find a few premade maps  by Playmint. In order to force one of these maps to be deployed with a `make dev`, you will need to add the MAP=$ arg to your command. Here are the currently supported MAP args in context:
 
 `MAP=tiny make dev
@@ -206,14 +207,28 @@ MAP=quest-map make dev
 MAP=default make dev`
 
 ### 2. Apply a map after deploying
+
 After doing a standard make dev, you can run the DS apply command and point it at one of the map folders. For example: `ds apply -R -f ./contracts/src/maps/quest-map/`
 
 ### 3. Build your own map and deploy it
+
 First up, you will need to run a `make dev` and then visit `http://localhost:3000/tile-fabricator`
 
 Once in the Tile Fabricator, you can design and export a map file. 
 
 If you then rename the .yml file to a .yaml and move it to your desired location, you will be able to run the ds apply command, like so:
 `ds apply -R -f ./path/to/mymap.yaml`
+
+### 4 Generating the performance-test map
+
+To generate the performance-test map (used to push the limits of number of tiles and plugins) run:
+
+```
+NUM_ARENAS=4 make contracts/src/maps/performance-test
+```
+
+...this generates a map configuration in `contracts/src/maps/performance-test`
+
+You can then either start locally via `MAP=performance-test make dev` or manually `ds apply -R -f contracts/src/maps/performance-test`
 
 </details>


### PR DESCRIPTION
### what

we want to be able to manually deploy the generated performance map to remote instances

which means separating the "generation" away from the devstartup script

👀  using the performance map is now a two stage process:

First you run:

```
NUM_ARENAS=4 make contracts/src/maps/performance-test
```

.... this populates the `contracts/src/maps/performance-test` dir with all the generated manifests.

Then we can treat it like any other map dir:

```
MAP=performance-test make dev
```

This means that we can also now apply the map to a remote instance via:

```
ds apply -n hexwoodX -R -f contracts/src/maps/performance-test
```

Use `make clean` to destroy the generated map and build another one

### notes

this is a bit more long-winded that before (as the dev script no longer detects it needs to generate the missing map), but since we don't expect to do it very often I think that's probably ok.

resolves: #1008 