### PR TITLE
See Unit Panel When Under Building

### DIFF
--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -364,14 +364,17 @@ export const TileInfoPanel = ({ kinds, ui }: { kinds: BuildingKindFragment[]; ui
                 mobileUnit.nextLocation &&
                 getTileDistance(mobileUnit.nextLocation.tile, selectedTile) < 2;
             return (
-                <TileBuilding
-                    kinds={kinds}
-                    canUse={!!canUse}
-                    building={building}
-                    world={world}
-                    mobileUnit={mobileUnit}
-                    ui={ui}
-                />
+                <>
+                    <TileBuilding
+                        kinds={kinds}
+                        canUse={!!canUse}
+                        building={building}
+                        world={world}
+                        mobileUnit={mobileUnit}
+                        ui={ui}
+                    />
+                    <TileAvailable player={player} mobileUnits={world?.mobileUnits || []} bags={world?.bags || []} />
+                </>
             );
         } else {
             return null; // fallback, don't expect this state


### PR DESCRIPTION
## What
You can now see another player's unit info when they are standing on the same tile as a building.

## Why
We discovered during playtests that players often gain an unfair advantage when standing under a building because it makes it impossible for another player to see info about their unit.

## How
This problem has now been addressed by allowing the tile-panel to be rendered even if a building is selected.
<img width="395" alt="image" src="https://github.com/playmint/ds/assets/27741109/d17b39d5-3082-4825-a62d-42211beac3bf">

Resolves #674 