### PR TITLE
use prebuilt images in default docker compose config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MAP=tiny

--- a/README.md
+++ b/README.md
@@ -10,25 +10,26 @@ See the [docs](./docs/README.md)
 
 <details>
 
-<summary>Building with Docker</summary>
+<summary>Running with Docker</summary>
 
 If you only need a local copy of the game built (without development helpers
 like hot reloading etc), then the easist way is to provision using
 Docker Compose.
 
-You need to build the unity map project first:
-
 ```
-make map
+MAP=tiny docker compose up
 ```
 
-Then to build and start the client and supporting services run:
+This will fetch the most recently built images for the game and run them
+without requiring a full build. 
+
+To start with a different set of map fixtures:
 
 ```
-docker compose up --build
+MAP=quest-map docker compuse up
 ```
 
-Client will be available at locahost:3000
+Once ready, the client will be available at http://locahost:3000
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,24 @@ like hot reloading etc), then the easist way is to provision using
 Docker Compose.
 
 ```
-MAP=tiny docker compose up
+docker compose up
 ```
 
 This will fetch the most recently built images for the game and run them
 without requiring a full build. 
 
-To start with a different set of map fixtures:
+By default we give you the "tiny" map, which is a small blank slate. To start
+with a different set of map fixtures you can edit the `.env` file in the root
+of the repository and set the `MAP` variable to the name of one of the
+directories
+[here](https://github.com/playmint/ds/tree/main/contracts/src/maps). 
+
+For example edit `.env` so that it looks like the following, and then run
+`docker compose up` to get a big populated map:
+
 
 ```
-MAP=quest-map docker compuse up
+MAP=quest-map
 ```
 
 Once ready, the client will be available at http://locahost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,29 +3,30 @@ version: '3'
 services:
 
   contracts:
-    build:
-      context: .
-      dockerfile: ./contracts/Dockerfile
-    image: playmint/ds-contracts:local
+    # build:
+    #   context: .
+    #   dockerfile: ./contracts/Dockerfile
+    image: ghcr.io/playmint/ds-contracts:hexwood0
     ports:
       - 8545:8545
     environment:
       DEPLOYER_PRIVATE_KEY: "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8"
       SERVICES_URL_HTTP: "http://cog:8080/query"
       SERVICES_URL_WS: "ws://cog:8080/query"
+      MAP: "${MAP}"
 
   frontend:
-    build:
-      context: .
-      dockerfile: ./frontend/Dockerfile
-    image: playmint/ds-frontend:local
+    # build:
+    #   context: .
+    #   dockerfile: ./frontend/Dockerfile
+    image: ghcr.io/playmint/ds-shell:hexwood0
     ports:
       - 3000:80
 
   cog:
-    build:
-      context: ./contracts/lib/cog/services
-    image: playmint/ds-services:local
+    # build:
+    #   context: ./contracts/lib/cog/services
+    image: ghcr.io/playmint/ds-services:hexwood0
     restart: always
     entrypoint:
     - /bin/ash


### PR DESCRIPTION
### what

disables the build steps in docker compose config and instead points to the `hexwood0` tags for the last built images

### why 

we don't use docker compose for dev, but it is useful if you want a local copy of the game running without needing all the build tooling, unity, and dependencies

resolves: #1029 

### testing

please see the updated README and try it out to check it does actually let you pull down the images .... it will run/startup pretty slow for those of you on M1 macs, since we are only building amd64 images at this point... but it should be ok once it's finally up

