### PR TITLE
Added plugin filter to also include items

### DIFF
--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -147,7 +147,8 @@ export function makePluginUI(
                                 }
                                 const plugin = active.has(p.id)
                                     ? active.get(p.id)
-                                    : state.world.buildings.some((building) => building?.kind?.id === p.kindID)
+                                    : state.world.buildings.some((building) => building?.kind?.id === p.kindID) ||
+                                      state.world.items.some((item) => item?.id === p.kindID)
                                     ? await loadPlugin(
                                           sandbox,
                                           dispatch,


### PR DESCRIPTION
# What

When loading plugins we also look in the list of items for matching IDs that are coupled to the plugin's kind ID

# Why

Were previously only looking for matching buildings on the map which prevented item plugins from loading

# Notes

We might be able to get rid of the filter entirely but it would mean always active plugins on buildings would load even without that plugin's building on the map. Not wanting to introduce problems I've keep that filter