### PR TITLE
Unit Team Distinction (Change color of a unit from plugin)

### DIFF
--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -185,7 +185,7 @@ export default async function update(state, block) {
                 type: "unit",
                 key: "color",
                 id: getHQTeamUnit(selectedBuilding, "Duck", i),
-                value: "#ffcc00",
+                value: "#f1b14e",
             }
         )
     }
@@ -195,7 +195,7 @@ export default async function update(state, block) {
                 type: "unit",
                 key: "color",
                 id: getHQTeamUnit(selectedBuilding, "Burger", i),
-                value: "#b30000",
+                value: "#ec5c61",
             }
         )
     }

--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -178,6 +178,28 @@ export default async function update(state, block) {
 
     connectDisplayBuildings(state, localBuildings);
 
+    const unitMapObj = [];
+    for (let i = 0; i < teamDuckLength; i++) {
+        unitMapObj.push(
+            {
+                type: "unit",
+                key: "color",
+                id: getHQTeamUnit(selectedBuilding, "Duck", i),
+                value: "#ffcc00",
+            }
+        )
+    }
+    for (let i = 0; i < teamBurgerLength; i++) {
+        unitMapObj.push(
+            {
+                type: "unit",
+                key: "color",
+                id: getHQTeamUnit(selectedBuilding, "Burger", i),
+                value: "#b30000",
+            }
+        )
+    }
+
     // check current game state:
     // - NotStarted : GameActive == false
     // - Running : GameActive == true && endBlock < currentBlock
@@ -401,7 +423,7 @@ export default async function update(state, block) {
 
     return {
         version: 1,
-        map: mapObj,
+        map: mapObj.concat(unitMapObj),
         components: [
             {
                 id: "dbhq",

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -312,7 +312,7 @@ export interface PluginStateComponent {
 }
 
 export interface PluginMapProperty {
-    type: 'building' | 'tile';
+    type: 'building' | 'tile' | 'unit';
     id: string;
     key: string;
     value: string | number;

--- a/frontend/src/components/map/MobileUnit.tsx
+++ b/frontend/src/components/map/MobileUnit.tsx
@@ -146,7 +146,7 @@ export const MobileUnits = memo(
         selectedMobileUnitID,
         onClickMobileUnit,
         playerID,
-        randomUnitProperties,
+        pluginProperties,
     }: {
         currentBlock: number;
         mobileUnits?: WorldMobileUnitFragment[];
@@ -154,7 +154,7 @@ export const MobileUnits = memo(
         selectedMobileUnitID?: string;
         playerID?: string;
         onClickMobileUnit: (id: string) => void;
-        randomUnitProperties: PluginMapProperty[];
+        pluginProperties: PluginMapProperty[];
     }) => {
         const [unitPositions, setUnitPositions] = useState({}); // New state for positions
 
@@ -202,7 +202,7 @@ export const MobileUnits = memo(
             () =>
                 units.map((u) => {
                     // Make this like Tile.tsx line 71
-                    const color = randomUnitProperties.find((prop) => prop.id == u.id)?.value.toString();
+                    const color = pluginProperties.find((prop) => prop.id == u.id)?.value.toString();
                     return (
                         <MobileUnit
                             sendScreenPosition={true}
@@ -221,7 +221,7 @@ export const MobileUnits = memo(
                         />
                     );
                 }),
-            [onClickMobileUnit, selectedMobileUnitID, units, updatePosition, randomUnitProperties]
+            [onClickMobileUnit, selectedMobileUnitID, units, updatePosition, pluginProperties]
         );
 
         const unitIcons = useMemo(

--- a/frontend/src/components/map/MobileUnit.tsx
+++ b/frontend/src/components/map/MobileUnit.tsx
@@ -1,6 +1,6 @@
 import { getTileHeightFromCoords } from '@app/helpers/tile';
 import { UnityComponentProps, useUnityComponentManager } from '@app/hooks/use-unity-component-manager';
-import { WorldBuildingFragment, WorldMobileUnitFragment, getCoords } from '@downstream/core';
+import { WorldBuildingFragment, WorldMobileUnitFragment, getCoords, PluginMapProperty } from '@downstream/core';
 import { memo, useCallback, useMemo, useState } from 'react';
 import Icon from './Icon';
 import { getBuildingAtTile } from '@downstream/core/src/utils';
@@ -26,6 +26,7 @@ export interface MobileUnitData {
     height: number;
     progress: number;
     selected?: 'none' | 'highlight' | 'outline';
+    color?: string;
     shared: boolean;
     visible: boolean;
     sendScreenPosition: boolean;
@@ -42,6 +43,7 @@ export const MobileUnit = memo(
         height,
         progress,
         selected,
+        color,
         shared,
         visible,
         sendScreenPosition,
@@ -102,6 +104,7 @@ export const MobileUnit = memo(
                     sendScreenPosition,
                     screenPositionHeightOffset,
                     selected: selected || 'none',
+                    color: color || '0',
                     shared,
                     visible,
                     position: { x, y, z },
@@ -114,6 +117,7 @@ export const MobileUnit = memo(
                     height,
                     progress,
                     selected,
+                    color,
                     shared,
                     visible,
                     sendScreenPosition,
@@ -142,6 +146,7 @@ export const MobileUnits = memo(
         selectedMobileUnitID,
         onClickMobileUnit,
         playerID,
+        randomUnitProperties,
     }: {
         currentBlock: number;
         mobileUnits?: WorldMobileUnitFragment[];
@@ -149,6 +154,7 @@ export const MobileUnits = memo(
         selectedMobileUnitID?: string;
         playerID?: string;
         onClickMobileUnit: (id: string) => void;
+        randomUnitProperties: PluginMapProperty[];
     }) => {
         const [unitPositions, setUnitPositions] = useState({}); // New state for positions
 
@@ -195,6 +201,8 @@ export const MobileUnits = memo(
         const unitComponents = useMemo(
             () =>
                 units.map((u) => {
+                    // Make this like Tile.tsx line 71
+                    const color = randomUnitProperties.find((prop) => prop.id == u.id)?.value.toString();
                     return (
                         <MobileUnit
                             sendScreenPosition={true}
@@ -204,6 +212,7 @@ export const MobileUnits = memo(
                             height={u.height}
                             progress={1}
                             selected={selectedMobileUnitID === u.id ? 'outline' : 'none'}
+                            color={color || '0'}
                             shared={u.atBuilding}
                             visible={u.visible}
                             onPointerClick={onClickMobileUnit}
@@ -212,7 +221,7 @@ export const MobileUnits = memo(
                         />
                     );
                 }),
-            [onClickMobileUnit, selectedMobileUnitID, units, updatePosition]
+            [onClickMobileUnit, selectedMobileUnitID, units, updatePosition, randomUnitProperties]
         );
 
         const unitIcons = useMemo(

--- a/frontend/src/components/map/MobileUnit.tsx
+++ b/frontend/src/components/map/MobileUnit.tsx
@@ -104,7 +104,7 @@ export const MobileUnit = memo(
                     sendScreenPosition,
                     screenPositionHeightOffset,
                     selected: selected || 'none',
-                    color: color || '0',
+                    color: color,
                     shared,
                     visible,
                     position: { x, y, z },
@@ -212,7 +212,7 @@ export const MobileUnits = memo(
                             height={u.height}
                             progress={1}
                             selected={selectedMobileUnitID === u.id ? 'outline' : 'none'}
-                            color={color || '0'}
+                            color={color}
                             shared={u.atBuilding}
                             visible={u.visible}
                             onPointerClick={onClickMobileUnit}

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -351,7 +351,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                         onClickMobileUnit={mobileUnitClick}
                         selectedMobileUnitID={selectedMobileUnit?.id}
                         playerID={player?.id}
-                        randomUnitProperties={unitColorsModifiedByPlugins}
+                        pluginProperties={unitColorsModifiedByPlugins}
                     />
                     <Bags
                         tiles={tiles || []}

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -107,6 +107,9 @@ export const Shell: FunctionComponent<ShellProps> = () => {
     const displayBuildingDataModifiedByPlugins =
         ui?.flatMap((res) => res.state.map.filter((prop) => prop.type === 'building')) || [];
 
+    const unitColorsModifiedByPlugins =
+        ui?.flatMap((res) => res.state.map.filter((prop) => prop.type === 'unit')) || [];
+
     // setup the unity frame
     useEffect(() => {
         if (!setContainerStyle) {
@@ -348,6 +351,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                         onClickMobileUnit={mobileUnitClick}
                         selectedMobileUnitID={selectedMobileUnit?.id}
                         playerID={player?.id}
+                        randomUnitProperties={unitColorsModifiedByPlugins}
                     />
                     <Bags
                         tiles={tiles || []}

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
@@ -39,7 +39,7 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
         if (renderers.Length > 0)
         {
             _defaultColor = renderers[0].material.GetColor("_EmissionColor");
-            _defaultBodyColor = ColorUtility.ToHtmlStringRGB(renderers[0].material.color);
+            _defaultBodyColor = "#" + ColorUtility.ToHtmlStringRGB(renderers[0].material.color);
         }
 
         _meshesTrans = transform.GetChild(0);
@@ -116,15 +116,7 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
         if ((_prevData?.color ?? "") != _nextData.color)
         {
             string colorString = _nextData.color;
-            if (!string.IsNullOrEmpty(colorString) && !colorString.StartsWith("#"))
-            {
-                colorString = "#" + colorString;
-            }
-            else if (string.IsNullOrEmpty(colorString))
-            {
-                colorString = "#" + _defaultBodyColor;
-            }
-
+            colorString = string.IsNullOrEmpty(colorString) ? _defaultBodyColor : colorString;
             ColorUtility.TryParseHtmlString(colorString, out Color targetColor);
             renderers[0].material.color = targetColor;
         }

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
@@ -258,11 +258,17 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
                     && int.TryParse(parts[2].Trim(), out int b)
                 )
                 {
-                    return new Color(Mathf.Clamp01(r / 255f), Mathf.Clamp01(g / 255f), Mathf.Clamp01(b / 255f));
+                    return new Color(
+                        Mathf.Clamp01(r / 255f),
+                        Mathf.Clamp01(g / 255f),
+                        Mathf.Clamp01(b / 255f)
+                    );
                 }
                 else
                 {
-                    Debug.LogWarning("RGBStringToColor: One or more RGB components are not integers.");
+                    Debug.LogWarning(
+                        "RGBStringToColor: One or more RGB components are not integers."
+                    );
                     return _defaultBodyColor; // Return default color if parsing fails
                 }
             }
@@ -274,7 +280,9 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
         }
         catch (System.Exception ex)
         {
-            Debug.LogWarning($"RGBStringToColor: Error parsing color string '{rgb}'. Exception: {ex.Message}");
+            Debug.LogWarning(
+                $"RGBStringToColor: Error parsing color string '{rgb}'. Exception: {ex.Message}"
+            );
             return _defaultBodyColor; // Return default color in case of unexpected error
         }
     }

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
@@ -253,9 +253,9 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
             {
                 // Try to parse each part to int, then normalize to float (0 to 1)
                 if (
-                    int.TryParse(parts[0].Trim(), out int r) &&
-                    int.TryParse(parts[1].Trim(), out int g) &&
-                    int.TryParse(parts[2].Trim(), out int b))
+                    int.TryParse(parts[0].Trim(), out int r)
+                    && int.TryParse(parts[1].Trim(), out int g)
+                    && int.TryParse(parts[2].Trim(), out int b))
                 {
                     return new Color(Mathf.Clamp01(r / 255f), Mathf.Clamp01(g / 255f), Mathf.Clamp01(b / 255f));
                 }

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
@@ -256,7 +256,7 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
                     int.TryParse(parts[0].Trim(), out int r)
                     && int.TryParse(parts[1].Trim(), out int g)
                     && int.TryParse(parts[2].Trim(), out int b)
-                    )
+                )
                 {
                     return new Color(Mathf.Clamp01(r / 255f), Mathf.Clamp01(g / 255f), Mathf.Clamp01(b / 255f));
                 }

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
@@ -148,8 +148,6 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
             _runningVisibilityCR = StartCoroutine(VisibilityCR(new Vector3(1, 1, 1), 1));
         }
 
-
-
         _prevData = _nextData;
     }
 

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
@@ -255,7 +255,8 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
                 if (
                     int.TryParse(parts[0].Trim(), out int r)
                     && int.TryParse(parts[1].Trim(), out int g)
-                    && int.TryParse(parts[2].Trim(), out int b))
+                    && int.TryParse(parts[2].Trim(), out int b)
+                    )
                 {
                     return new Color(Mathf.Clamp01(r / 255f), Mathf.Clamp01(g / 255f), Mathf.Clamp01(b / 255f));
                 }

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using ColorUtility = UnityEngine.ColorUtility;
 
 public class MobileUnitController : BaseComponentController<MobileUnitData>
 {
@@ -26,7 +27,7 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
     public Material redOutlineMat,
         greenOutlineMat;
     protected Color _defaultColor;
-    protected Color _defaultBodyColor;
+    protected string _defaultBodyColor;
 
     private Transform _meshesTrans;
 
@@ -38,7 +39,7 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
         if (renderers.Length > 0)
         {
             _defaultColor = renderers[0].material.GetColor("_EmissionColor");
-            _defaultBodyColor = renderers[0].material.color;
+            _defaultBodyColor = ColorUtility.ToHtmlStringRGB(renderers[0].material.color);
         }
 
         _meshesTrans = transform.GetChild(0);
@@ -112,10 +113,20 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
         }
 
         // Body color
-        if (_nextData.color?.Length > 0 && (_prevData?.color ?? "") != _nextData.color)
+        if ((_prevData?.color ?? "") != _nextData.color)
         {
-            Color newColor = RGBStringToColor(_nextData.color);
-            renderers[0].material.color = newColor;
+            string colorString = _nextData.color;
+            if (!string.IsNullOrEmpty(colorString) && !colorString.StartsWith("#"))
+            {
+                colorString = "#" + colorString;
+            }
+            else if (string.IsNullOrEmpty(colorString))
+            {
+                colorString = "#" + _defaultBodyColor;
+            }
+
+            ColorUtility.TryParseHtmlString(colorString, out Color targetColor);
+            renderers[0].material.color = targetColor;
         }
 
         // Visibility
@@ -237,53 +248,5 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
         }
 
         _runningVisibilityCR = null;
-    }
-
-    // Helper function to convert RGB string to Color
-    Color RGBStringToColor(string rgb)
-    {
-        if (rgb == "0")
-        {
-            return _defaultBodyColor;
-        }
-        try
-        {
-            string[] parts = rgb.Split(',');
-            if (parts.Length == 3)
-            {
-                // Try to parse each part to int, then normalize to float (0 to 1)
-                if (
-                    int.TryParse(parts[0].Trim(), out int r)
-                    && int.TryParse(parts[1].Trim(), out int g)
-                    && int.TryParse(parts[2].Trim(), out int b)
-                )
-                {
-                    return new Color(
-                        Mathf.Clamp01(r / 255f),
-                        Mathf.Clamp01(g / 255f),
-                        Mathf.Clamp01(b / 255f)
-                    );
-                }
-                else
-                {
-                    Debug.LogWarning(
-                        "RGBStringToColor: One or more RGB components are not integers."
-                    );
-                    return _defaultBodyColor; // Return default color if parsing fails
-                }
-            }
-            else
-            {
-                Debug.LogWarning("Invalid RGB string format. Must be 'R,G,B'.");
-                return _defaultBodyColor; // Return default color if format is incorrect
-            }
-        }
-        catch (System.Exception ex)
-        {
-            Debug.LogWarning(
-                $"RGBStringToColor: Error parsing color string '{rgb}'. Exception: {ex.Message}"
-            );
-            return _defaultBodyColor; // Return default color in case of unexpected error
-        }
     }
 }

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitController.cs
@@ -252,7 +252,8 @@ public class MobileUnitController : BaseComponentController<MobileUnitData>
             if (parts.Length == 3)
             {
                 // Try to parse each part to int, then normalize to float (0 to 1)
-                if (int.TryParse(parts[0].Trim(), out int r) &&
+                if (
+                    int.TryParse(parts[0].Trim(), out int r) &&
                     int.TryParse(parts[1].Trim(), out int g) &&
                     int.TryParse(parts[2].Trim(), out int b))
                 {

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitData.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitData.cs
@@ -6,7 +6,7 @@ public class MobileUnitData : BaseComponentData
     public float height;
     public float progress; // 0 -> 1 percent between prev/next
     public string? selected; // ={none/highlight/outline}
-    public string? color; // hex eg "#ff0000" or "ff0000"
+    public string? color; // https://docs.unity3d.com/ScriptReference/ColorUtility.TryParseHtmlString.html
     public bool shared; //  ie sharing with a building
     public bool visible;
 }

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitData.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitData.cs
@@ -6,7 +6,7 @@ public class MobileUnitData : BaseComponentData
     public float height;
     public float progress; // 0 -> 1 percent between prev/next
     public string? selected; // ={none/highlight/outline}
-    public string? color; // rgb eg: "255,198,0" or "0" for default
+    public string? color; // hex eg "#ff0000" or "ff0000"
     public bool shared; //  ie sharing with a building
     public bool visible;
 }

--- a/map/Assets/Scripts/Components/MobileUnit/MobileUnitData.cs
+++ b/map/Assets/Scripts/Components/MobileUnit/MobileUnitData.cs
@@ -6,6 +6,7 @@ public class MobileUnitData : BaseComponentData
     public float height;
     public float progress; // 0 -> 1 percent between prev/next
     public string? selected; // ={none/highlight/outline}
+    public string? color; // rgb eg: "255,198,0" or "0" for default
     public bool shared; //  ie sharing with a building
     public bool visible;
 }

--- a/map/Assets/Scripts/Editor/Dioramas/MobileUnitDiorama.cs
+++ b/map/Assets/Scripts/Editor/Dioramas/MobileUnitDiorama.cs
@@ -33,6 +33,7 @@ class MobileUnitDiorama : IDiorama
                     height = 0.1f,
                     progress = 0,
                     selected = "none",
+                    color = "255,198,0",
                     shared = false,
                     visible = true
                 } },
@@ -112,6 +113,7 @@ class MobileUnitDiorama : IDiorama
                     height = 0.4f,
                     progress = 1,
                     selected = "none",
+                    color = "255,0,0",
                     shared = false,
                     visible = true
                 } },

--- a/map/Assets/Scripts/Editor/Dioramas/MobileUnitDiorama.cs
+++ b/map/Assets/Scripts/Editor/Dioramas/MobileUnitDiorama.cs
@@ -33,7 +33,7 @@ class MobileUnitDiorama : IDiorama
                     height = 0.1f,
                     progress = 0,
                     selected = "none",
-                    color = "255,198,0",
+                    color = "#00ff1a",
                     shared = false,
                     visible = true
                 } },
@@ -113,7 +113,6 @@ class MobileUnitDiorama : IDiorama
                     height = 0.4f,
                     progress = 1,
                     selected = "none",
-                    color = "255,0,0",
                     shared = false,
                     visible = true
                 } },


### PR DESCRIPTION
## What
Changes to Unity and the frontend to allow a mobile unit's color to be changed from plugins.

### Unity diorama
![image](https://github.com/playmint/ds/assets/27741109/ee377fcf-f50e-4224-88c5-9f4a4e75e17e)

### Custom plugin changing unit's color
![image](https://github.com/playmint/ds/assets/27741109/2b5f081d-148d-42bd-93e7-e31bc58bacbb)

## [Why](https://github.com/orgs/playmint/projects/1/views/1?pane=issue&itemId=52368565)
This has been a common request during our playtests of Duck Burger, Hexcraft, and more.
_"As a team based experience maker I want to show which team each Unit is on so players can see whats going on"_

## How
First, changes in Unity to MobileUnitData, MobileUnitController, and MobileUnitDiorama, resulting in the diorama screenshot above.
Then changes to the frontend, mostly following the format of how plugins can change tile colours.

## Info
To test this in a local build, I created a very simple custom plugin and hard-coded my unit's ID into the map:
```js
    const mapObj = [];
    mapObj.push(
        {
            type: "unit",
            key: "color",
            id: "0x0945e868000000000000000000000000000000000000033b",
            value: "#ff0000",
        }
    )

    return {
        version: 1,
        map: mapObj, ....
```

edit: team colours have now been implemented into the DuckBurgerHQ example building.

Resolves #1023 