### PR TITLE
Only set team colours when in range (DuckBurgerHQ)

### DIFF
--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -178,23 +178,35 @@ export default async function update(state, block) {
 
     connectDisplayBuildings(state, localBuildings);
 
+    // unit plugin properties - unit color
     const unitMapObj = [];
+    const hqCoords = selectedBuilding.location?.tile?.coords;
     for (let i = 0; i < teamDuckLength; i++) {
+        const unitId = getHQTeamUnit(selectedBuilding, "Duck", i);
+        const unitCoords = state.world?.mobileUnits?.find(unit => unit.id === unitId).nextLocation?.tile?.coords;
+        if (distance(getTileCoords(unitCoords), getTileCoords(hqCoords)) > 5) {
+            continue;
+        }
         unitMapObj.push(
             {
                 type: "unit",
                 key: "color",
-                id: getHQTeamUnit(selectedBuilding, "Duck", i),
+                id: unitId,
                 value: "#f1b14e",
             }
         )
     }
     for (let i = 0; i < teamBurgerLength; i++) {
+        const unitId = getHQTeamUnit(selectedBuilding, "Burger", i);
+        const unitCoords = state.world?.mobileUnits?.find(unit => unit.id === unitId).nextLocation?.tile?.coords;
+        if (distance(getTileCoords(unitCoords), getTileCoords(hqCoords)) > 5) {
+            continue;
+        }
         unitMapObj.push(
             {
                 type: "unit",
                 key: "color",
-                id: getHQTeamUnit(selectedBuilding, "Burger", i),
+                id: unitId,
                 value: "#ec5c61",
             }
         )


### PR DESCRIPTION
## What
Requires the unit to be in range of the DuckBurgerHQ before setting the unit's colour.

In the image below, it shows 2 units who are both on a team (from the DuckBurgerHQ on the left). One is standing outside the range of 5 tiles.
![image](https://github.com/playmint/ds/assets/27741109/b1f188a1-459f-4b39-b993-377ff8a95343)

## Why
Because a player might have joined a game of Duck Burger, but wondered off to another game before Duck Burger was reset.

## How
It checks the distance between the unit and the DuckBurgerHQ before assigning the colour to make sure it's in range:
```js
if (distance(getTileCoords(unitCoords), getTileCoords(hqCoords)) > 5) {
            continue;
        }
```