### PR TITLE
allow spinning up "tonk" map with docker compose

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -13,6 +13,17 @@ const DEPLOYER_PRIVATE_KEY = "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff
 const MAP = process.env.MAP || "default";
 
 async function handleStartup(){
+    // bail if MAP=tonk
+    if (MAP === 'tonk') {
+        console.error('');
+        console.error('MAP=tonk is not supported via `make dev`');
+        console.error('');
+        console.error('Either use: docker compose --profile tonk up');
+        console.error('');
+        console.error('Or use MAP=default and then work out how to build and run tonk services manually (requires rust toolchain)');
+        console.error('');
+        process.exit(1);
+    }
     // which map to deploy (relative to contracts)
     const mapPath = path.join('./src/maps/', MAP);
     if (!fs.existsSync(path.join('contracts', mapPath))) {

--- a/.devstartup.js
+++ b/.devstartup.js
@@ -18,7 +18,7 @@ async function handleStartup(){
         console.error('');
         console.error('MAP=tonk is not supported via `make dev`');
         console.error('');
-        console.error('Either use: docker compose --profile tonk up');
+        console.error('Either use: `MAP=tonk docker compose --profile tonk up`');
         console.error('');
         console.error('Or use MAP=default and then work out how to build and run tonk services manually (requires rust toolchain)');
         console.error('');

--- a/.github/workflows/build-hexwood.yml
+++ b/.github/workflows/build-hexwood.yml
@@ -34,6 +34,7 @@ on:
           - quest-map
           - team-vanilla
           - hexcraft
+          - tonk
 
 jobs:
   build:

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -3,6 +3,7 @@ gameID: {{ $.Values.frontend.gameAddress | quote}}
 build: {{ $.Values.version | quote }}
 wsEndpoint: "wss://services-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}/query"
 httpEndpoint: "https://services-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}/query"
+tonkEndpoint: "https://tonk-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
 {{ end }}
 
 ---
@@ -89,6 +90,8 @@ spec:
             value: "ws://localhost:8080/query"
           - name: MAP
             value: {{ $.Values.map | quote }}
+          - name: TONK_URL_HTTP
+            value: "http://{{ $.Release.Name}}-tonk.{{ $.Release.Namespace }}.svc.cluster.local"
           ports:
             - name: network
               containerPort: 8545

--- a/chart/templates/tonk.yaml
+++ b/chart/templates/tonk.yaml
@@ -1,0 +1,108 @@
+{{ if eq $.Values.map "tonk" }}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-tonk
+  namespace: {{ $.Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-tonk
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ $.Release.Name }}-tonk
+      annotations:
+        gitsha: {{ $.Values.version | quote }}
+    spec:
+      priorityClassName: {{ $.Values.priorityClassName | quote }}
+      containers:
+        - name: redis
+          image: redis:7.2.4-alpine
+          imagePullPolicy: Always
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+        - name: state
+          image: playmint/tonk-state-service:latest
+          imagePullPolicy: Always
+          env:
+            - name: TONK_SERVICES_STAGE
+              value: "PRODUCTION"
+            - name: REDIS_URL
+              value: "redis://localhost:6379"
+            - name: RUST_LOG
+              value: "info"
+            - name: DS_ENDPOINT
+              value: "http://{{ $.Release.Name}}-services.{{ $.Release.Namespace }}.svc.cluster.local"
+        - name: web
+          image: playmint/tonk-web-server:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8082
+              protocol: TCP
+          env:
+            - name: TONK_SERVICES_STAGE
+              value: "PRODUCTION"
+            - name: REDIS_URL
+              value: "redis://localhost:6379"
+            - name: RUST_LOG
+              value: "info"
+            - name: ALLOWED_ORIGIN
+              value: "https://{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-tonk
+  namespace: {{ $.Release.Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ $.Release.Name }}-tonk
+
+---
+apiVersion: "gateway.solo.io/v1"
+kind: VirtualService
+metadata:
+  name: {{ $.Release.Name }}-tonk
+  namespace: {{ $.Release.Namespace }}
+spec:
+  virtualHost:
+    domains: ["tonk-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"]
+    routes:
+    - matchers:
+      - prefix: "/"
+      routeAction:
+        single:
+          kube:
+            ref:
+              name: {{ $.Release.Name }}-tonk
+              namespace: {{ $.Release.Namespace }}
+            port: 80
+      options:
+        timeout: 120s
+        upgrades:
+        - websocket: {}
+        retries:
+          retryOn: gateway-error
+          numRetries: 1
+          perTryTimeout: 120s
+  sslConfig:
+    sniDomains: ["tonk-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"]
+    secretRef:
+      name: "downstream-domain-certificate"
+      namespace: "ingress-system"
+
+
+{{ end }}

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -64,6 +64,14 @@ MAP=${MAP:-"default"}
 echo "ds apply ${MAP}..."
 ds -k "${DEPLOYER_PRIVATE_KEY}" -n local --ws-endpoint="${SERVICES_WS}" --http-endpoint="${SERVICES_HTTP}" apply -R -f "./src/maps/${MAP}"
 
+# postinstall script
+if [ -f "./src/maps/${MAP}/postinstall.js" ]; then
+    echo "+------------------------+"
+    echo "| executing postinstall  |"
+    echo "+------------------------+"
+    node "./src/maps/${MAP}/postinstall.js"
+fi
+
 echo "+-------+"
 echo "| ready |"
 echo "+-------+"

--- a/contracts/src/maps/tonk/HexDump/HexDump.js
+++ b/contracts/src/maps/tonk/HexDump/HexDump.js
@@ -1,0 +1,49 @@
+import ds from 'downstream';
+
+export default async function update({ selected }) {
+    console.log("building id: ", selected.mapElement.id);
+    console.log("selected coords: ", selected.tiles[0].coords);
+    // const inputBag = selectedBuilding && selectedBuilding.bags.find(b => b.key == 0).bag;
+    // const canPourDrink = inputBag && inputBag.slots.length == 2 && inputBag.slots.every(slot => slot.balance > 0) && selectedEngineer;
+
+    // const craft = () => {
+    //     if (!selectedEngineer) {
+    //         ds.log('no selected engineer');
+    //         return;
+    //     }
+    //     if (!selectedBuilding) {
+    //         ds.log('no selected building');
+    //         return;
+    //     }
+
+    //     ds.dispatch(
+    //         {
+    //             name: 'BUILDING_USE',
+    //             args: [selectedBuilding.id, selectedEngineer.id, []]
+    //         },
+    //     );
+
+    //     ds.log('Enjoy your drink!');
+    // };
+
+    let buttons = [];
+    let html = ``;
+
+    return {
+        version: 1,
+        components: [
+            {
+                id: 'data-dump-north',
+                type: 'building',
+                content: [
+                    {
+                        id: 'default',
+                        type: 'inline',
+                        buttons,
+                        html,
+                    }
+                ],
+            },
+        ],
+    };
+}

--- a/contracts/src/maps/tonk/HexDump/HexDump.sol
+++ b/contracts/src/maps/tonk/HexDump/HexDump.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+contract TonkDepot is BuildingKind {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }
+}

--- a/contracts/src/maps/tonk/HexDump/manifest.yaml
+++ b/contracts/src/maps/tonk/HexDump/manifest.yaml
@@ -1,0 +1,24 @@
+kind: BuildingKind
+spec:
+  name: Data Dump North
+  description: "TonkAttack: a monstrous pile of worthless hex codes"
+  category: factory
+  model: 05-10
+  color: 3
+  contract:
+    file: ./HexDump.sol
+  plugin:
+    file: ./HexDump.js
+  materials:
+    - name: Green Goo
+      quantity: 10
+    - name: Blue Goo
+      quantity: 10
+    - name: Red Goo
+      quantity: 10
+  inputs: 
+    - name: Paperclip
+      quantity: 1
+  outputs: 
+    - name: Tonk
+      quantity: 1

--- a/contracts/src/maps/tonk/MemeGenerator/MemeGenerator.js
+++ b/contracts/src/maps/tonk/MemeGenerator/MemeGenerator.js
@@ -1,0 +1,49 @@
+import ds from 'downstream';
+
+export default async function update({ selected }) {
+    console.log("building id: ", selected.mapElement.id);
+    console.log("selected coords: ", selected.tiles[0].coords);
+    // const inputBag = selectedBuilding && selectedBuilding.bags.find(b => b.key == 0).bag;
+    // const canPourDrink = inputBag && inputBag.slots.length == 2 && inputBag.slots.every(slot => slot.balance > 0) && selectedEngineer;
+
+    // const craft = () => {
+    //     if (!selectedEngineer) {
+    //         ds.log('no selected engineer');
+    //         return;
+    //     }
+    //     if (!selectedBuilding) {
+    //         ds.log('no selected building');
+    //         return;
+    //     }
+
+    //     ds.dispatch(
+    //         {
+    //             name: 'BUILDING_USE',
+    //             args: [selectedBuilding.id, selectedEngineer.id, []]
+    //         },
+    //     );
+
+    //     ds.log('Enjoy your drink!');
+    // };
+
+    let buttons = [];
+    let html = ``;
+
+    return {
+        version: 1,
+        components: [
+            {
+                id: 'data-dump-east',
+                type: 'building',
+                content: [
+                    {
+                        id: 'default',
+                        type: 'inline',
+                        buttons,
+                        html,
+                    }
+                ],
+            },
+        ],
+    };
+}

--- a/contracts/src/maps/tonk/MemeGenerator/MemeGenerator.sol
+++ b/contracts/src/maps/tonk/MemeGenerator/MemeGenerator.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+contract TonkDepot is BuildingKind {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }
+}

--- a/contracts/src/maps/tonk/MemeGenerator/manifest.yaml
+++ b/contracts/src/maps/tonk/MemeGenerator/manifest.yaml
@@ -1,0 +1,24 @@
+kind: BuildingKind
+spec:
+  name: Data Dump East 
+  description: "TonkAttack: You wouldn't steam a ham"
+  category: factory
+  model: 04-17
+  color: 1
+  contract:
+    file: ./MemeGenerator.sol
+  plugin:
+    file: ./MemeGenerator.js
+  materials:
+    - name: Green Goo
+      quantity: 10
+    - name: Blue Goo
+      quantity: 10
+    - name: Red Goo
+      quantity: 10
+  inputs: 
+    - name: Paperclip
+      quantity: 1
+  outputs: 
+    - name: Tonk 
+      quantity: 1

--- a/contracts/src/maps/tonk/QuestBuildingMaterials/Items.yaml
+++ b/contracts/src/maps/tonk/QuestBuildingMaterials/Items.yaml
@@ -1,0 +1,45 @@
+
+---
+kind: Item
+spec:
+  name: L33t Bricks
+  icon: 07-191
+  goo:
+    red: 1
+    green: 99999
+    blue: 99999
+  stackable: true
+
+---
+kind: Item
+spec:
+  name: Gold Coin
+  icon: 10-33
+  goo:
+    red: 5
+    green: 10
+    blue: 10
+  stackable: true
+
+
+---
+kind: Item
+spec:
+  name: Gold Note
+  icon: 10-32
+  goo:
+    red: 25
+    green: 50
+    blue: 10
+  stackable: true
+
+---
+kind: Item
+spec:
+  name: Paperclip
+  icon: 24-129
+  goo:
+    red: 50
+    green: 100
+    blue: 25
+  stackable: true

--- a/contracts/src/maps/tonk/SelfiePoint/SelfiePoint.js
+++ b/contracts/src/maps/tonk/SelfiePoint/SelfiePoint.js
@@ -1,0 +1,50 @@
+import ds from 'downstream';
+
+export default async function update({ selected }) {
+    const { tiles, mobileUnit } = selected || {};
+    console.log("building id: ", selected.mapElement.id);
+    console.log("selected coords: ", selected.tiles[0].coords);
+    // const inputBag = selectedBuilding && selectedBuilding.bags.find(b => b.key == 0).bag;
+    // const canPourDrink = inputBag && inputBag.slots.length == 2 && inputBag.slots.every(slot => slot.balance > 0) && selectedEngineer;
+
+    // const craft = () => {
+    //     if (!selectedEngineer) {
+    //         ds.log('no selected engineer');
+    //         return;
+    //     }
+    //     if (!selectedBuilding) {
+    //         ds.log('no selected building');
+    //         return;
+    //     }
+
+    //     ds.dispatch(
+    //         {
+    //             name: 'BUILDING_USE',
+    //             args: [selectedBuilding.id, selectedEngineer.id, []]
+    //         },
+    //     );
+
+    //     ds.log('Enjoy your drink!');
+    // };
+
+    let buttons = [];
+    let html = ``;
+
+    return {
+        version: 1,
+        components: [
+            {
+                id: 'data-dump-west',
+                type: 'building',
+                content: [
+                    {
+                        id: 'default',
+                        type: 'inline',
+                        buttons,
+                        html,
+                    }
+                ],
+            },
+        ],
+    };
+}

--- a/contracts/src/maps/tonk/SelfiePoint/SelfiePoint.sol
+++ b/contracts/src/maps/tonk/SelfiePoint/SelfiePoint.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+contract TonkDepot is BuildingKind {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }
+}

--- a/contracts/src/maps/tonk/SelfiePoint/manifest.yaml
+++ b/contracts/src/maps/tonk/SelfiePoint/manifest.yaml
@@ -1,0 +1,24 @@
+kind: BuildingKind
+spec:
+  name: Data Dump West 
+  description: "TonkAttack: An exotic location perfect for basic selfies"
+  category: factory
+  model: 04-14
+  color: 5
+  contract:
+    file: ./SelfiePoint.sol
+  plugin:
+    file: ./SelfiePoint.js
+  materials:
+    - name: Green Goo
+      quantity: 10
+    - name: Blue Goo
+      quantity: 10
+    - name: Red Goo
+      quantity: 10
+  inputs: 
+    - name: Paperclip
+      quantity: 1
+  outputs: 
+    - name: Tonk 
+      quantity: 1

--- a/contracts/src/maps/tonk/TonkTower/Tonk.js
+++ b/contracts/src/maps/tonk/TonkTower/Tonk.js
@@ -1,0 +1,1036 @@
+import ds from "downstream";
+
+var game, tonkPlayer, tonkTask, lastRoundResult;
+let bugging = false;
+let player_to_bug = null;
+let complete_task = false;
+let perform_function = false;
+let first_click_in = true;
+let confirmed = false;
+
+const ENDPOINT = ds.config.tonkEndpoint;
+
+async function getGame() {
+    try {
+        let response = await fetch(`${ENDPOINT}/game`);
+        let raw = await response.text();
+        return JSON.parse(raw);
+    } catch (e) {
+        console.log(e);
+        return `{ "status": "GameServerDown" }`;
+    }
+}
+
+async function getPlayer(id) {
+    try {
+        let response = await fetch(`${ENDPOINT}/player/${id}`);
+        let raw = await response.text();
+        //console.log("Player JSON: " + raw);
+        return JSON.parse(raw);
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+function isInGame(players, playerId) {
+    return players.findIndex((p) => p.id == playerId) !== -1;
+}
+
+async function getPlayers(gameId, playerId) {
+    try {
+        let response = await fetch(
+            `${ENDPOINT}/game/${gameId}/player?player_id=${playerId}`,
+        );
+        let raw = await response.text();
+        return JSON.parse(raw);
+    } catch (e) {
+        console.error(e);
+        return [];
+    }
+}
+
+async function getResult() {
+    try {
+        let response = await fetch(`${ENDPOINT}/game/result`);
+        let text = await response.text();
+        return JSON.parse(text);
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+async function getLastRoundResult(game) {
+    //TODO implement
+    console.log("tonk getLastRound", game.time.round - 1);
+    try {
+        let lastRound = game.time.round - 1;
+        let response = await fetch(`${ENDPOINT}/game/result/${lastRound}`);
+        let text = await response.text();
+        return JSON.parse(text);
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+async function registerPlayer(id, mobileUnitId, displayName, _hash, _secret) {
+    var raw = JSON.stringify({
+        id: id,
+        mobile_unit_id: mobileUnitId,
+        display_name: displayName,
+    });
+    var requestOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: raw,
+    };
+
+    try {
+        // let response = await fetch(`${ENDPOINT}/player/${id}?secret_key=${secret}&onchain_hash=${hash}`, requestOptions)
+        await fetch(`${ENDPOINT}/player/${id}`, requestOptions);
+        // let text = await response.text();
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+async function getTask(player) {
+    try {
+        let response = await fetch(
+            `${ENDPOINT}/task?player_id=${player.id}&secret_key=fff`,
+        );
+        let text = await response.text();
+        return JSON.parse(text);
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+async function postTask(task, player) {
+    var raw = JSON.stringify(task);
+    var requestOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: raw,
+    };
+
+    try {
+        await fetch(
+            `${ENDPOINT}/task?player_id=${player.id}&secret_key=fff`,
+            requestOptions,
+        );
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+async function postAction(target, game, player, confirmed) {
+    var raw = JSON.stringify({
+        poison_target: target,
+        round: game.time.round,
+        confirmed,
+        interrupted_task: false,
+    });
+    var requestOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: raw,
+    };
+
+    try {
+        await fetch(
+            `${ENDPOINT}/action?player_id=${player.id}&secret_key=fff`,
+            requestOptions,
+        );
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+function getInformativeText(status, tonkPlayer) {
+    switch (status) {
+        case "SPECTATOR": {
+            return "You are a spectator. You may join when game is in the lobby.";
+        }
+        case "ELIMINATED": {
+            return "You have been eliminated. Please wait and then return to the center.";
+        }
+        case "Lobby": {
+            return "You will receive instructions when the game begins.";
+        }
+        case "Tasks": {
+            if (tonkPlayer.role === "Bugged") {
+                let isNearTower =
+                    tonkPlayer.proximity &&
+                    tonkPlayer.proximity.nearby_buildings &&
+                    tonkPlayer.proximity.nearby_buildings.filter(
+                        (b) => b.is_tower,
+                    ).length > 0;
+                let isNearPlayer =
+                    tonkPlayer.proximity &&
+                    tonkPlayer.proximity.nearby_players &&
+                    tonkPlayer.proximity.nearby_players.length > 0;
+                if (isNearTower) {
+                    return "You cannot tonk players within 3 tiles of the compute center";
+                }
+
+                if (!isNearPlayer) {
+                    return "You must be within 2 tiles of a player to tonk them. Look for the button to appear below.";
+                }
+            } else {
+                if (tonkTask.complete) {
+                    return "You have performed your duty. Waiting for next instructions...";
+                } else {
+                    return "Follow the directions. When you are next to the building a button will appear below.";
+                }
+            }
+            return "";
+        }
+        case "Vote": {
+            return "Make your way to the compute center to vote out the Brainwashed units!";
+        }
+        case "VoteResult": {
+            return "Waiting for next instructions...";
+        }
+        case "End": {
+            return "The game is over. Return to the compute center to create a new lobby.";
+        }
+        default: {
+            return "";
+        }
+    }
+}
+
+function gameStatusText(game) {
+    const { status, win_result } = game;
+    switch (status) {
+        case "SPECTATOR": {
+            return "You are not in the game";
+        }
+        case "ELIMINATED": {
+            return "You have been eliminated";
+        }
+        case "Lobby": {
+            return "Game has an open lobby";
+        }
+        case "Tasks": {
+            return "Units are doing their tasks";
+        }
+        case "Vote": {
+            return "Voting is in session";
+        }
+        case "VoteResult": {
+            return "All votes are in and counted";
+        }
+        case "End": {
+            if (win_result === "Thuggery") {
+                return "Brainwashed win";
+            } else {
+                return "Sentient win";
+            }
+        }
+        default: {
+            return "";
+        }
+    }
+}
+
+function getRoleText(role, has_joined) {
+    switch (role) {
+        case "Bugged": {
+            return "Brainwashed Unit";
+        }
+        case "Normal": {
+            return "Sentient Unit";
+        }
+        default: {
+            if (has_joined) {
+                return "████████ Unit";
+            } else {
+                return "Spectator Unit";
+            }
+        }
+    }
+}
+
+function getEliminationReason(e) {
+    switch (e.reason) {
+        case "BuggedOut": {
+            return "was tonked.";
+        }
+        case "VotedOut": {
+            return "was voted out.";
+        }
+        case "Inaction": {
+            return "failed to act.";
+        }
+        default: {
+            return "no news to report.";
+        }
+    }
+}
+
+function getTaskDepotText(player) {
+    if (typeof tonkTask === "undefined") {
+        return "ERROR";
+    }
+    // this is the text displayed to the Brainwashed
+    if (tonkTask.destination.id === "") {
+        if (player.used_action === "ReturnToTower") {
+            return "COMPUTE CENTER";
+        } else if (player.used_action === "TaskComplete") {
+            return "GOOD JOB UNIT";
+        } else {
+            return "TONK A UNIT";
+        }
+    }
+    if (!tonkTask.dropped_off) {
+        return tonkTask.destination.readable_id;
+    }
+    if (!tonkTask.dropped_off_second) {
+        return tonkTask.second_destination.readable_id;
+    }
+    if (!tonkTask.complete) {
+        return "COMPUTE CENTER";
+    }
+    if (tonkTask.complete) {
+        return "GOOD JOB UNIT";
+    }
+
+    return "";
+}
+
+function inlineStyle(style) {
+    return Object.keys(style)
+        .map((key) => {
+            return `${key}:${style[key]}`;
+        })
+        .join(";");
+}
+
+const containerStyle = {
+    width: "100%",
+};
+
+const screenContainerStyle = {
+    width: "255px",
+    "max-width": "255px",
+    height: "118px",
+    "max-height": "118px",
+    "border-radius": "12px",
+    overflow: "hidden",
+    background: "black",
+    position: "absolute",
+    "margin-left": "1px",
+};
+
+const miniScreenContainerStyle = {
+    width: "253px",
+    "max-width": "253px",
+    height: "53px",
+    "margin-left": "1px",
+    "max-height": "53px",
+    "border-radius": "5px",
+    overflow: "hidden",
+    background: "black",
+    position: "absolute",
+};
+
+const screenGradientStyle = {
+    width: "253px",
+    "max-width": "253px",
+    height: "118px",
+    "max-height": "118px",
+    position: "absolute",
+    background:
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.50) 5.22%, rgba(255, 255, 255, 0.38) 14.06%, rgba(255, 255, 255, 0.00) 100%)",
+};
+
+const lowerGlareStyle = {
+    position: "absolute",
+    top: "81px",
+    transform: "rotate(180deg)",
+    width: "253px",
+    "max-width": "253px",
+    height: "34px",
+    "max-height": "34px",
+    background:
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.30) 5.22%, rgba(255, 255, 255, 0.23) 21.88%, rgba(255, 255, 255, 0.00) 100%)",
+    filter: "blur(7px)",
+};
+const upperGlareStyle = {
+    width: "253px",
+    "max-width": "253px",
+    height: "34px",
+    "max-height": "34px",
+    background:
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.30) 5.22%, rgba(255, 255, 255, 0.23) 21.88%, rgba(255, 255, 255, 0.00) 100%)",
+    filter: "blur(7px)",
+};
+
+const miniUpperGlareStyle = {
+    background:
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.50) 5.22%, rgba(255, 255, 255, 0.23) 21.88%, rgba(255, 255, 255, 0.00) 100%)",
+};
+
+const logoStyle = {
+    width: "253px",
+    position: "absolute",
+    top: "2px",
+    left: "0px",
+};
+
+const screenRow = {
+    display: "block",
+    width: "100%",
+    height: "123px",
+    position: "absolute",
+    top: 0,
+    left: 0,
+};
+
+const miniGradient = {
+    height: "53px",
+    "max-height": "53px",
+    background:
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.25) 5.22%, rgba(255, 255, 255, 0.18) 14.06%, rgba(255, 255, 255, 0.00) 100%)",
+};
+
+const miniGlare = {
+    height: "17px",
+    "max-height": "17px",
+};
+
+const bigTextStyle = {
+    "font-family": "Recursive, monospace",
+    "font-size": "25px",
+    "font-style": "normal",
+    "font-weight": 500,
+};
+
+const roleTextStyle = {
+    color: "#E47740",
+    "text-shadow":
+        "-2px -2px 3px rgba(228, 119, 66, 0.50), 2px 2px 2px rgba(228, 119, 63, 0.50)",
+    "line-height": "34px",
+    height: "53px",
+    top: 0,
+    position: "absolute",
+    "text-align": "center",
+    padding: "10px",
+    width: "100%",
+};
+
+const rowStyle = {
+    display: "block",
+    width: "100%",
+    height: "120px",
+    "margin-top": "12px",
+};
+// button-styles__TextButton-sc-7fe74a04-0 button-styles__ActionButton-sc-7fe74a04-1 kEuMYh jQZoSm
+// sc-7fe74a04-0 sc-7fe74a04-1 gpXETn jzrUbI
+const labelStyle = {
+    "font-family": "Recursive, monospace",
+    "font-size": "18px",
+    "font-weight": "700",
+    margin: 0,
+    padding: 0,
+    "max-width": "130px",
+};
+const boxAndLabelStyle = {
+    margin: 0,
+    padding: 0,
+    display: "inline-block",
+};
+const boxStyle = {
+    display: "inline-block",
+    "border-radius": "5px",
+    background: "#EDEBF6",
+    border: "1px solid #A7A3AF",
+    "box-shadow": "-1px -1px 0px 0px #EDEBF6",
+    margin: "5px",
+};
+
+const timeBoxStyle = {
+    display: "inline-block",
+    "border-radius": "5px",
+    background: "#EDEBF6",
+    border: "3px solid black",
+};
+
+const statusStyle = {
+    "min-width": "215px",
+    "max-width": "215px",
+    "min-height": "75px",
+    "max-height": "75px",
+};
+
+const directionsStyle = {
+    "min-width": "215px",
+    "max-width": "215px",
+    "min-height": "53px",
+    "max-height": "53px",
+};
+
+const timeStyle = {
+    "min-width": "94px",
+    "max-width": "94px",
+    "min-height": "75px",
+    "max-height": "75px",
+};
+
+const entryStyle = {
+    "font-weight": 800,
+    "font-size": "14px",
+    margin: "5px",
+};
+
+const timeTextStyle = {
+    "font-weight": 800,
+    "font-size": "28px",
+    color: "#FB7001",
+    margin: "15px 0",
+    padding: 0,
+    "text-align": "center",
+};
+
+const warningTextStyle = {
+    color: "#A19BAD",
+    "font-family": "Recursive, monospace",
+    "font-size": "18px",
+    "font-weight": "500",
+    "text-align": "center",
+};
+
+let nearbyPlayersContainer = {
+    position: "fixed",
+    display: "inline-block",
+    bottom: "3.6rem",
+    right: "2.4rem",
+    "min-height": "4rem",
+    padding: "1.2rem",
+    "background-color": "white",
+    transition: "bottom 1s ease-in, opacity 0.6s ease-in",
+    "border-radius": "1.2rem",
+    border: "#0D090F 3px solid",
+    "max-width": "350px",
+};
+
+let playerFlexBox = {
+    display: "flex",
+    position: "relative",
+    "max-width": "100%",
+    "flex-direction": "row",
+    "flex-wrap": "wrap",
+    "max-height": "265px",
+};
+
+const colorOrange = {
+    color: "#FB7001",
+};
+const colorPurple = {
+    color: "#9C74FD",
+};
+const colorGreen = {
+    color: "#32B25A",
+};
+const colorPink = {
+    color: "#E76CC9",
+};
+const colorBlue = {
+    color: "#2DAEE0",
+};
+
+const blackBackgroundStyle = {
+    display: "block",
+    width: "260px",
+    height: "200px",
+    position: "absolute",
+    background: "black",
+    "border-radius": "14px",
+    top: "-2px",
+    left: "-3px",
+    "z-index": "-1",
+};
+
+function renderNearbyPlayers(tonkPlayer) {
+    let nearbyPlayers = tonkPlayer.proximity
+        ? tonkPlayer.proximity.nearby_players || []
+        : [];
+    return `
+        <div style="${inlineStyle(nearbyPlayersContainer)}">
+            <p style="${inlineStyle({
+                ...labelStyle,
+                "max-width": "100%",
+            })}">Nearby Units</p>
+            <p style="${inlineStyle({
+                ...warningTextStyle,
+                width: "100%",
+                "text-align": "left",
+            })}">Units within this range are a danger to you.</p>
+            <div style="${inlineStyle(playerFlexBox)}">
+                ${nearbyPlayers
+                    .map((p) => {
+                        return `
+                        <p style="${inlineStyle(entryStyle)}">${
+                            p.display_name
+                        }</p>
+                    `;
+                    })
+                    .join("\n")}
+            </div>
+        </div>
+    `;
+}
+
+function renderInformation(informativeText) {
+    return `
+    <div style="${inlineStyle({
+        ...rowStyle,
+        height: "175px",
+        margin: "0px 0 25px 0",
+        display: "flex",
+        "align-items": "center",
+        "justify-content": "center",
+        "max-height": "220px",
+    })}">
+        <p style="${inlineStyle({
+            ...warningTextStyle,
+            "max-width": "264px",
+        })}">${informativeText}</p>
+    </div>
+    `;
+}
+
+function renderRoundView(status, player) {
+    let depotText = getTaskDepotText(player);
+    switch (status) {
+        case "SPECTATOR": {
+            return "";
+        }
+        case "ELIMINATED": {
+            return renderLastRoundInformation();
+        }
+        case "Lobby": {
+            return "";
+        }
+        case "Tasks": {
+            return renderDirections(depotText);
+        }
+        case "Vote": {
+            return renderLastRoundInformation();
+        }
+        case "VoteResult": {
+            return renderLastRoundInformation();
+        }
+        case "End": {
+            return renderLastRoundInformation();
+        }
+        default: {
+            return "";
+        }
+    }
+}
+
+function renderLastRoundInformation() {
+    if (!lastRoundResult.eliminated || lastRoundResult.eliminated.length == 0) {
+        lastRoundResult.eliminated = [
+            {
+                player: {
+                    display_name: "N/A",
+                },
+            },
+        ];
+    }
+    return `
+<div style="${inlineStyle(rowStyle)}">
+    <div style="${inlineStyle(boxAndLabelStyle)}">
+        <p style="${inlineStyle({
+            ...labelStyle,
+            width: "100%",
+        })}">LAST ROUND SUMMARY</p>
+        <div style="${inlineStyle({
+            ...boxStyle,
+            ...statusStyle,
+            "overflow-y": "scroll",
+        })}"> 
+            ${lastRoundResult.eliminated
+                .map((e) => {
+                    if (e.player.role === "Bugged") {
+                        return `
+                        <p style="${inlineStyle({
+                            ...entryStyle,
+                            ...colorOrange,
+                        })}">${e.player.display_name} — ${getEliminationReason(
+                            e,
+                        )}</p>
+                    `;
+                    } else {
+                        return `
+                        <p style="${inlineStyle(entryStyle)}">${
+                            e.player.display_name
+                        } — ${getEliminationReason(e)}</p>
+                    `;
+                    }
+                })
+                .join("\n")}
+        </div>
+    </div>
+</div>
+    `;
+}
+
+function getColorForDestination(destination) {
+    switch (destination) {
+        case "DATA DUMP NORTH": {
+            return colorGreen.color;
+        }
+        case "DATA DUMP WEST": {
+            return colorPurple.color;
+        }
+        case "DATA DUMP EAST": {
+            return colorPink.color;
+        }
+        case "COMPUTE CENTER": {
+            return colorBlue.color;
+        }
+        default: {
+            return colorOrange.color;
+        }
+    }
+}
+
+function getColorForBug() {
+    if (tonkPlayer.used_action === "ReturnToTower") {
+        return colorBlue.color;
+    } else if (tonkPlayer.used_action === "TaskComplete") {
+        return colorOrange.color;
+    } else {
+        return "#F00";
+    }
+}
+
+function renderDirections(depotText) {
+    let color = getColorForDestination(depotText);
+    const colorStyle =
+        tonkTask.destination.id === ""
+            ? { background: getColorForBug() }
+            : { background: color };
+    return `
+    <div style="${inlineStyle(rowStyle)}">
+        <div style="${inlineStyle(boxAndLabelStyle)}">
+            <p style="${inlineStyle(labelStyle)}">DIRECTIONS</p>
+            <div style="${inlineStyle({
+                ...boxStyle,
+                ...directionsStyle,
+                ...colorStyle,
+            })}"> 
+                <p style="${inlineStyle({
+                    ...bigTextStyle,
+                    "font-size": "22px",
+                    "text-align": "center",
+                    "line-height": "50px",
+                })}">${depotText}</p>
+            </div>
+        </div>
+    </div>
+    `;
+}
+
+function renderDefault(time, gameStatusText, roleText) {
+    return `
+<div style="${inlineStyle({
+        ...blackBackgroundStyle,
+        transform: "translateY(-175px)",
+    })}">
+</div>
+<div style="${inlineStyle({ ...screenRow, transform: "translateY(-174px)" })}">
+    <div style="${inlineStyle(screenContainerStyle)}">
+        <div style="${inlineStyle(screenGradientStyle)}"></div>
+        <div style="${inlineStyle(upperGlareStyle)}"></div>
+        <div style="${inlineStyle(lowerGlareStyle)}"></div>
+        <img src="https://d19un6ckffnywj.cloudfront.net/tonk-attack-transparent-logo.gif" style="${inlineStyle(
+            logoStyle,
+        )}" />
+    </div>
+</div>
+<div style="${inlineStyle({
+        ...screenRow,
+        transform: "translateY(-55px)",
+        height: "53px",
+    })}">
+    <div style="${inlineStyle(miniScreenContainerStyle)}">
+        <div style="${inlineStyle({
+            ...screenGradientStyle,
+            ...miniGradient,
+        })}"></div>
+        <div style="${inlineStyle({
+            ...upperGlareStyle,
+            ...miniGlare,
+            ...miniUpperGlareStyle,
+        })}"></div>
+        <div style="${inlineStyle({
+            ...lowerGlareStyle,
+            ...miniGlare,
+            top: "36px",
+        })}"></div>
+        <p style="${inlineStyle({
+            ...bigTextStyle,
+            ...roleTextStyle,
+        })}">${roleText}</p>
+    </div>
+</div>
+<div style="${inlineStyle({
+        ...screenRow,
+        transform: "translate(255px, 24px)",
+        height: "106px",
+        width: "auto",
+    })}">
+    <div style="${inlineStyle({
+        ...boxAndLabelStyle,
+        transform: "translateY(0)",
+    })}">
+        <p style="${inlineStyle({
+            ...labelStyle,
+            ...timeBoxStyle,
+            display: "block",
+            margin: "0 0 -3px 0",
+            "text-align": "center",
+        })}">TIME</p>
+        <div style="${inlineStyle({
+            ...timeBoxStyle,
+            ...timeStyle,
+            margin: "0",
+        })}"> 
+            <p style="${inlineStyle(timeTextStyle)}">${time}</p>
+        </div>
+    </div>
+</div>
+<div style="${inlineStyle(rowStyle)}">
+    <div style="${inlineStyle(boxAndLabelStyle)}">
+        <p style="${inlineStyle(labelStyle)}">GAME STATUS</p>
+        <div style="${inlineStyle({ ...boxStyle, ...statusStyle })}"> 
+            <p style="${inlineStyle(entryStyle)}">${gameStatusText}</p>
+        </div>
+    </div>
+</div>
+    `;
+}
+export default async function update(params) {
+    const { selected, player } = params;
+    const { mobileUnit } = selected || {};
+    let playerEliminated = false;
+
+    // if(!player){
+    //     console.log(" NO PLAYER");
+    //     return;
+    // }
+    // else
+    // {
+    //     console.log("PLAYER FOUND");
+    // }
+
+    game = await getGame();
+    tonkPlayer = await getPlayer(player.id);
+
+    // REGISTER FOR NAME UPDATES OR IF FIRST TIME CONNECTING
+    let nameField = mobileUnit.name || {
+        value: `UNIT ${mobileUnit.key.replace("0x", "").toUpperCase()}`,
+    };
+    if (!tonkPlayer || tonkPlayer.id == "" || first_click_in) {
+        await registerPlayer(player.id, mobileUnit.id, nameField.value);
+        first_click_in = false;
+    } else if (tonkPlayer.display_name != nameField.value) {
+        await registerPlayer(player.id, mobileUnit.id, nameField.value);
+    }
+
+    let players = await getPlayers(game.id, player.id);
+    let has_joined = isInGame(players, player.id);
+    let status = has_joined ? game.status : "SPECTATOR";
+
+    status = tonkPlayer.eliminated || playerEliminated ? "ELIMINATED" : status;
+
+    let buttons = [];
+    const bugOut = (id, displayName) => {
+        bugging = true;
+        player_to_bug = {
+            id,
+            display_name: displayName,
+        };
+    };
+
+    const confirmBug = () => {
+        bugging = true;
+        confirmed = true;
+        player_to_bug = {
+            id: tonkPlayer.id,
+            display_name: "fake",
+        };
+    };
+
+    const completeTask = () => {
+        complete_task = true;
+    };
+
+    const performFunction = () => {
+        perform_function = true;
+    };
+
+    if (bugging) {
+        await postAction(player_to_bug, game, tonkPlayer, confirmed);
+        bugging = false;
+        player_to_bug = null;
+        confirmed = false;
+    }
+
+    if (game.status === "Tasks") {
+        tonkTask = await getTask(tonkPlayer);
+        buttons = [];
+        if (tonkPlayer.role == "Bugged") {
+            if (
+                tonkPlayer.proximity.nearby_players &&
+                tonkPlayer.proximity.nearby_players.length != 0 &&
+                tonkPlayer.used_action == "Unused"
+            ) {
+                tonkPlayer.proximity.nearby_players.forEach((p) => {
+                    if (!p.proximity.immune && p.role !== "Bugged") {
+                        buttons.push({
+                            text: `Tonk ${p.display_name}`,
+                            type: "action",
+                            action: bugOut.bind(this, p.id, p.display_name),
+                            disabled: false,
+                        });
+                    }
+                });
+            }
+            let isNearTower =
+                tonkPlayer.proximity &&
+                tonkPlayer.proximity.nearby_buildings &&
+                tonkPlayer.proximity.nearby_buildings.filter((b) => b.is_tower)
+                    .length > 0;
+            if (tonkPlayer.used_action == "ReturnToTower" && isNearTower) {
+                buttons = [
+                    {
+                        text: `Upload Kill`,
+                        type: "action",
+                        action: confirmBug.bind(this),
+                        disabled: false,
+                    },
+                ];
+            }
+        } else {
+            if (complete_task) {
+                await postTask(tonkTask, tonkPlayer);
+                complete_task = false;
+            }
+            if (perform_function) {
+                await postTask(tonkTask, tonkPlayer);
+                perform_function = false;
+            }
+            if (
+                tonkPlayer.proximity.nearby_buildings &&
+                tonkPlayer.proximity.nearby_buildings.findIndex(
+                    (b) => b.id == tonkTask.destination.id,
+                ) >= 0 &&
+                !tonkTask.dropped_off
+            ) {
+                buttons = [
+                    {
+                        text: "Download Data",
+                        type: "action",
+                        action: performFunction,
+                        disabled: perform_function,
+                    },
+                ];
+            }
+            if (
+                tonkPlayer.proximity.nearby_buildings &&
+                tonkPlayer.proximity.nearby_buildings.findIndex(
+                    (b) => b.id == tonkTask.second_destination.id,
+                ) >= 0 &&
+                !tonkTask.dropped_off_second &&
+                tonkTask.dropped_off
+            ) {
+                buttons = [
+                    {
+                        text: "Download Data",
+                        type: "action",
+                        action: performFunction,
+                        disabled: perform_function,
+                    },
+                ];
+            }
+            if (
+                tonkPlayer.proximity.nearby_buildings &&
+                tonkPlayer.proximity.nearby_buildings.findIndex(
+                    (b) => b.is_tower,
+                ) >= 0 &&
+                !tonkTask.complete &&
+                tonkTask.dropped_off &&
+                tonkTask.dropped_off_second
+            ) {
+                buttons = [
+                    {
+                        text: "Upload Data",
+                        type: "action",
+                        action: completeTask,
+                        disabled: complete_task,
+                    },
+                ];
+            }
+        }
+    }
+
+    if (game.status === "VoteResult") {
+        let result = await getResult();
+        lastRoundResult = result;
+        playerEliminated =
+            result.eliminated &&
+            result.eliminated.findIndex((p) => p.player.id == tonkPlayer.id) >=
+                0;
+    }
+
+    if (game.status === "Vote") {
+        lastRoundResult = await getLastRoundResult(game);
+    }
+
+    if (game.status === "End") {
+        lastRoundResult = await getResult();
+    }
+
+    return {
+        version: 1,
+        components: [
+            {
+                id: "tonk",
+                type: "item",
+                content: [
+                    {
+                        id: "default",
+                        type: "inline",
+                        html: `
+                        <div style="${inlineStyle(containerStyle)}">
+                            ${renderDefault(
+                                game.time.timer,
+                                gameStatusText(game),
+                                getRoleText(tonkPlayer.role, has_joined),
+                            )}
+                            ${renderRoundView(status, tonkPlayer)}
+                            ${renderInformation(
+                                getInformativeText(status, tonkPlayer),
+                            )}
+                        </div>
+                        ${renderNearbyPlayers(tonkPlayer)}
+                        `,
+                        buttons,
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/contracts/src/maps/tonk/TonkTower/TonkTower.js
+++ b/contracts/src/maps/tonk/TonkTower/TonkTower.js
@@ -1,0 +1,622 @@
+import ds from "downstream";
+
+const MIN_NUMBER_PLAYERS = 2;
+let game, players, tonkPlayer;
+
+let wants_to_join = false;
+let wants_to_start = false;
+let cast_vote = false;
+let saved_vote_id = null;
+
+const ENDPOINT = ds.config.tonkEndpoint;
+
+async function getGame() {
+    try {
+        let response = await fetch(`${ENDPOINT}/game`);
+        let raw = await response.text();
+        return JSON.parse(raw);
+    } catch (e) {
+        console.log(e);
+        return {
+            status: "GameServerDown",
+        };
+    }
+}
+
+async function getPlayers(gameId, playerId) {
+    // fetch("localhost:8082/game/9d19e34892d546bea2fbeba08be9e573/player", requestOptions)
+    // .then(response => response.text())
+    // .then(result => console.log(result))
+    // .catch(error => console.log('error', error));
+
+    try {
+        let response = await fetch(
+            `${ENDPOINT}/game/${gameId}/player?player_id=${playerId}`,
+        );
+        let raw = await response.text();
+        return JSON.parse(raw);
+    } catch (e) {
+        console.log(e);
+        return `[]`;
+    }
+}
+
+async function requestStart() {
+    // var myHeaders = new Headers();
+    // myHeaders.append("Content-Type", "application/json");
+
+    var requestOptions = {
+        method: "POST",
+    };
+
+    try {
+        let response = await fetch(`${ENDPOINT}/game`, requestOptions);
+        let text = await response.text();
+        console.log(text);
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+async function requestJoin(gameId, playerId, _secretKey) {
+    // var myHeaders = new Headers();
+    // myHeaders.append("Content-Type", "application/json");
+
+    var raw = JSON.stringify({
+        id: playerId,
+    });
+
+    var requestOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Sec-Fetch-Mode": "cors",
+        },
+        mode: "cors",
+        body: raw,
+    };
+
+    try {
+        let response = await fetch(
+            `${ENDPOINT}/game/${gameId}/player`,
+            requestOptions,
+        );
+        let text = await response.text();
+        console.log(text);
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+async function sendVote(candidateId, player) {
+    var raw = JSON.stringify({
+        candidate: {
+            id: candidateId,
+        },
+    });
+
+    var requestOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Sec-Fetch-Mode": "cors",
+        },
+        mode: "cors",
+        body: raw,
+    };
+
+    try {
+        let response = await fetch(
+            `${ENDPOINT}/vote?player_id=${player.id}&secret_key=fff`,
+            requestOptions,
+        );
+        let text = await response.text();
+        console.log(text);
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+async function getPlayer(id) {
+    try {
+        let response = await fetch(`${ENDPOINT}/player/${id}`);
+        let raw = await response.text();
+        return JSON.parse(raw);
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+function gameResultToText(game) {
+    const { win_result } = game;
+    if (win_result == "Thuggery") {
+        return "The Brainwashed units have outnumbered the sentient units.";
+    } else if (win_result == "Democracy") {
+        return "The Sentient have won because they voted out all the Brainwashed.";
+    } else if (win_result == "Perfection") {
+        return "The Sentient have won because they completed all their tasks in one round.";
+    } else if (win_result == "Armageddon") {
+        return "All units have destroyed each other. There is no one left.";
+    } else {
+        return "The game is over, but I don't know why!";
+    }
+}
+
+function findBags(world, mobileUnit) {
+    return world.bags.filter(
+        (b) => b.equipee && b.equipee.node.id == mobileUnit.id,
+    );
+}
+
+function getWarningText(game, players, has_tonk) {
+    if (!has_tonk) {
+        return "You need to craft a tonk to join";
+    }
+    switch (game.status) {
+        case "Lobby": {
+            if (players.length < 2) {
+                return "Game can start when more than 2 units join";
+            }
+        }
+        case "Tasks": {
+            return "Your crafted tonk will show you instructions.";
+        }
+        case "Vote": {
+            if (tonkPlayer.used_action === "Voted") {
+                return "You have voted. Waiting for results...";
+            } else {
+                return "Select a unit to eliminate.";
+            }
+        }
+        case "VoteResult": {
+            return "";
+        }
+        case "End": {
+            return gameResultToText(game);
+        }
+        default: {
+            return "";
+        }
+    }
+}
+
+function gameStatusText(game) {
+    const { status, win_result } = game;
+    switch (status) {
+        case "Lobby": {
+            return "We are actively looking for new units to enlist.";
+        }
+        case "Tasks": {
+            return "Our units are on active duty. Good luck units!";
+        }
+        case "Vote": {
+            return "We are deliberating certain internal problems.";
+        }
+        case "VoteResult": {
+            return "We have concluded all deliberations.";
+        }
+        case "End": {
+            if (win_result === "Thuggery") {
+                return "The Brainwashed have taken over.";
+            } else {
+                return "The Sentient have landed a major victory.";
+            }
+        }
+        default: {
+            return "";
+        }
+    }
+}
+
+function inlineStyle(style) {
+    return Object.keys(style)
+        .map((key) => {
+            return `${key}:${style[key]}`;
+        })
+        .join(";");
+}
+
+const containerStyle = {
+    width: "100%",
+};
+const rowStyle = {
+    display: "block",
+    width: "100%",
+    height: "120px",
+    "margin-top": "12px",
+};
+const labelStyle = {
+    "font-family": "Recursive, monospace",
+    "font-size": "18px",
+    "font-weight": "700",
+    margin: 0,
+    padding: 0,
+    "max-width": "130px",
+};
+const boxAndLabelStyle = {
+    margin: 0,
+    padding: 0,
+    display: "inline-block",
+};
+const boxStyle = {
+    display: "inline-block",
+    "border-radius": "5px",
+    background: "#EDEBF6",
+    border: "1px solid #A7A3AF",
+    "box-shadow": "-1px -1px 0px 0px #EDEBF6",
+    margin: "5px",
+};
+const activeUnitsStyle = {
+    "min-width": "119px",
+    "max-width": "119px",
+    "min-height": "100px",
+    "max-height": "100px",
+    "overflow-y": "scroll",
+    padding: "5px",
+};
+
+const eliminatedStyle = {
+    "min-width": "119px",
+    "max-width": "119px",
+    "min-height": "100px",
+    "max-height": "100px",
+    "overflow-y": "scroll",
+    padding: "5px",
+};
+
+const statusStyle = {
+    "min-width": "157px",
+    "max-width": "157px",
+    "min-height": "75px",
+    "max-height": "75px",
+};
+
+const entryStyle = {
+    "font-weight": 800,
+    "font-size": "14px",
+    margin: "5px",
+};
+
+const selectStyle = {
+    width: "100%",
+    height: "50px",
+};
+
+const warningTextStyle = {
+    color: "#A19BAD",
+    "font-family": "Recursive, monospace",
+    "font-size": "18px",
+    "font-weight": "500",
+    "text-align": "center",
+};
+const colorOrange = {
+    color: "#FB7001",
+};
+
+const buttonStyle = {
+    width: "100%",
+    height: "5rem",
+    "font-size": "1.6rem",
+    color: "#FB7001",
+    background: "linear-gradient(#E4E1EB,#F7F5FA 35%)",
+    "font-weight": "800",
+    padding: "0.5rem 1.2rem 0 0.8rem",
+    "border-radius": "0.8rem",
+    display: "block",
+    "margin-top": "0.5rem",
+};
+
+const screenContainerStyle = {
+    "min-width": "80px",
+    "max-width": "80px",
+    "min-height": "75px",
+    "max-height": "75px",
+    "border-radius": "5px",
+    overflow: "hidden",
+    background: "black",
+    position: "relative",
+    margin: "32px 0 0 10px",
+};
+
+const screenGradientStyle = {
+    "min-width": "80px",
+    "max-width": "80px",
+    "min-height": "75px",
+    "max-height": "75px",
+    position: "absolute",
+    background:
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.12) 5.22%, rgba(255, 255, 255, 0.08) 14.06%, rgba(255, 255, 255, 0.00) 100%)",
+};
+
+const lowerGlareStyle = {
+    position: "absolute",
+    top: "41px",
+    transform: "rotate(180deg)",
+    "min-width": "80px",
+    "max-width": "80px",
+    height: "34px",
+    "max-height": "34px",
+    background:
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.30) 5.22%, rgba(255, 255, 255, 0.23) 21.88%, rgba(255, 255, 255, 0.00) 100%)",
+    filter: "blur(7px)",
+};
+const upperGlareStyle = {
+    "min-width": "80px",
+    "max-width": "80px",
+    height: "34px",
+    "max-height": "34px",
+    background:
+        "linear-gradient(180deg, rgba(255, 255, 255, 0.30) 5.22%, rgba(255, 255, 255, 0.23) 21.88%, rgba(255, 255, 255, 0.00) 100%)",
+    filter: "blur(7px)",
+};
+
+const logoStyle = {
+    width: "80px",
+    top: 0,
+    position: "absolute",
+};
+
+export function renderVote(players, tonkPlayer) {
+    console.log(players);
+    console.log(tonkPlayer);
+    return `
+    <div style="${inlineStyle({ ...rowStyle, "margin-top": "25px" })}">
+        <div style="${inlineStyle({ ...boxAndLabelStyle, display: "block" })}">
+            <p style="${inlineStyle({
+                ...labelStyle,
+                "max-width": "150px",
+            })}">VOTE UNIT OUT</p>
+            <select name="vote" style="${inlineStyle({
+                ...boxStyle,
+                ...selectStyle,
+            })}">
+                ${players
+                    .filter(
+                        (p) => p.id !== tonkPlayer.id && p.role !== "Bugged",
+                    )
+                    .map((p) => {
+                        return `
+                        <option value="${p.id}">${p.display_name}</option>
+                    `;
+                    })
+                    .join("\n")}
+            </select>
+        </div>
+        <div>
+            <button type="submit" style="${inlineStyle(
+                buttonStyle,
+            )}">Cast Vote</button>
+        </div>
+    </div>
+    `;
+}
+
+export function renderWarning(warningText) {
+    return `
+    <div style="${inlineStyle({
+        ...rowStyle,
+        height: "auto",
+        margin: "42px 0 25px 0",
+        display: "flex",
+        "align-items": "center",
+        "justify-content": "center",
+        "max-height": "220px",
+    })}">
+        <p style="${inlineStyle({
+            ...warningTextStyle,
+            "max-width": "264px",
+        })}">${warningText}</p>
+    </div>
+    `;
+}
+export function renderDefault(_time, gameStatusText, players, eliminated) {
+    return `
+    <div style="${inlineStyle({ ...rowStyle, display: "flex" })}">
+        <div style="${inlineStyle(boxAndLabelStyle)}">
+            <p style="${inlineStyle(labelStyle)}">ANNOUNCEMENTS</p>
+            <div style="${inlineStyle({ ...boxStyle, ...statusStyle })}"> 
+                <p style="${inlineStyle(entryStyle)}">${gameStatusText}</p>
+            </div>
+        </div>
+        <div style="${inlineStyle(screenContainerStyle)}">
+            <img src="https://d19un6ckffnywj.cloudfront.net/beaver-head-blkbg.gif" style="${inlineStyle(
+                logoStyle,
+            )}" />
+            <div style="${inlineStyle(screenGradientStyle)}"></div>
+            <div style="${inlineStyle(upperGlareStyle)}"></div>
+            <div style="${inlineStyle(lowerGlareStyle)}"></div>
+        </div>
+    </div>
+    <div style="${inlineStyle(rowStyle)}">
+        <div style="${inlineStyle(boxAndLabelStyle)}">
+            <p style="${inlineStyle(labelStyle)}">ACTIVE</p>
+            <div style="${inlineStyle({ ...boxStyle, ...activeUnitsStyle })}"> 
+                ${players
+                    .map((p) => {
+                        return `
+                    <p style="${inlineStyle(entryStyle)}">${p.display_name}</p>
+                    `;
+                    })
+                    .join("\n")}
+            </div>
+        </div>
+        <div style="${inlineStyle(boxAndLabelStyle)}">
+            <p style="${inlineStyle(labelStyle)}">ELIMINATED</p>
+            <div style="${inlineStyle({ ...boxStyle, ...eliminatedStyle })}"> 
+                ${eliminated
+                    .map((e) => {
+                        if (e.player.role === "Bugged") {
+                            return `
+                        <p style="${inlineStyle({
+                            ...entryStyle,
+                            ...colorOrange,
+                        })}">${e.player.display_name}</p>
+                        `;
+                        } else {
+                            return `
+                        <p style="${inlineStyle(entryStyle)}">${
+                            e.player.display_name
+                        }</p>
+                        `;
+                        }
+                    })
+                    .join("\n")}
+            </div>
+        </div>
+    </div>
+    `;
+}
+
+export default async function update(params) {
+    let buttons = [];
+    let submit;
+
+    const { selected, player, world } = params;
+    console.log(world);
+    // console.log(params);
+    const { mobileUnit } = selected || {};
+    //console.log("building id: ", selected.mapElement.id);
+    //console.log("selected coords: ", selected.tiles[0].coords);
+    // console.log(player);
+
+    const buildingId = selected.mapElement.id;
+    let bags = findBags(world, mobileUnit);
+    const has_tonk =
+        bags[0].slots.findIndex((b) => b.item && b.item.name.value == "Tonk") >=
+            0 ||
+        bags[1].slots.findIndex((b) => b.item && b.item.name.value == "Tonk") >=
+            0;
+    const craft = () => {
+        if (!mobileUnit) {
+            ds.log("no selected engineer");
+            return;
+        }
+        if (!buildingId) {
+            ds.log("no selected building");
+            return;
+        }
+
+        ds.dispatch({
+            name: "BUILDING_USE",
+            args: [buildingId, mobileUnit.id, []],
+        });
+
+        ds.log("Tonk!");
+    };
+
+    if (!has_tonk) {
+        buttons.push({
+            text: "Craft Tonk",
+            type: "action",
+            action: craft,
+            disabled: false,
+        });
+    }
+
+    game = await getGame();
+    players = await getPlayers(game.id, player.id);
+    tonkPlayer = await getPlayer(player.id);
+
+    if (wants_to_join) {
+        try {
+            await requestJoin(game.id, player.id);
+            wants_to_join = false;
+        } catch (e) {
+            console.log(e);
+        }
+    }
+
+    if (wants_to_start) {
+        try {
+            await requestStart();
+            wants_to_start = false;
+        } catch (e) {
+            console.log(e);
+        }
+    }
+    const joinGame = () => {
+        wants_to_join = true;
+    };
+
+    const startGame = () => {
+        wants_to_start = true;
+    };
+
+    if (cast_vote) {
+        await sendVote(saved_vote_id, player);
+        cast_vote = false;
+        saved_vote_id = null;
+    }
+
+    const player_is_in_game = players
+        ? players.findIndex((p) => p.id == player.id) >= 0
+        : [];
+    if (game.status == "Lobby") {
+        if (!player_is_in_game && !!has_tonk && game.status == "Lobby") {
+            buttons.push({
+                text: "Join Game",
+                type: "action",
+                action: joinGame,
+                disabled: !has_tonk,
+            });
+        }
+        if (players.length >= MIN_NUMBER_PLAYERS && player_is_in_game) {
+            buttons.push({
+                text: "Start Game",
+                type: "action",
+                action: startGame,
+                disabled: !has_tonk || !player_is_in_game,
+            });
+        }
+    }
+
+    const onCastVote = (values) => {
+        cast_vote = true;
+        saved_vote_id = values.vote;
+    };
+
+    // if (game.status == "Tasks") {
+    // }
+    if (game.status == "Vote") {
+        submit = onCastVote;
+    }
+    // if (game.status == "VoteResult") {
+    // }
+
+    const warningText = getWarningText(game, players, has_tonk);
+    let time = game.status == "Vote" ? "N/A" : game.time.timer;
+    let showVote =
+        game.status === "Vote" &&
+        !tonkPlayer.eliminated &&
+        tonkPlayer.used_action !== "Voted";
+
+    return {
+        version: 1,
+        components: [
+            {
+                id: "tonk-tower",
+                type: "building",
+                content: [
+                    {
+                        id: "default",
+                        type: "inline",
+                        html: `
+                        <div style="${inlineStyle(containerStyle)}">
+                            ${renderDefault(
+                                time,
+                                gameStatusText(game),
+                                players,
+                                game.eliminated_players || [],
+                            )}
+                            ${showVote ? renderVote(players, tonkPlayer) : ""}
+                            ${renderWarning(warningText)}
+                        </div>
+                        `,
+                        buttons,
+                        submit,
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/contracts/src/maps/tonk/TonkTower/TonkTower.sol
+++ b/contracts/src/maps/tonk/TonkTower/TonkTower.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+
+contract TonkTower is BuildingKind {
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes memory /*payload*/ ) public override {
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
+    }
+}

--- a/contracts/src/maps/tonk/TonkTower/manifest.yaml
+++ b/contracts/src/maps/tonk/TonkTower/manifest.yaml
@@ -1,0 +1,39 @@
+---
+kind: Item
+spec:
+  name: Tonk 
+  icon: 19-200
+  plugin:
+    file: ./Tonk.js
+  goo:
+    red: 0
+    green: 0
+    blue: 2
+  stackable: false
+
+---
+kind: BuildingKind
+spec:
+  name: Tonk Compute Center 
+  description: "TONK is an organization of sentient units dedicated to the stupefaction of M.O.R.T.O.N. We achieve this through the uploading of junk training data. Join us!"
+  category: factory
+  model: 14-06
+  contract:
+    file: ./TonkTower.sol
+  plugin:
+    file: ./TonkTower.js
+  materials:
+    - name: Green Goo
+      quantity: 10 
+    - name: Blue Goo
+      quantity: 10
+    - name: Red Goo
+      quantity: 10 
+  inputs:
+    - name: Blue Goo
+      quantity: 4
+    - name: Red Goo
+      quantity: 4
+  outputs:
+    - name: Tonk 
+      quantity: 1

--- a/contracts/src/maps/tonk/map.yaml
+++ b/contracts/src/maps/tonk/map.yaml
@@ -1,0 +1,971 @@
+---
+kind: Building
+spec:
+  name: Tonk Compute Center
+  location: [1, 0, -1]
+
+---
+kind: Building
+spec:
+  name: Data Dump East
+  location: [5, 2, -7]
+
+---
+kind: Building
+spec:
+  name: Data Dump West
+  location: [-4, -3, 7]
+
+---
+kind: Building
+spec:
+  name: Data Dump North
+  location: [-8, 10, -2]
+
+---
+kind: Tile
+spec:
+  location: [-2, 0, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-3, 1, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-3, 0, 3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, 0, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-2, 1, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, -1, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-2, -1, 3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-3, -1, 4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-4, 0, 4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-4, 1, 3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-3, 2, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-4, 2, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-2, 2, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, 1, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, 0, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [1, -1, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, -1, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, -2, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, 1, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, 2, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, 2, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [1, 2, -3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, 2, -4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [3, 1, -4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [4, 1, -5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [4, 0, -4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [5, -1, -4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [5, -2, -3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [4, -2, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [4, -3, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [4, -4, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [3, -4, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, -4, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [1, -3, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, -3, 3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, -3, 4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-2, -2, 4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [1, -4, 3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, -4, 4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, -2, 3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, -3, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [3, -3, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [1, -2, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, -2, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [3, -2, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, -1, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [1, 0, -1]
+
+---
+kind: Building
+spec:
+  name: Tonk Compute Center
+  location: [1, 0, -1]
+
+---
+kind: Tile
+spec:
+  location: [1, 1, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, 0, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, 1, -3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, 3, -3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [1, 3, -4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, 4, -4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, 4, -3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-2, 4, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-2, 3, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-3, 4, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-3, 5, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-4, 3, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-4, 4, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-4, 5, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-5, 3, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-5, 4, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-5, 5, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-5, 2, 3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-5, 1, 4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-4, -1, 5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-5, 0, 5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, -4, 5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, -5, 3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [3, -5, 2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [4, -5, 1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [5, -5, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [1, -5, 4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, -5, 5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-3, -2, 5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-2, -3, 5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, 3, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-3, 3, 0]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-2, 5, -3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [-1, 5, -4]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [0, 5, -5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [1, 4, -5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [3, 0, -3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [3, -1, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [3, 2, -5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [4, -1, -3]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [5, -3, -2]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [5, -4, -1]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [5, 0, -5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  location: [2, 3, -5]
+  biome: DISCOVERED
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [5, 2, -7]
+
+---
+kind: Building
+spec:
+  name: Data Dump East
+  location: [5, 2, -7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-4, -3, 7]
+
+---
+kind: Building
+spec:
+  name: Data Dump West
+  location: [-4, -3, 7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-8, 10, -2]
+
+---
+kind: Building
+spec:
+  name: Data Dump North
+  location: [-8, 10, -2]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, 6, -1]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, 6, 0]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, 7, -1]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, 7, -2]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, 8, -3]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, 8, -2]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-7, 8, -1]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-7, 7, 0]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-8, 8, 0]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-9, 9, 0]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-9, 10, -1]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-9, 11, -2]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-8, 11, -3]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-7, 11, -4]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-7, 10, -3]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, 9, -3]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, 10, -4]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-7, 9, -2]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-8, 9, -1]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [3, 3, -6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [3, 4, -7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [4, 4, -8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [5, 4, -9]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [6, 3, -9]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [7, 2, -9]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [7, 1, -8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [6, 1, -7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [6, 0, -6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [5, 1, -6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [4, 2, -6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [4, 3, -7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [5, 3, -8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [6, 2, -8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-4, -2, 6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-3, -3, 6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-3, -4, 7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-4, -4, 8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, -4, 9]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, -3, 8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, -2, 8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, -2, 7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, -1, 6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-2, -4, 6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-1, -5, 6]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-2, -5, 7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-2, -6, 8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-3, -6, 9]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-3, -5, 8]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-4, -5, 9]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, -5, 10]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, -3, 9]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, -4, 10]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [7, 0, -7]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-4, 6, -2]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-3, 6, -3]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-4, 7, -3]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-4, 8, -4]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, 9, -4]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-5, 10, -5]
+
+---
+kind: Tile
+spec:
+  biome: DISCOVERED
+  location: [-6, 11, -5]

--- a/contracts/src/maps/tonk/postinstall.js
+++ b/contracts/src/maps/tonk/postinstall.js
@@ -1,0 +1,95 @@
+const TONK_URL_HTTP = process.env.TONK_URL_HTTP;
+if (!TONK_URL_HTTP) {
+    throw new Error("TONK_URL_HTTP env var not set");
+}
+
+async function register_building(id, readable_id, is_tower, message, location) {
+    var myHeaders = new Headers();
+    myHeaders.append("Content-Type", "application/json");
+
+    var raw = JSON.stringify({
+        id: id,
+        is_tower: is_tower,
+        task_message: message,
+        readable_id: readable_id,
+        location,
+    });
+
+    var requestOptions = {
+        method: "POST",
+        headers: myHeaders,
+        body: raw,
+        redirect: "follow",
+    };
+
+    return fetch(`${TONK_URL_HTTP}/building`, requestOptions)
+        .then((response) => response.text())
+        .then((result) => console.log(result))
+        .catch((error) => console.log("error", error));
+}
+
+const HEX_DUMP_MESSAGE = "Download garbage data";
+const MEME_GEN_MESSAGE = "Download steamed hams";
+const SELFIE_POINT_MESSAGE = "Download vacation selfies";
+
+// async function register_all() {
+//     await register_building("0x34cf8a7e000000000000000000000000000000010000ffff", "COMPUTE CENTER", true, "", [
+//          '0x0', '0x0', '0x01', '0xffff'
+//     ])
+//     await register_building("0x34cf8a7e000000000000000000000000000000010000ffff", "DATA DUMP NORTH", false, HEX_DUMP_MESSAGE, [
+//         '0x0', '0xfff9', '0x0a', '0xfffd'
+//     ])
+//     await register_building("0x34cf8a7e000000000000000000000000000000050002fff9", "DATA DUMP EAST", false, MEME_GEN_MESSAGE, [
+//         '0x0', '0x09', '0x02', '0xfff5'
+//     ])
+//     await register_building("0x34cf8a7e0000000000000000000000000000fffcfffd0007", "DATA DUMP WEST", false, SELFIE_POINT_MESSAGE, [
+//         '0x0', '0xfff4', '0x03', '0x09'
+//     ])
+// }
+// async function register_all() {
+//     await register_building("0x34cf8a7e000000000000000000000000000000010000ffff",true, "", [
+//         '0x0', '0x01', '0x0', '0xffff'
+//     ])
+//     await register_building("0x34cf8a7e0000000000000000000000000000fff9000afffd",false, HEX_DUMP_MESSAGE, [
+//         '0x0', '0xfff9', '0x0a', '0xfffd'
+//     ])
+//     await register_building("0x34cf8a7e000000000000000000000000000000050002fff9",false, LOGGERS_MESSAGE, [
+//         '0x0', '0x05', '0x02', '0xfff9'
+//     ])
+//     await register_building("0x34cf8a7e0000000000000000000000000000fff400030009",false, BREAKPOINT_MESSAGE, [
+//         '0x0', '0xfff4', '0x03', '0x09'
+//     ])
+// }
+
+async function register_all() {
+    await register_building(
+        "0x34cf8a7e000000000000000000000000000000010000ffff",
+        "COMPUTE CENTER",
+        true,
+        "",
+        ["0x0", "0x01", "0x0", "0xffff"],
+    );
+    await register_building(
+        "0x34cf8a7e0000000000000000000000000000fff8000afffe",
+        "DATA DUMP NORTH",
+        false,
+        HEX_DUMP_MESSAGE,
+        [ "0x0", "0xfff8", "0x0a", "0xfffe" ],
+    );
+    await register_building(
+        "0x34cf8a7e000000000000000000000000000000050002fff9",
+        "DATA DUMP EAST",
+        false,
+        MEME_GEN_MESSAGE,
+        ["0x0", "0x05", "0x02", "0xfff9"],
+    );
+    await register_building(
+        "0x34cf8a7e0000000000000000000000000000fffcfffd0007",
+        "DATA DUMP WEST",
+        false,
+        SELFIE_POINT_MESSAGE,
+        ["0x0", "0xfffc", "0xfffd", "0x07"],
+    );
+}
+
+register_all();

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -138,6 +138,7 @@ export function makePluginUI(
                 return Promise.all(
                     plugins
                         .map(async (p): Promise<PluginUpdateResponse | null> => {
+                            let plugin: ActivePlugin | null | undefined;
                             try {
                                 const { player } = state;
                                 const dispatch = player ? player.dispatch : noopDispatcher;
@@ -145,7 +146,7 @@ export function makePluginUI(
                                     console.warn(`plugin has no id, skipping`);
                                     return null;
                                 }
-                                const plugin = active.has(p.id)
+                                plugin = active.has(p.id)
                                     ? active.get(p.id)
                                     : state.world.buildings.some((building) => building?.kind?.id === p.kindID) ||
                                       state.world.items.some((item) => item?.id === p.kindID)
@@ -177,7 +178,9 @@ export function makePluginUI(
                                 }
                                 console.error(`Removing plugin ${p.id} from 'active' due to error`, err);
                                 active.delete(p.id);
-                                sandbox.deleteContext(p.id);
+                                if (plugin) {
+                                    await sandbox.deleteContext(plugin.context);
+                                }
                                 return null;
                             }
                         })

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -25,15 +25,15 @@ export interface EthereumProvider extends Eip1193Provider {
 export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>;
 
 export interface Sandbox {
-    init: () => Promise<void>;
+    init: (cfg: Partial<GameConfig>) => Promise<void>;
     newContext: (
         dispatch: PluginDispatchFunc,
         logMessage: Logger,
         questMessage: Logger,
         config: PluginConfig,
     ) => Promise<number>;
-    deleteContext;
-    hasContext;
+    deleteContext: (id: number) => Promise<void>;
+    hasContext: (id: number) => Promise<boolean>;
     evalCode: (context: number, code: string) => Promise<any>;
     setState: (state: GameStatePlugin, blk: number) => Promise<void>;
 }
@@ -82,6 +82,7 @@ export interface GameConfig {
     wsSocketImpl?: unknown;
     httpEndpoint: string;
     httpFetchImpl?: typeof fetch;
+    tonkEndpoint?: string;
 }
 
 export type ActionName = Parameters<ActionsInterface['getFunction']>[0];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3'
+version: "3"
 
 services:
-
   contracts:
     # build:
     #   context: .
@@ -11,9 +10,12 @@ services:
       - 8545:8545
     environment:
       DEPLOYER_PRIVATE_KEY: "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8"
+      TONK_URL_HTTP: "http://tonk-web-server:8082"
       SERVICES_URL_HTTP: "http://cog:8080/query"
       SERVICES_URL_WS: "ws://cog:8080/query"
       MAP: "${MAP}"
+    volumes:
+      - ./contracts/src/maps:/contracts/src/maps
 
   frontend:
     # build:
@@ -29,14 +31,14 @@ services:
     image: ghcr.io/playmint/ds-services:hexwood0
     restart: always
     entrypoint:
-    - /bin/ash
-    - -eu
-    - -c
-    - |
-      echo "waiting contracts"
-      /wait-for -it contracts:8545 -t 300
-      echo "starting"
-      exec /ds-node
+      - /bin/ash
+      - -eu
+      - -c
+      - |
+        echo "waiting contracts"
+        /wait-for -it contracts:8545 -t 300
+        echo "starting"
+        exec /ds-node
     environment:
       CHAIN_ID: "1337"
       SEQUENCER_PRIVATE_KEY: "095a37ef5b5d87db7fe50551725cb64804c8c554868d3d729c0dd17f0e664c87"
@@ -50,4 +52,33 @@ services:
     depends_on:
       - contracts
 
+  redis:
+    profiles: [tonk]
+    image: redis:latest
+    ports:
+      - "6379:6379"
 
+  tonk-state-service:
+    profiles: [tonk]
+    image: playmint/tonk-state-service:latest
+    depends_on:
+      - redis
+      - cog
+    environment:
+      TONK_SERVICES_STAGE: PRODUCTION
+      REDIS_URL: "redis://redis:6379"
+      RUST_LOG: "info"
+      DS_ENDPOINT: "http://cog:8080/query"
+
+  tonk-web-server:
+    profiles: [tonk]
+    image: playmint/tonk-web-server:latest
+    ports:
+      - "8082:8082"
+    depends_on:
+      - redis
+    environment:
+      TONK_SERVICES_STAGE: PRODUCTION
+      REDIS_URL: "redis://redis:6379"
+      RUST_LOG: "info"
+      ALLOWED_ORIGIN: "http://localhost:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ version: "3"
 
 services:
   contracts:
-    # build:
-    #   context: .
-    #   dockerfile: ./contracts/Dockerfile
+    build:
+      context: .
+      dockerfile: ./contracts/Dockerfile
     image: ghcr.io/playmint/ds-contracts:hexwood0
     ports:
       - 8545:8545
@@ -18,16 +18,16 @@ services:
       - ./contracts/src/maps:/contracts/src/maps
 
   frontend:
-    # build:
-    #   context: .
-    #   dockerfile: ./frontend/Dockerfile
+    build:
+      context: .
+      dockerfile: ./frontend/Dockerfile
     image: ghcr.io/playmint/ds-shell:hexwood0
     ports:
       - 3000:80
 
   cog:
-    # build:
-    #   context: ./contracts/lib/cog/services
+    build:
+      context: ./contracts/lib/cog/services
     image: ghcr.io/playmint/ds-services:hexwood0
     restart: always
     entrypoint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
 
   redis:
     profiles: [tonk]
-    image: redis:latest
+    image: redis:7.2.4-alpine
     ports:
       - "6379:6379"
 

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -3,6 +3,7 @@
     "build": "dev",
     "wsEndpoint": "ws://localhost:8080/query",
     "httpEndpoint": "http://localhost:8080/query",
+    "tonkEndpoint": "http://localhost:8082",
     "wallets": {
         "metamask": true,
         "walletconnect": true,

--- a/frontend/src/hooks/use-game-state.tsx
+++ b/frontend/src/hooks/use-game-state.tsx
@@ -159,11 +159,14 @@ export const GameStateProvider = ({ config, children }: DSContextProviderProps) 
         if (!block) {
             return;
         }
+        if (!config) {
+            return;
+        }
         console.log('restart count', sandboxDeaths);
         workerRef.current = new Worker(new URL('../workers/sandbox.ts', import.meta.url));
         const workerSandbox: Comlink.Remote<Sandbox> = Comlink.wrap(workerRef.current);
         workerSandbox
-            .init()
+            .init(config)
             .then(() => {
                 console.log('new sandbox started');
                 const { logger: questMsgSender, logs: questMsgs } = makeLogger({ name: 'questMessages' });
@@ -187,7 +190,7 @@ export const GameStateProvider = ({ config, children }: DSContextProviderProps) 
                 });
             })
             .catch(() => console.error(`sandbox init fail`));
-    }, [sandboxDeaths, sources1]);
+    }, [sandboxDeaths, sources1, config]);
 
     const { selectProvider } = sources1 || {};
 


### PR DESCRIPTION
### What

* Adds a basic tonk map to contracts/src/maps
* Updates the docker compose config to allow spinning up the game + tonk-services for testing
* Adds a new `ds.config` property available to plugins that exposes [the game's config](https://github.com/playmint/ds/blob/tonk-local/frontend/public/config.json) to allow tonk plugins to discover correct endpoint `ds.config.tonkEndpoint`
* detect if there is a `postinstall.js` file in the map folder, and execute it during deploy ... which is then used to register tonk buildings
* warn if you try to do `MAP=tonk make dev` since you would need the services built manually yourself
* mounts the maps dir into the docker compose container ... so you can alter maps without needing to rebuild the image

### Why

This is all the bits we need to be able to dynamically setup a tonk-attack game ...  ~~in a followup PR we will update the Chart to make use of all of these bits to include tonk-services during deployment~~ (chart manifests now included in this PR)

### Testing notes

Since this PR modifies the frontend + contracts containers, you will need to pass `--build` to test ... for example:

```
MAP=tonk docker compose --profile=tonk up --build
```
