### PR TITLE
Unit Team Colours in Hexcraft

### DIFF
--- a/contracts/src/maps/hexcraft/game/js/Headquarter.js
+++ b/contracts/src/maps/hexcraft/game/js/Headquarter.js
@@ -374,9 +374,20 @@ function getTileCoords(coords) {
     ];
 }
 
+function distance(tileCoords, nextTile) {
+  return Math.max(
+      Math.abs(tileCoords[0] - nextTile[0]),
+      Math.abs(tileCoords[1] - nextTile[1]),
+      Math.abs(tileCoords[2] - nextTile[2]),
+  );
+}
+
 function inHexcraftArea(unitCoords, hqCoords){
     const inRange = unitCoords[1] >= hqCoords[1] && unitCoords[1] <= hqCoords[1] + 18;
-    return inRange;
+    const hexcraftMiddleCoords = [hqCoords[0], hqCoords[1] + 9, hqCoords[2]];
+    const d = distance(hexcraftMiddleCoords, unitCoords);
+    const inDistance = d <= 20;
+    return inRange && inDistance;
 }
 
 // search through all the bags in the world to find those belonging to this eqipee

--- a/contracts/src/maps/hexcraft/game/js/Headquarter.js
+++ b/contracts/src/maps/hexcraft/game/js/Headquarter.js
@@ -119,7 +119,7 @@ export default async function update(state) {
   for (let i = 0; i < blueTeamLength; i++){
     const unitId = getHQTeamUnit(selectedBuilding, "blue", i);
     const unitCoords = state.world?.mobileUnits?.find(unit => unit.id === unitId).nextLocation?.tile?.coords;
-    if (!inHexcraftArea(unitCoords, hqCoords)){
+    if (!inHexcraftArea(getTileCoords(unitCoords), getTileCoords(hqCoords))){
         continue;
     }
     unitMapObj.push(
@@ -375,13 +375,8 @@ function getTileCoords(coords) {
 }
 
 function inHexcraftArea(unitCoords, hqCoords){
-    const qDiff = unitCoords[1] - hqCoords[1];
-    const rDiff = unitCoords[2] - hqCoords[2];
-
-    const inWidth = Math.abs(qDiff) <= 12 / 2;
-    const inHeight = rDiff >= 0 && rDiff <= 18;
-
-    return inWidth && inHeight;
+    const inRange = unitCoords[1] >= hqCoords[1] && unitCoords[1] <= hqCoords[1] + 18;
+    return inRange;
 }
 
 // search through all the bags in the world to find those belonging to this eqipee

--- a/contracts/src/maps/hexcraft/game/js/Headquarter.js
+++ b/contracts/src/maps/hexcraft/game/js/Headquarter.js
@@ -98,6 +98,40 @@ export default async function update(state) {
   // - Running : GameActive == true && endBlock < currentBlock
   // - GameOver : GameActive == true && endBlock >= currentBlock
 
+  // unit team colors
+  const unitMapObj = [];
+  const hqCoords = selectedBuilding.location?.tile?.coords;
+  for (let i = 0; i < redTeamLength; i++){
+    const unitId = getHQTeamUnit(selectedBuilding, "red", i);
+    const unitCoords = state.world?.mobileUnits?.find(unit => unit.id === unitId).nextLocation?.tile?.coords;
+    if (!inHexcraftArea(getTileCoords(unitCoords), getTileCoords(hqCoords))){
+        continue;
+    }
+    unitMapObj.push(
+        {
+            type: "unit",
+            key: "color",
+            id: unitId,
+            value: "#ec5c61",
+        }
+    )
+  }
+  for (let i = 0; i < blueTeamLength; i++){
+    const unitId = getHQTeamUnit(selectedBuilding, "blue", i);
+    const unitCoords = state.world?.mobileUnits?.find(unit => unit.id === unitId).nextLocation?.tile?.coords;
+    if (!inHexcraftArea(unitCoords, hqCoords)){
+        continue;
+    }
+    unitMapObj.push(
+        {
+            type: "unit",
+            key: "color",
+            id: unitId,
+            value: "#2daee0",
+        }
+    )
+  }
+
   // we build a list of button objects that are rendered in the building UI panel when selected
   let buttonList = [];
 
@@ -216,7 +250,7 @@ export default async function update(state) {
   // console.log({ htmlBlock });
   return {
     version: 1,
-    map: [],
+    map: unitMapObj,
     components: [
       {
         id: "headquarter",
@@ -313,6 +347,41 @@ function checkBlueBaseAmount(state) {
 
 function getMobileUnit(state) {
   return state?.selected?.mobileUnit;
+}
+
+function hexToSignedDecimal(hex) {
+    if (hex.startsWith("0x")) {
+        hex = hex.substr(2);
+    }
+
+    let num = parseInt(hex, 16);
+    let bits = hex.length * 4;
+    let maxVal = Math.pow(2, bits);
+
+    // Check if the highest bit is set (negative number)
+    if (num >= maxVal / 2) {
+        num -= maxVal;
+    }
+
+    return num;
+}
+
+function getTileCoords(coords) {
+    return [
+        hexToSignedDecimal(coords[1]),
+        hexToSignedDecimal(coords[2]),
+        hexToSignedDecimal(coords[3]),
+    ];
+}
+
+function inHexcraftArea(unitCoords, hqCoords){
+    const qDiff = unitCoords[1] - hqCoords[1];
+    const rDiff = unitCoords[2] - hqCoords[2];
+
+    const inWidth = Math.abs(qDiff) <= 12 / 2;
+    const inHeight = rDiff >= 0 && rDiff <= 18;
+
+    return inWidth && inHeight;
 }
 
 // search through all the bags in the world to find those belonging to this eqipee


### PR DESCRIPTION
## What
Unit models are now assigned colours that correspond to what team they're on (red or blue).
![image](https://github.com/playmint/ds/assets/27741109/0fd069cd-9ab9-405a-af32-1a10fd9dc772)

## Why
When playtesting Hexcraft, we found that not being able to see what team other players were on added a lot of confusion.

## How
It loops through the members of each team and assigns the colour:
```js
  const unitMapObj = [];
  const hqCoords = selectedBuilding.location?.tile?.coords;
  for (let i = 0; i < redTeamLength; i++){
    const unitId = getHQTeamUnit(selectedBuilding, "red", i);
    const unitCoords = state.world?.mobileUnits?.find(unit => unit.id === unitId).nextLocation?.tile?.coords;
    if (!inHexcraftArea(getTileCoords(unitCoords), getTileCoords(hqCoords))){
        continue;
    }
    unitMapObj.push(
        {
            type: "unit",
            key: "color",
            id: unitId,
            value: "#ec5c61",
        }
    )
  }
```

## Info
I've tried to ensure that only units within the Hexcraft game area are changed. In our system, I can accurately verify whether a unit is within the vertical range of the map, but I haven't found a consistent method for the horizontal axis. currently, I'm checking the distance from the center of the Hexcraft play area to ensure the unit isn't beyond the map's furthest point. However, the limitation of this is that if a new map is introduced where Hexcraft is near another game (horizontally), a unit might be incorrectly identified as being within the Hexcraft arena when it's not.

Resolves #1051 