### PR TITLE
cli version 0.0.19 publish

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playmint/ds-cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playmint/ds-cli",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/ethereum-provider": "^2.9.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playmint/ds-cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "cli client for interacting with downstream.game",
   "main": "index.js",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "cli": {
       "name": "@playmint/ds-cli",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "@downstream/core": "file:core",


### PR DESCRIPTION
# What

published v0.0.19 of `ds-cli`
This includes the change to `schema.sol` that encodes Item IDs the same way as the applier does as in the IDs are a hash of `item/[item name]` instead of a hash of the name and recipe