### PR TITLE
import / export items as ERC1155 tokens

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -42,7 +42,7 @@ async function handleStartup(){
     const commands = [
         {
             name: 'networks',
-            command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --block-time 2 --block-base-fee-per-gas 1 --transaction-block-keeper 25 --prune-history",
+            command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --block-time 2 --block-base-fee-per-gas 1 --transaction-block-keeper 250",
             prefixColor: 'black',
         },
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "contracts/lib/abdk-libraries-solidity"]
 	path = contracts/lib/abdk-libraries-solidity
 	url = https://github.com/abdk-consulting/abdk-libraries-solidity
+[submodule "contracts/lib/solmate"]
+	path = contracts/lib/solmate
+	url = https://github.com/transmissions11/solmate

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -2,4 +2,5 @@
 cog/=lib/cog/contracts/src/
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
+solmate/=lib/solmate/src/
 abdk-libraries-solidity/=lib/abdk-libraries-solidity

--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -39,11 +39,13 @@ contract GameDeployer is Script {
 
         address[] memory allowlist = _loadAllowList(deployerAddr);
         DownstreamGame ds = new DownstreamGame();
+        InventoryRule inventoryRule = new InventoryRule(ds);
 
         string memory o = "key";
         vm.serializeAddress(o, "game", address(ds));
         vm.serializeAddress(o, "state", address(ds.getState()));
         vm.serializeAddress(o, "router", address(ds.getRouter()));
+        vm.serializeAddress(o, "tokens", address(inventoryRule.getTokensAddress()));
         string memory latestJson = vm.serializeAddress(o, "dispatcher", address(ds.getDispatcher()));
         vm.writeJson(latestJson, "./out/latest.json");
 
@@ -52,7 +54,7 @@ contract GameDeployer is Script {
         dispatcher.registerRule(new CheatsRule(deployerAddr));
         dispatcher.registerRule(new MovementRule(ds));
         dispatcher.registerRule(new ScoutRule());
-        dispatcher.registerRule(new InventoryRule());
+        dispatcher.registerRule(inventoryRule);
         dispatcher.registerRule(new BuildingRule(ds));
         dispatcher.registerRule(new CraftingRule(ds));
         dispatcher.registerRule(new PluginRule());

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -68,6 +68,7 @@ contract DownstreamGame is BaseGame {
         state.registerNodeType(Kind.Quest.selector, "Quest", CompoundKeyKind.UINT160);
         state.registerNodeType(Kind.Task.selector, "Task", CompoundKeyKind.UINT32_ARRAY);
         state.registerNodeType(Kind.ID.selector, "ID", CompoundKeyKind.BYTES);
+        state.registerNodeType(Kind.OwnedToken.selector, "OwnedToken", CompoundKeyKind.BYTES);
 
         // register the relationship ids we are using
         state.registerEdgeType(Rel.Owner.selector, "Owner", WeightKind.UINT64);

--- a/contracts/src/Items1155.sol
+++ b/contracts/src/Items1155.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "forge-std/console2.sol";
 import "cog/IState.sol";
 import {Schema, Node, Kind, GOO_GREEN, GOO_BLUE, GOO_RED} from "@ds/schema/Schema.sol";
 import "@ds/utils/Base64.sol";
@@ -97,7 +96,6 @@ contract Items1155 is ERC1155 {
         bytes calldata data
     ) public virtual override {
         super.safeBatchTransferFrom(from, to, ids, amounts, data);
-        console2.log("------safeBatchTransferFrom");
 
         for (uint256 i = 0; i < ids.length; i++) {
             _updateOwnedToken(from, to, ids[i], amounts[i]);
@@ -106,11 +104,6 @@ contract Items1155 is ERC1155 {
 
     function _updateOwnedToken(address from, address to, uint256 tokenId, uint256 amount) public virtual {
         bytes24 itemId = bytes24(uint192(tokenId));
-
-        console2.log("to", to);
-        console2.log("tokenId", tokenId);
-        console2.log("addr", address(this));
-        console2.log("amount", amount);
 
         // decement from
         if (from != address(0)) {

--- a/contracts/src/Items1155.sol
+++ b/contracts/src/Items1155.sol
@@ -105,7 +105,7 @@ contract Items1155 is ERC1155 {
     function _updateOwnedToken(address from, address to, uint256 tokenId, uint256 amount) public virtual {
         bytes24 itemId = bytes24(uint192(tokenId));
 
-        // decement from
+        // decrement from
         if (from != address(0)) {
             bytes24 ownedTokenId = Node.OwnedToken(tokenId, Node.Player(from));
             (bytes24 existingItem, uint64 existingBalance) = state.getItemSlot(ownedTokenId, 0);

--- a/contracts/src/Items1155.sol
+++ b/contracts/src/Items1155.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/console2.sol";
+import "cog/IState.sol";
+import {Schema, Node, Kind, GOO_GREEN, GOO_BLUE, GOO_RED} from "@ds/schema/Schema.sol";
+import "@ds/utils/Base64.sol";
+import "@ds/utils/LibString.sol";
+
+import {ERC1155} from "solmate/tokens/ERC1155.sol";
+
+using Schema for State;
+
+contract Items1155 is ERC1155 {
+    address owner; // The InventoryRule owns this
+    State state;
+
+    constructor(address _owner, State _state) {
+        owner = _owner;
+        state = _state;
+    }
+
+    // ERC-1046 compat
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        return getDataURI(tokenId);
+    }
+
+    function uri(uint256 tokenId) public view override returns (string memory) {
+        return getDataURI(tokenId);
+    }
+
+    function getDataURI(uint256 tokenId) internal view returns (string memory) {
+        bytes24 itemId = bytes24(uint192(tokenId));
+
+        bytes memory dataURI = abi.encodePacked(
+            "{",
+            '"name": "',
+            state.getDataString(itemId, "name"),
+            '",',
+            '"description": "Downstream Item",',
+            '"image": "https://assets.downstream.game/icons/',
+            state.getDataString(itemId, "icon"),
+            '.svg",',
+            '"attributes": ',
+            getDataAttributes(itemId),
+            "}"
+        );
+        return string(abi.encodePacked("data:application/json;base64,", Base64.encode(dataURI)));
+    }
+
+    function getDataAttributes(bytes24 itemId) internal view returns (bytes memory) {
+        (uint32[3] memory goo, bool isStackable) = state.getItemStructure(itemId);
+        return abi.encodePacked(
+            "[",
+            '{"trait_type": "Red", "value": ',
+            LibString.toString(goo[GOO_RED]),
+            "},",
+            '{"trait_type": "Green", "value": ',
+            LibString.toString(goo[GOO_GREEN]),
+            "},",
+            '{"trait_type": "Blue", "value": ',
+            LibString.toString(goo[GOO_BLUE]),
+            "},",
+            '{"trait_type": "Equipable", "value": "',
+            (isStackable ? "false" : "true"),
+            '"}',
+            "]"
+        );
+    }
+
+    function mint(address to, uint256 tokenId, uint256 amount, bytes memory data) public {
+        require(msg.sender == owner, "only the game can mint");
+        _mint(to, tokenId, amount, data);
+        _updateOwnedToken(address(0), to, tokenId, amount);
+    }
+
+    function burn(address from, uint256 tokenId, uint256 amount) public {
+        require(msg.sender == owner, "only the game can burn");
+        _burn(from, tokenId, amount);
+        _updateOwnedToken(from, address(0), tokenId, amount);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes calldata data)
+        public
+        virtual
+        override
+    {
+        super.safeTransferFrom(from, to, id, amount, data);
+        _updateOwnedToken(from, to, id, amount);
+    }
+
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) public virtual override {
+        super.safeBatchTransferFrom(from, to, ids, amounts, data);
+        console2.log("------safeBatchTransferFrom");
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            _updateOwnedToken(from, to, ids[i], amounts[i]);
+        }
+    }
+
+    function _updateOwnedToken(address from, address to, uint256 tokenId, uint256 amount) public virtual {
+        bytes24 itemId = bytes24(uint192(tokenId));
+
+        console2.log("to", to);
+        console2.log("tokenId", tokenId);
+        console2.log("addr", address(this));
+        console2.log("amount", amount);
+
+        // decement from
+        if (from != address(0)) {
+            bytes24 ownedTokenId = Node.OwnedToken(tokenId, Node.Player(from));
+            (bytes24 existingItem, uint64 existingBalance) = state.getItemSlot(ownedTokenId, 0);
+            require(existingItem == 0x0 || existingItem == itemId, "invalid from ownedtoken item");
+            uint64 newBalance = 0;
+            if (existingBalance > uint64(amount)) {
+                newBalance = existingBalance - uint64(amount);
+            }
+            state.setItemSlot(ownedTokenId, 0, itemId, newBalance);
+            state.setOwner(ownedTokenId, Node.Player(from));
+            // TODO: if newBalance is zero ... remove the owner edge so it doesn't show up in queries
+        }
+
+        // increment to
+        if (to != address(0)) {
+            bytes24 ownedTokenId = Node.OwnedToken(tokenId, Node.Player(to));
+            (bytes24 existingItem, uint64 existingBalance) = state.getItemSlot(ownedTokenId, 0);
+            require(existingItem == 0x0 || existingItem == itemId, "invalid to ownedtoken item");
+            state.setItemSlot(ownedTokenId, 0, itemId, existingBalance + uint64(amount));
+            state.setOwner(ownedTokenId, Node.Player(to));
+        }
+    }
+}

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -52,6 +52,11 @@ interface Actions {
         uint64 qty
     ) external;
 
+    function EXPORT_ITEM(bytes24 fromEquipee, uint8 fromEquipSlot, uint8 fromItemSlot, address toAddress, uint64 qty)
+        external;
+
+    function IMPORT_ITEM(bytes24 itemId, bytes24 toEquipee, uint8 toEquipSlot, uint8 toItemSlot, uint64 qty) external;
+
     // register an external contract as possible building
     function REGISTER_BUILDING_KIND(
         bytes24 buildingKind,

--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -26,9 +26,6 @@ import {
     LIFE_MUL
 } from "@ds/schema/Schema.sol";
 import {TileUtils} from "@ds/utils/TileUtils.sol";
-import "forge-std/console.sol";
-import "@ds/utils/Base64.sol";
-import "@ds/utils/LibString.sol";
 import {ItemUtils} from "@ds/utils/ItemUtils.sol";
 
 using Schema for State;

--- a/contracts/src/rules/CraftingRule.sol
+++ b/contracts/src/rules/CraftingRule.sol
@@ -54,6 +54,12 @@ contract CraftingRule is Rule {
         }
         state.setID(itemKind, idNode);
 
+        state.setData(itemKind, "name", bytes32(bytes(name)));
+        state.setData(itemKind, "icon", bytes32(bytes(icon)));
+
+        // FIXME: remove these annotations
+        //        we don't need these annotations as we have the setData ones above
+        //        but we currently depend on the annotation in various graphql places
         state.annotate(itemKind, "name", name);
         state.annotate(itemKind, "icon", icon);
     }

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -44,6 +44,7 @@ interface Kind {
     function Quest() external;
     function Task() external;
     function ID() external;
+    function OwnedToken() external;
 }
 
 uint64 constant BLOCK_TIME_SECS = 2;
@@ -121,6 +122,11 @@ library Node {
         return bytes24(
             abi.encodePacked(Kind.Item.selector, uniqueID, stackable, atoms[GOO_GREEN], atoms[GOO_BLUE], atoms[GOO_RED])
         );
+    }
+
+    function OwnedToken(uint256 tokenId, bytes24 playerId) internal pure returns (bytes24) {
+        return
+            CompoundKeyEncoder.BYTES(Kind.OwnedToken.selector, bytes20(keccak256(abi.encodePacked(tokenId, playerId))));
     }
 
     function Player(address addr) internal pure returns (bytes24) {
@@ -524,6 +530,19 @@ library Schema {
 
     function getDataUint256(State state, bytes24 nodeID, string memory key) external view returns (uint256) {
         return uint256(state.getData(nodeID, key));
+    }
+
+    function getDataString(State state, bytes24 nodeID, string memory key) external view returns (string memory) {
+        bytes32 b = state.getData(nodeID, key);
+        uint8 i = 0;
+        while (i < 32 && b[i] != 0) {
+            i++;
+        }
+        bytes memory nonNullBytes = new bytes(i);
+        for (i = 0; i < 32 && b[i] != 0; i++) {
+            nonNullBytes[i] = b[i];
+        }
+        return string(nonNullBytes);
     }
 
     function getAttacker(State state, bytes24 sessionID, uint8 index) external view returns (bytes24) {

--- a/contracts/test/helpers/GameTest.sol
+++ b/contracts/test/helpers/GameTest.sol
@@ -110,7 +110,7 @@ abstract contract GameTest {
         dispatcher.registerRule(new CheatsRule(address(dev)));
         dispatcher.registerRule(new MovementRule(game));
         dispatcher.registerRule(new ScoutRule());
-        dispatcher.registerRule(new InventoryRule());
+        dispatcher.registerRule(new InventoryRule(game));
         dispatcher.registerRule(new BuildingRule(game));
         dispatcher.registerRule(new CraftingRule(game));
         dispatcher.registerRule(new PluginRule());

--- a/contracts/test/helpers/GameTest.sol
+++ b/contracts/test/helpers/GameTest.sol
@@ -12,6 +12,7 @@ import {DownstreamGame, PREFIX_MESSAGE} from "@ds/Downstream.sol";
 import {Actions, BiomeKind} from "@ds/actions/Actions.sol";
 import "@ds/schema/Schema.sol";
 import "@ds/utils/ItemUtils.sol";
+import {Items1155} from "@ds/Items1155.sol";
 
 import {CheatsRule} from "@ds/rules/CheatsRule.sol";
 import {MovementRule} from "@ds/rules/MovementRule.sol";
@@ -83,6 +84,7 @@ abstract contract GameTest {
     State internal state;
     Dev internal dev;
     Vm internal __vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    Items1155 tokens;
 
     // player accounts to test with
     PlayerAccount[4] players;
@@ -90,6 +92,7 @@ abstract contract GameTest {
     constructor() {
         // setup the dev contract for calling cheats
         dev = new Dev();
+        game = new DownstreamGame();
 
         // init players
         players[0] = PlayerAccount({key: 0xa1, addr: __vm.addr(0xa1)});
@@ -104,13 +107,16 @@ abstract contract GameTest {
         allowlist[2] = players[2].addr;
         allowlist[3] = players[3].addr;
 
+        // items
+        InventoryRule inventoryRule = new InventoryRule(game);
+        tokens = Items1155(inventoryRule.getTokensAddress());
+
         // setup game
-        game = new DownstreamGame();
         dispatcher = BaseDispatcher(address(game.getDispatcher()));
         dispatcher.registerRule(new CheatsRule(address(dev)));
         dispatcher.registerRule(new MovementRule(game));
         dispatcher.registerRule(new ScoutRule());
-        dispatcher.registerRule(new InventoryRule(game));
+        dispatcher.registerRule(inventoryRule);
         dispatcher.registerRule(new BuildingRule(game));
         dispatcher.registerRule(new CraftingRule(game));
         dispatcher.registerRule(new PluginRule());

--- a/core/src/player.graphql
+++ b/core/src/player.graphql
@@ -8,6 +8,18 @@ fragment SelectedPlayer on Node {
             ...Quest
         }
     }
+
+    tokens: edges(match: { kinds: "OwnedToken", via: { rel: "Owner", dir: IN } }) {
+        token: node {
+            id
+            info: edge(match: { kinds: "Item", via: { rel: "Balance", dir: OUT } }) {
+                balance: weight
+                item: node {
+                    ...Item
+                }
+            }
+        }
+    }
 }
 
 query GetSelectedPlayer($gameID: ID!, $id: String!) {

--- a/core/src/player.ts
+++ b/core/src/player.ts
@@ -64,5 +64,6 @@ function toFakeSelectedPlayer(wallet: Wallet): SelectedPlayerFragment {
         id: wallet.id,
         addr: wallet.address,
         quests: [],
+        tokens: [],
     };
 }

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -104,6 +104,7 @@ export function makePluginUI(
                                       id: state.player.id,
                                       addr: state.player.addr,
                                       quests: state.player.quests,
+                                      tokens: state.player.tokens,
                                   }
                                 : undefined,
                             world: {

--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -52,10 +52,14 @@ export const NavPanel = ({
     toggleQuestsActive,
     questsActive,
     questsCount,
+    toggleWalletItemsActive,
+    walletItemsActive,
 }: {
     questsCount?: number;
     questsActive?: boolean;
     toggleQuestsActive?: () => void;
+    toggleWalletItemsActive?: () => void;
+    walletItemsActive?: boolean;
 }) => {
     const { connect, disconnect: forgetProvider, provider } = useWalletProvider();
     const { clearSession } = useSession();
@@ -240,6 +244,12 @@ export const NavPanel = ({
                 </svg>
                 {!player && <span className="text">CONNECT</span>}
             </AccountButton>
+
+            {toggleWalletItemsActive && (
+                <TextButton onClick={toggleWalletItemsActive} className={`${walletItemsActive ? 'toggleOn' : ''}`}>
+                    WALLET
+                </TextButton>
+            )}
 
             {typeof questsActive !== 'undefined' && questsCount && questsCount > 0 ? (
                 <TextButton onClick={toggleQuestsActive} className={`${questsActive ? 'toggleOn' : ''}`}>

--- a/frontend/src/components/panels/wallet-items-panel.tsx
+++ b/frontend/src/components/panels/wallet-items-panel.tsx
@@ -207,8 +207,8 @@ export const WalletItemsItem: FunctionComponent<{
     return (
         <StyledWalletItemsItem>
             <div className="header">
-                <h3>wallet items</h3>
-                <p>these things live in your wallet</p>
+                <h3>Wallet Storage</h3>
+                <p>Items stored with your player wallet</p>
             </div>
 
             <div className="taskContainer">

--- a/frontend/src/components/panels/wallet-items-panel.tsx
+++ b/frontend/src/components/panels/wallet-items-panel.tsx
@@ -1,0 +1,248 @@
+import { BagFragment, ConnectedPlayer } from '@app/../../core/src';
+import { useWalletProvider } from '@app/hooks/use-wallet-provider';
+import { Inventory } from '@app/plugins/inventory';
+import { BasePanelStyles } from '@app/styles/base-panel.styles';
+import { ActionButton } from '@app/styles/button.styles';
+import { colorMap, colors } from '@app/styles/colors';
+import { FunctionComponent, useCallback, useMemo } from 'react';
+import styled, { css } from 'styled-components';
+
+const StyledWalletItemsPanel = styled.div`
+    width: 43.5rem;
+    position: relative;
+    overflow-y: auto;
+    max-height: calc(100vh - 35rem);
+    pointer-events: all;
+`;
+
+const WalletItemsActionButton = styled(ActionButton)`
+    color: ${colors.green_0};
+    background: ${colors.grey_5};
+
+    &:hover {
+        background: ${colors.green_0};
+        color: ${colors.grey_5};
+        opacity: 1;
+    }
+
+    &:active {
+        background: ${colors.green_1};
+        color: ${colors.grey_5};
+    }
+`;
+
+const WalletItemsItemStyles = () => css`
+    position: relative;
+    padding: 0;
+    overflow: hidden;
+    margin-bottom: 0.5rem;
+
+    cursor: default;
+
+    h3 {
+        margin: 0;
+    }
+
+    .header {
+        background: ${colorMap.secondaryBackground};
+        padding: var(--panel-padding);
+
+        p {
+            font-size: 1.3rem;
+            color: ${colors.grey_3};
+        }
+    }
+
+    /* Progress bar */
+
+    .progress {
+        width: 100%;
+        display: flex;
+        flex-direction: row;
+        margin-top: 0.5rem;
+
+        .progressText {
+            margin-left: 1.5rem;
+            font-weight: 700;
+            font-size: 1.2rem;
+        }
+
+        .progressBar {
+            flex-grow: 1;
+        }
+    }
+
+    /* Tasks */
+
+    .taskContainer {
+        font-size: 1.4rem;
+        padding: var(--panel-padding) var(--panel-padding) 0 var(--panel-padding);
+    }
+
+    .buttonContainer {
+        margin: var(--panel-padding) 0;
+        display: flex;
+        justify-content: center;
+    }
+
+    .buttonContainer .completeWalletItemsButton {
+        width: 30rem;
+    }
+`;
+
+const StyledWalletItemsItem = styled.div`
+    ${BasePanelStyles}
+    ${WalletItemsItemStyles}
+`;
+
+export const WalletItemsItem: FunctionComponent<{
+    blockNumber: number;
+    player: ConnectedPlayer;
+}> = ({ player, blockNumber }) => {
+    const { provider } = useWalletProvider();
+    const tokens = useMemo(
+        () =>
+            blockNumber > 0
+                ? player.tokens.sort((a, b) => {
+                      return (a.token.info?.item.id || '') < (b.token.info?.item.id || '') ? -1 : 1;
+                  })
+                : [],
+        [player.tokens, blockNumber]
+    );
+
+    const psudoBags: BagFragment[] = useMemo(
+        () =>
+            tokens.reduce((bags, { token }, idx) => {
+                if (!token || !token.info || token.info.balance < 1) {
+                    return bags;
+                }
+                let bag: BagFragment;
+                if (bags.length === 0 || idx % 6 === 0) {
+                    bag = {
+                        id: `0xplayerwallet${idx}`,
+                        key: `0xplayerwallet${idx}`,
+                        slots: [],
+                        owner: {
+                            id: player.id,
+                        },
+                        equipee: {
+                            key: idx,
+                            node: {
+                                id: '0xplayer',
+                            },
+                        },
+                    };
+                    bags.push(bag);
+                } else {
+                    bag = bags[bags.length - 1];
+                }
+                bag.slots.push({
+                    key: bag.slots.length,
+                    balance: token.info.balance,
+                    item: token.info.item,
+                });
+                return bags;
+            }, [] as BagFragment[]),
+        [tokens, player.id]
+    );
+
+    // always keep an extra empty bag row so that there
+    // is always somewhere to drop stuff
+    const psudoBagsPlusOne = useMemo(
+        () => [
+            ...psudoBags,
+            {
+                id: `0xplayerwalletlast`,
+                key: `0xplayerwalletlast`,
+                slots: [],
+                owner: {
+                    id: player.id,
+                },
+                equipee: {
+                    key: 99999,
+                    node: {
+                        id: '0xplayer',
+                    },
+                },
+            },
+        ],
+        [psudoBags, player.id]
+    );
+
+    const addTokensMetamask = useCallback(() => {
+        if (!provider) {
+            return;
+        }
+        if (!player || player.tokens.length == 0) {
+            return;
+        }
+        const args = player.tokens.reduce((args, { token }) => {
+            if (!token.info) {
+                return args;
+            }
+            args.push({
+                method: 'wallet_watchAsset',
+                params: {
+                    type: 'ERC1155',
+                    options: {
+                        // FIXME: get this from config.json or graphql somehow
+                        address: '0x0a668c3342e68b5F9054403e2080fA77259e8DbA',
+                        tokenId: BigInt(token.info.item.id).toString(),
+                    },
+                },
+            });
+            return args;
+        }, [] as any[]);
+        console.debug('sending to metamask', args);
+        const p = provider.provider as any;
+        if (p.sendAsync) {
+            p.sendAsync(args);
+        } else if (p.sendCustomRequest) {
+            p.sendCustomRequest(args);
+        } else {
+            console.warn('provider does not support sendAsync or sendCustomRequest');
+        }
+    }, [player, provider]);
+
+    return (
+        <StyledWalletItemsItem>
+            <div className="header">
+                <h3>wallet items</h3>
+                <p>these things live in your wallet</p>
+            </div>
+
+            <div className="taskContainer">
+                <Inventory
+                    bags={psudoBagsPlusOne}
+                    ownerId={`WALLET${player.addr}`}
+                    isInteractable={true}
+                    numBagSlots={6}
+                />
+            </div>
+            <div className="buttonContainer">
+                {provider && provider.method === 'metamask' && (
+                    <WalletItemsActionButton onClick={addTokensMetamask} className="completeWalletItemsButton">
+                        Add Tokens To Metamask
+                    </WalletItemsActionButton>
+                )}
+            </div>
+        </StyledWalletItemsItem>
+    );
+};
+
+export interface WalletItemsPanelProps {
+    player: ConnectedPlayer;
+    blockNumber: number;
+}
+
+export const WalletItemsPanel: FunctionComponent<WalletItemsPanelProps> = ({
+    player,
+    blockNumber,
+}: // acceptedWalletItemss,
+WalletItemsPanelProps) => {
+    return (
+        <StyledWalletItemsPanel className="no-scrollbars">
+            <WalletItemsItem player={player} blockNumber={blockNumber} />
+        </StyledWalletItemsPanel>
+    );
+};

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -35,6 +35,7 @@ import { styles } from './shell.styles';
 import { QuestPanel } from '@app/components/panels/quest-panel';
 import { getBagsAtEquipee, getBuildingAtTile, getSessionsAtTile } from '@downstream/core/src/utils';
 import { StyledBasePanel, StyledHeaderPanel } from '@app/styles/base-panel.styles';
+import { WalletItemsPanel } from '@app/components/panels/wallet-items-panel';
 
 export interface ShellProps extends ComponentProps {}
 
@@ -68,6 +69,8 @@ export const Shell: FunctionComponent<ShellProps> = () => {
     const ui = usePluginState();
     const [questsActive, setQuestsActive] = useState<boolean>(true);
     const toggleQuestsActive = useCallback(() => setQuestsActive((prev) => !prev), []);
+    const [walletItemsActive, setWalletItemsActive] = useState<boolean>(false);
+    const toggleWalletItemsActive = useCallback(() => setWalletItemsActive((prev) => !prev), []);
     const questMessages = useQuestMessages(10);
     const acceptedQuests = useMemo(() => {
         return (
@@ -376,6 +379,8 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                             questsActive={player && world && questsActive && acceptedQuests.length > 0}
                             toggleQuestsActive={toggleQuestsActive}
                             questsCount={acceptedQuests.length}
+                            toggleWalletItemsActive={toggleWalletItemsActive}
+                            walletItemsActive={walletItemsActive}
                         />
                         {world && player && questsActive && acceptedQuests.length > 0 && (
                             <QuestPanel
@@ -386,7 +391,9 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                                 questMessages={questMessages}
                             />
                         )}
-                        {/* <Logs className="logs" /> */}
+                        {world && player && walletItemsActive && (
+                            <WalletItemsPanel player={player} blockNumber={blockNumber} />
+                        )}
                     </div>
                     <ItemPluginPanel ui={ui || []} />
                     <div className="bottom-left">

--- a/frontend/src/plugins/inventory/index.tsx
+++ b/frontend/src/plugins/inventory/index.tsx
@@ -1,16 +1,17 @@
 /** @format */
 
+import { Bag } from '@app/plugins/inventory/bag';
+import { ComponentProps } from '@app/types/component-props';
+import { BagFragment } from '@downstream/core';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { ComponentProps } from '@app/types/component-props';
-import { Bag } from '@app/plugins/inventory/bag';
-import { BagFragment } from '@downstream/core';
 
 export interface InventoryProps extends ComponentProps {
     ownerId: string;
     bags: BagFragment[];
     isInteractable: boolean;
     showIcon?: boolean;
+    numBagSlots?: number;
 }
 
 const StyledInventory = styled('div')`
@@ -22,7 +23,7 @@ const StyledInventory = styled('div')`
 `;
 
 export const Inventory: FunctionComponent<InventoryProps> = (props: InventoryProps) => {
-    const { bags, ownerId, isInteractable, showIcon } = props;
+    const { bags, ownerId, isInteractable, showIcon, numBagSlots } = props;
 
     return (
         <StyledInventory>
@@ -35,6 +36,7 @@ export const Inventory: FunctionComponent<InventoryProps> = (props: InventoryPro
                         ownerId={ownerId}
                         isInteractable={isInteractable}
                         showIcon={showIcon}
+                        numBagSlots={numBagSlots}
                     />
                 ))}
             </ul>


### PR DESCRIPTION
### what

* Allow players to import and export downstream items into an ERC1155 compatible form for use outside of the main game world
* Players get a kind of "global inventory" which they can move items into or out of, when items are in this inventory they behave as standard ERC1155 tokens, and can be transferred.


https://github.com/playmint/ds/assets/45921/856930fa-3e35-45fa-ab39-df08a2b6606f



### why

* we believe having a mechanism for exchanging tokens outside of the main game will give additional surface area for composability/interoperability

### how

There are two new game actions:

* `EXPORT_ITEM`  - transfer an item you have control over in game to an ethereum address
* `IMPORT_ITEM` - transfer an item you have in your player wallet into an in-game inventory

### testing with metamask

👀 **Please read!** ... metamask integration is flakey

You can test this out and play with the metamask bits, but you must:

* Set "display nft media" to `true` ... in metamask `settings -> security/privacy` 
* You must manually add the localhost network  and ensure you are using it (until #1062 is done)
* You must clear all the activity/nonce history each time you start `make dev`
* Metamask lags behind the network alot ... you will need to spam the "add token to metamask" button alot before it eventully works
* Any tokens you add may not update their state until you click on them... so they can get out of sync easily
* **this one is the best** ... there's a bug in the "send" feature, it will ask you to type in a balance to send ... it only lets you type in decimal, but behind the scenes it sends as hex ... so sending `10` will send `16` .... tbh they do say they don't actually support sending, so guess it's a work in progress ... but probably stick to sending small numbers to avoid confusion
* the way metamask queries the chain via old state means I had to disable anvil's prune-history 😱  .... this is BAD as prune-history is the thing that is keeping anvil's disk/memory usage low
* you will also need some ETH to do a transfer ... give yourself some eth with `cast send --private-key 0x8451fe83595a88521cac265c1356568ab84c2b5d81654f36ea309be28ded5a0d --value 5.0ether $YOUR_ADDRESS` (replacing the YOUR_ADDRESS bit)

### related

* resolves: #1056 
* resolves: #1067 

### todo

before merge...

* [x] resolve issue where pending state does update on transfer
* [x] what to do about prune-history
* [x] check wallet-inventory works alongside quests panel
* [x] tidy up the text in the wallet inventory panel
* [x] stop throwing in inventory failure


