### PR TITLE
Runtime memory limit to 256 MiB from 6.25 MiB

### DIFF
--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -65,7 +65,7 @@ export async function init(cfg: Partial<GameConfig>) {
     const qjs = await getQuickJS();
 
     runtime = qjs.newRuntime();
-    runtime.setMemoryLimit(1024 * 640 * 10);
+    runtime.setMemoryLimit(256 * 1024 * 1024);
     runtime.setMaxStackSize(1024 * 320);
 
     pollPendingJobs();


### PR DESCRIPTION
## What
Sandbox runtime memory limit increased from 6.25 MiB to 256 MiB.

## Why
During our playtest on the open croissant map, we all ran into "Out of memory" errors which were causing all plugins to fail. There is already logic to automatically restart the sandbox when we hit this error, but since 3 games have been combined into one map, the memory appears to be hitting its limit from the start which is stopping the restart logic from working.

## How
```js
runtime.setMemoryLimit(256 * 1024 * 1024);
```

## Further questions
- How much memory is too much memory?
- What happens when the set memory limit/used memory exceeds the memory of a user's computer?