### PR TITLE
per-deployment chain-ids + auto switch metamask to correct chain id

### DIFF
--- a/.devstartup.js
+++ b/.devstartup.js
@@ -42,7 +42,7 @@ async function handleStartup(){
     const commands = [
         {
             name: 'networks',
-            command: "anvil -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --block-time 2 --block-base-fee-per-gas 1 --transaction-block-keeper 250",
+            command: "anvil --chain-id 22300 -m 'thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens' --block-time 2 --block-base-fee-per-gas 1 --transaction-block-keeper 250",
             prefixColor: 'black',
         },
 

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -3,6 +3,9 @@ gameID: {{ $.Values.frontend.gameAddress | quote}}
 build: {{ $.Values.version | quote }}
 wsEndpoint: "wss://services-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}/query"
 httpEndpoint: "https://services-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}/query"
+networkEndpoint: "https://network-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
+networkName: "{{ $.Release.Namespace }}"
+networkID: "{{ $.Release.Namespace | mustRegexFind "[0-9]+$" | printf "223%02s" }}"
 tonkEndpoint: "https://tonk-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
 {{ end }}
 
@@ -33,7 +36,7 @@ spec:
             - name: PORT
               value: "8080"
             - name: CHAIN_ID
-              value: {{ $.Values.chainId | toString | quote }}
+              value: "{{ $.Release.Namespace | mustRegexFind "[0-9]+$" | printf "223%02s" }}"
             - name: SEQUENCER_PRIVATE_KEY
               value: {{ $.Values.sequencer.privateKey | quote }}
             - name: SEQUENCER_PROVIDER_URL_HTTP
@@ -82,6 +85,8 @@ spec:
           image: {{ printf "ghcr.io/playmint/ds-contracts:%s" $.Values.version }}
           imagePullPolicy: Always
           env:
+          - name: CHAIN_ID
+            value: "{{ $.Release.Namespace | mustRegexFind "[0-9]+$" | printf "223%02s" }}"
           - name: DEPLOYER_PRIVATE_KEY
             value: "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8"
           - name: SERVICES_URL_HTTP

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -87,6 +87,8 @@ spec:
           env:
           - name: CHAIN_ID
             value: "{{ $.Release.Namespace | mustRegexFind "[0-9]+$" | printf "223%02s" }}"
+          - name: EXTRA_ANVIL_ARGS
+            value: "--prune-history --transaction-block-keeper 25"
           - name: DEPLOYER_PRIVATE_KEY
             value: "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8"
           - name: SERVICES_URL_HTTP

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -20,17 +20,19 @@ rm -f deployments/*
 # must match the value for the target hardhat networks
 ACCOUNT_MNEMONIC="thunder road vendor cradle rigid subway isolate ridge feel illegal whale lens"
 
+# optional anvil args
+ANVIL_ARGS=${EXTRA_ANVIL_ARGS:-""}
+
 echo "+-------------------+"
 echo "| starting evm node |"
 echo "+-------------------+"
 anvil \
     --block-base-fee-per-gas 1 \
     --block-time 2 \
-    --transaction-block-keeper 25 \
-    --prune-history \
 	--host 0.0.0.0 \
     --chain-id "${CHAIN_ID}" \
 	-m "${ACCOUNT_MNEMONIC}" \
+    ${ANVIL_ARGS} \
 	&
 
 

--- a/contracts/entrypoint.sh
+++ b/contracts/entrypoint.sh
@@ -29,6 +29,7 @@ anvil \
     --transaction-block-keeper 25 \
     --prune-history \
 	--host 0.0.0.0 \
+    --chain-id "${CHAIN_ID}" \
 	-m "${ACCOUNT_MNEMONIC}" \
 	&
 

--- a/core/src/cog.ts
+++ b/core/src/cog.ts
@@ -58,6 +58,9 @@ const cogDefaultConfig = {
     actions: DOWNSTREAM_GAME_ACTIONS,
     wsEndpoint: 'ws://localhost:8080/query',
     httpEndpoint: 'http://localhost:8080/query',
+    networkEndpoint: 'http://localhost:8545',
+    networkID: '22300',
+    networkName: 'hexwoodlocal',
 } satisfies GameConfig;
 
 /**

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -83,6 +83,9 @@ export interface GameConfig {
     httpEndpoint: string;
     httpFetchImpl?: typeof fetch;
     tonkEndpoint?: string;
+    networkEndpoint: string;
+    networkID: string;
+    networkName: string;
 }
 
 export type ActionName = Parameters<ActionsInterface['getFunction']>[0];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - 8545:8545
     environment:
       CHAIN_ID: "22300"
+      EXTRA_ANVIL_ARGS: "--transaction-block-keeper 250"
       DEPLOYER_PRIVATE_KEY: "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8"
       TONK_URL_HTTP: "http://tonk-web-server:8082"
       SERVICES_URL_HTTP: "http://cog:8080/query"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - 8545:8545
     environment:
+      CHAIN_ID: "22300"
       DEPLOYER_PRIVATE_KEY: "0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8"
       TONK_URL_HTTP: "http://tonk-web-server:8082"
       SERVICES_URL_HTTP: "http://cog:8080/query"
@@ -40,7 +41,7 @@ services:
         echo "starting"
         exec /ds-node
     environment:
-      CHAIN_ID: "1337"
+      CHAIN_ID: "22300"
       SEQUENCER_PRIVATE_KEY: "095a37ef5b5d87db7fe50551725cb64804c8c554868d3d729c0dd17f0e664c87"
       SEQUENCER_PROVIDER_URL_HTTP: "http://contracts:8545"
       SEQUENCER_PROVIDER_URL_WS: "ws://contracts:8545"

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -4,6 +4,9 @@
     "wsEndpoint": "ws://localhost:8080/query",
     "httpEndpoint": "http://localhost:8080/query",
     "tonkEndpoint": "http://localhost:8082",
+    "networkEndpoint": "http://localhost:8545",
+    "networkID": "22300",
+    "networkName": "hexwoodlocal",
     "wallets": {
         "metamask": true,
         "walletconnect": true,

--- a/frontend/src/hooks/use-config.tsx
+++ b/frontend/src/hooks/use-config.tsx
@@ -11,6 +11,9 @@ export interface ConfigFile {
     build: string;
     wsEndpoint: string;
     httpEndpoint: string;
+    networkEndpoint: string;
+    networkID: string;
+    networkName: string;
     wallets?: WalletConfig;
 }
 

--- a/frontend/src/hooks/use-wallet-provider.tsx
+++ b/frontend/src/hooks/use-wallet-provider.tsx
@@ -57,6 +57,11 @@ export const WalletProviderProvider = ({ children, config }: { children: ReactNo
                                 chainId,
                                 chainName: config.networkName,
                                 rpcUrls: [config.networkEndpoint],
+                                nativeCurrency: {
+                                    name: 'ETH',
+                                    symbol: 'ETH',
+                                    decimals: 18,
+                                },
                             },
                         ],
                     });

--- a/frontend/src/pages/building-fabricator.tsx
+++ b/frontend/src/pages/building-fabricator.tsx
@@ -267,7 +267,7 @@ contract BasicFactory is BuildingKind {
         // require carrying an idCard
         // you can change idCardItemId to another item id
         CheckIsCarryingItem(state, actor, idCardItemId);
-    
+
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
     }*/
 
@@ -1672,7 +1672,7 @@ export default function ShellPage() {
 
     return (
         <UnityMapProvider showLoading={false} display="none">
-            <WalletProviderProvider wallets={config?.wallets || {}}>
+            <WalletProviderProvider config={config}>
                 <GameStateProvider config={config}>
                     <SessionProvider>
                         <InventoryProvider>

--- a/frontend/src/pages/docs/[[...slug]].tsx
+++ b/frontend/src/pages/docs/[[...slug]].tsx
@@ -1,23 +1,23 @@
-import { readdir } from 'fs/promises';
-import { join } from 'path';
 import { readFileSync } from 'fs';
+import { readdir } from 'fs/promises';
 import matter from 'gray-matter';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
-import { unified } from 'unified';
+import { join } from 'path';
 import rehypeHighlight from 'rehype-highlight';
-import remarkParse from 'remark-parse';
 import rehypeStringify from 'rehype-stringify';
+import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
+import { unified } from 'unified';
 
-import type { InferGetStaticPropsType, GetStaticProps, GetStaticPaths } from 'next';
-import styled from 'styled-components';
-import { WalletProviderProvider } from '@app/hooks/use-wallet-provider';
 import { useConfig } from '@app/hooks/use-config';
 import { GameStateProvider } from '@app/hooks/use-game-state';
 import { SessionProvider } from '@app/hooks/use-session';
-import { useRouter } from 'next/router';
+import { WalletProviderProvider } from '@app/hooks/use-wallet-provider';
+import type { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
 
 const DOCS_CONTENT_DIR = '../docs';
 
@@ -226,7 +226,7 @@ export default function Page({ doc, tree }: InferGetStaticPropsType<typeof getSt
     }
     const title = doc.title || doc.slug.slice(-1).find(() => true) || '';
     return (
-        <WalletProviderProvider wallets={config?.wallets || {}}>
+        <WalletProviderProvider config={config}>
             <GameStateProvider config={config}>
                 <SessionProvider>
                     <Head>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,7 +12,7 @@ export default function ShellPage() {
 
     return (
         <UnityMapProvider>
-            <WalletProviderProvider wallets={config?.wallets || {}}>
+            <WalletProviderProvider config={config}>
                 <GameStateProvider config={config}>
                     <SessionProvider>
                         <InventoryProvider>


### PR DESCRIPTION
### what

- include network id,endpoint,name in config.json
- dynamically generate unique chain-id based on namespace for each deployed network
- automatically add/switch metamask to the configured endpoint when you select "metamask"

![Screenshot 2024-02-27 at 09 08 50](https://github.com/playmint/ds/assets/45921/f5ba836a-c609-40e4-974c-eccb940ac724)


### why

to make it easier to play with things like Items as ERC1155 tokens where you would need to connect to the correct network endpoint to interact

we cannot add different network endpoints to metamask without also using different chain ids ... so need to spin up the networks with different chain id and then pass this configuration into the app so that it can tell metamask the correct endpoint + chain id

### related

* resolves: #1062 

### issues

* if the switch fails, we just mark the attempt as failed and never try again ... otherwise we can get stuck in a loop of attempting.... it might be better to present a "switch network" button, but that will mean changing the UI a fair bit more
* it will only ever prompt to switch when you click "metamask" in the connect dialog ... it doesn't detect if you have manually switched networks after than point ... so it's still easy for it to get out of sync
* we could/should support switching walletconnect wallets too, but the focus here has been on metamask and demoing ERC1155 tokens in metamask so this is out of scope for now

### before merge

check that it correctly adds/switches when running...

* [x] via make dev
* [x] via compose up
* [x] via a deployed hexwoodN instance (switching works but because history is pruned metamask things like ERC1155 tokens don't work)

### when testing...

the game tries to cache your account so that you don't have to sign in all the time ... this means you will likely need to "disconnect" and refresh before you get prompted to add or switch network
