### PR TITLE
Snowsphere: the unsafe sandbox

### DIFF
--- a/contracts/src/maps/tonk/tonk_kinds/TonkTower/Tonk.js
+++ b/contracts/src/maps/tonk/tonk_kinds/TonkTower/Tonk.js
@@ -17,7 +17,7 @@ async function getGame() {
         return JSON.parse(raw);
     } catch (e) {
         console.log(e);
-        return `{ "status": "GameServerDown" }`;
+        return { status: "GameServerDown" };
     }
 }
 
@@ -855,6 +855,72 @@ export default async function update(params) {
 
     status = tonkPlayer.eliminated || playerEliminated ? "ELIMINATED" : status;
 
+    // Team colorus
+    const mapUnitObj = [];
+    const { status: game_status, win_result } = game;
+    players?.forEach((p) => {
+        switch(p.role) {
+            // Only bugged units can see p.role
+            case "Bugged":
+                // This info is only seen by bugged units
+                mapUnitObj.push({
+                    type: "unit",
+                    key: "color",
+                    id: p.mobile_unit_id,
+                    value: "#ec5c61", // RED - MAIN
+                });
+                break;
+            case "Normal":
+                // This info is only seen by bugged units
+                mapUnitObj.push({
+                    type: "unit",
+                    key: "color",
+                    id: p.mobile_unit_id,
+                    value: game_status === "End" && win_result === "Thuggery" ? "#135198" : "#2daee0", // Brainwashed win ? BLUE - SHADOW : BLUE - MAIN
+                });
+                break;
+            default:
+                if (game_status === "End") {
+                    if (win_result === "Thuggery"){
+                        // Brainwashed win - show all as dark blue
+                        mapUnitObj.push({
+                            type: "unit",
+                            key: "color",
+                            id: p.mobile_unit_id,
+                            value: "#135198", // BLUE - SHADOW
+                        });
+                    }else if (win_result === "Democracy" || win_result === "Perfection"){
+                        // Sentients win - show all as light blue
+                        mapUnitObj.push({
+                            type: "unit",
+                            key: "color",
+                            id: p.mobile_unit_id,
+                            value: "#2daee0", // BLUE - MAIN
+                        });
+                    }
+                }
+                else if (game.status === "Lobby"){
+                    // Show everyone as purple in lobby
+                    mapUnitObj.push({
+                        type: "unit",
+                        key: "color",
+                        id: p.mobile_unit_id,
+                        value: "#9c74fd", // PURPLE - MAIN
+                    });
+                }
+                else{
+                    // sentient units see everyone as blue
+                    mapUnitObj.push({
+                        type: "unit",
+                        key: "color",
+                        id: p.mobile_unit_id,
+                        value: "#2daee0", // BLUE - MAIN
+                    });
+                }
+                break;
+        }
+    });
+
     let buttons = [];
     const bugOut = (id, displayName) => {
         bugging = true;
@@ -1005,6 +1071,7 @@ export default async function update(params) {
 
     return {
         version: 1,
+        map: mapUnitObj || [],
         components: [
             {
                 id: "tonk",

--- a/contracts/src/maps/tonk/tonk_kinds/TonkTower/TonkTower.js
+++ b/contracts/src/maps/tonk/tonk_kinds/TonkTower/TonkTower.js
@@ -37,7 +37,7 @@ async function getPlayers(gameId, playerId) {
         return JSON.parse(raw);
     } catch (e) {
         console.log(e);
-        return `[]`;
+        return [];
     }
 }
 
@@ -357,8 +357,6 @@ const logoStyle = {
 };
 
 export function renderVote(players, tonkPlayer) {
-    console.log(players);
-    console.log(tonkPlayer);
     return `
     <div style="${inlineStyle({ ...rowStyle, "margin-top": "25px" })}">
         <div style="${inlineStyle({ ...boxAndLabelStyle, display: "block" })}">
@@ -468,16 +466,36 @@ export function renderDefault(_time, gameStatusText, players, eliminated) {
 }
 
 export default async function update(params) {
+    try {
+        return await _update(params);
+    } catch (err) {
+        console.error('tonktower not ready:', err);
+        return {
+            version: 1,
+            map: [],
+            components: [
+                {
+                    id: "tonk-tower",
+                    type: "building",
+                    content: [
+                        {
+                            id: "default",
+                            type: "inline",
+                            html: `Not Ready`,
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+}
+
+async function _update(params) {
     let buttons = [];
     let submit;
 
     const { selected, player, world } = params;
-    // console.log(world);
-    // console.log(params);
     const { mobileUnit } = selected || {};
-    // console.log("building id: ", selected.mapElement.id);
-    // console.log("selected coords: ", selected.tiles[0].coords);
-    // console.log(player);
 
     const buildingId = selected?.mapElement?.id;
     let bags = mobileUnit ? findBags(world, mobileUnit) : [];
@@ -580,7 +598,7 @@ export default async function update(params) {
                         id: p.mobile_unit_id,
                         value: "#2daee0", // BLUE - MAIN
                     });
-                }                
+                }
                 break;
         }
     });
@@ -650,7 +668,7 @@ export default async function update(params) {
     // }
 
     const warningText = getWarningText(game, players, has_tonk);
-    let time = game.status == "Vote" ? "N/A" : game.time.timer;
+    let time = game.status == "Vote" ? "N/A" : game.time?.timer || 'N/A';
     let showVote =
         game.status === "Vote" &&
         !tonkPlayer.eliminated &&

--- a/contracts/src/maps/tonk/tonk_kinds/TonkTower/TonkTower.js
+++ b/contracts/src/maps/tonk/tonk_kinds/TonkTower/TonkTower.js
@@ -414,7 +414,7 @@ export function renderDefault(_time, gameStatusText, players, eliminated) {
     <div style="${inlineStyle({ ...rowStyle, display: "flex" })}">
         <div style="${inlineStyle(boxAndLabelStyle)}">
             <p style="${inlineStyle(labelStyle)}">ANNOUNCEMENTS</p>
-            <div style="${inlineStyle({ ...boxStyle, ...statusStyle })}"> 
+            <div style="${inlineStyle({ ...boxStyle, ...statusStyle })}">
                 <p style="${inlineStyle(entryStyle)}">${gameStatusText}</p>
             </div>
         </div>
@@ -430,7 +430,7 @@ export function renderDefault(_time, gameStatusText, players, eliminated) {
     <div style="${inlineStyle(rowStyle)}">
         <div style="${inlineStyle(boxAndLabelStyle)}">
             <p style="${inlineStyle(labelStyle)}">ACTIVE</p>
-            <div style="${inlineStyle({ ...boxStyle, ...activeUnitsStyle })}"> 
+            <div style="${inlineStyle({ ...boxStyle, ...activeUnitsStyle })}">
                 ${players
                     .map((p) => {
                         return `
@@ -442,7 +442,7 @@ export function renderDefault(_time, gameStatusText, players, eliminated) {
         </div>
         <div style="${inlineStyle(boxAndLabelStyle)}">
             <p style="${inlineStyle(labelStyle)}">ELIMINATED</p>
-            <div style="${inlineStyle({ ...boxStyle, ...eliminatedStyle })}"> 
+            <div style="${inlineStyle({ ...boxStyle, ...eliminatedStyle })}">
                 ${eliminated
                     .map((e) => {
                         if (e.player.role === "Bugged") {
@@ -616,9 +616,7 @@ export default async function update(params) {
         saved_vote_id = null;
     }
 
-    const player_is_in_game = players
-        ? players.findIndex((p) => p.id == player.id) >= 0
-        : [];
+    const player_is_in_game = (players || []).findIndex((p) => p.id == player.id) >= 0;
     if (game.status == "Lobby") {
         if (!player_is_in_game && !!has_tonk && game.status == "Lobby") {
             buttons.push({

--- a/contracts/src/maps/tonk/tonk_kinds/TonkTower/TonkTower.js
+++ b/contracts/src/maps/tonk/tonk_kinds/TonkTower/TonkTower.js
@@ -535,74 +535,6 @@ async function _update(params) {
     players = await getPlayers(game?.id, player?.id);
     tonkPlayer = await getPlayer(player?.id);
 
-    // team colors
-    // console.log("players: ", players, "eliminated: ", game.eliminated_players || [], "game: ", game);
-
-    const mapUnitObj = [];
-    const { status, win_result } = game;
-    players?.forEach((p) => {
-        switch(p.role) {
-            // Only bugged units can see p.role
-            case "Bugged":
-                // This info is only seen by bugged units
-                mapUnitObj.push({
-                    type: "unit",
-                    key: "color",
-                    id: p.mobile_unit_id,
-                    value: "#ec5c61", // RED - MAIN
-                });
-                break;
-            case "Normal":
-                // This info is only seen by bugged units
-                mapUnitObj.push({
-                    type: "unit",
-                    key: "color",
-                    id: p.mobile_unit_id,
-                    value: status === "End" && win_result === "Thuggery" ? "#135198" : "#2daee0", // Brainwashed win ? BLUE - SHADOW : BLUE - MAIN
-                });
-                break;
-            default:
-                if (status === "End") {
-                    if (win_result === "Thuggery"){
-                        // Brainwashed win - show all as dark blue
-                        mapUnitObj.push({
-                            type: "unit",
-                            key: "color",
-                            id: p.mobile_unit_id,
-                            value: "#135198", // BLUE - SHADOW
-                        });
-                    }else if (win_result === "Democracy" || win_result === "Perfection"){
-                        // Sentients win - show all as light blue
-                        mapUnitObj.push({
-                            type: "unit",
-                            key: "color",
-                            id: p.mobile_unit_id,
-                            value: "#2daee0", // BLUE - MAIN
-                        });
-                    }
-                }
-                else if (game.status === "Lobby"){
-                    // Show everyone as purple in lobby
-                    mapUnitObj.push({
-                        type: "unit",
-                        key: "color",
-                        id: p.mobile_unit_id,
-                        value: "#9c74fd", // PURPLE - MAIN
-                    });
-                }
-                else{
-                    // sentient units see everyone as blue
-                    mapUnitObj.push({
-                        type: "unit",
-                        key: "color",
-                        id: p.mobile_unit_id,
-                        value: "#2daee0", // BLUE - MAIN
-                    });
-                }
-                break;
-        }
-    });
-
     if (wants_to_join) {
         try {
             await requestJoin(game.id, player.id);
@@ -676,7 +608,6 @@ async function _update(params) {
 
     return {
         version: 1,
-        map: mapUnitObj || [],
         components: [
             {
                 id: "tonk-tower",

--- a/contracts/src/maps/tonk/tonk_kinds/TonkTower/manifest.yaml
+++ b/contracts/src/maps/tonk/tonk_kinds/TonkTower/manifest.yaml
@@ -22,7 +22,6 @@ spec:
     file: ./TonkTower.sol
   plugin:
     file: ./TonkTower.js
-    alwaysActive: true
   materials:
     - name: Green Goo
       quantity: 10 

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -231,7 +231,7 @@ function isAutoloadableBuildingPlugin(
                 return false;
             }
             const unitItemKindIds = getBagsAtEquipee(world.bags, mobileUnit).flatMap((bag) =>
-                bag.slots.flatMap((slot) => slot.item.id),
+                bag.slots.filter((slot) => slot.balance > 0).flatMap((slot) => slot.item.id),
             );
             return unitItemKindIds.some((id) => p.supports?.id === id);
         default:

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -350,26 +350,14 @@ export async function loadPlugin(
     // setup the submit func
     const submitProxy = async (ref: string, values: PluginSubmitCallValues): Promise<void> => {
         console.log('submit', ref, values);
-        const res = await sandbox.evalCode(
-            context,
-            `(async function({ref, values}){
-                    const fn = globalThis.__refs[ref];
-                    fn && fn(values);
-                    return JSON.stringify({ok: true});
-                })(${JSON.stringify({ ref, values })})`,
-        );
+        const res = await sandbox.submit(context, { ref, values });
         console.log('submitted', ref, res);
     };
 
     // setup the update func
     const updateProxy = async (): Promise<PluginUpdateResponse> => {
         try {
-            const pluginResponse = await sandbox.evalCode(
-                context,
-                `(async () => {
-                    return globalThis.__update();
-                })()`,
-            );
+            const pluginResponse = await sandbox.update(context);
 
             const _pluginResponse = (await sandbox.hasContext(context)) === true ? pluginResponse : {};
             return {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -34,7 +34,8 @@ export interface Sandbox {
     ) => Promise<number>;
     deleteContext: (id: number) => Promise<void>;
     hasContext: (id: number) => Promise<boolean>;
-    evalCode: (context: number, code: string) => Promise<any>;
+    update: (context: number) => Promise<PluginUpdateResponse>;
+    submit: (context: number, values: { ref: string; values: any }) => Promise<void>;
     setState: (state: GameStatePlugin, blk: number) => Promise<void>;
 }
 

--- a/frontend/src/hooks/use-game-state.tsx
+++ b/frontend/src/hooks/use-game-state.tsx
@@ -83,7 +83,7 @@ export const GameStateProvider = ({ config, children }: DSContextProviderProps) 
     const { provider } = useWalletProvider();
     const [sources1, setSources1] = useState<DSContextValue1>();
     const [sources2, setSources2] = useState<DSContextValue2>();
-    const [sandboxDeaths, setSandboxDeaths] = useState<number>(0);
+    // const [sandboxDeaths, setSandboxDeaths] = useState<number>(0);
     const workerRef = useRef<Worker>();
 
     useEffect(() => {
@@ -162,7 +162,6 @@ export const GameStateProvider = ({ config, children }: DSContextProviderProps) 
         if (!config) {
             return;
         }
-        console.log('restart count', sandboxDeaths);
         workerRef.current = new Worker(new URL('../workers/snowsphere.ts', import.meta.url));
         const workerSandbox: Comlink.Remote<Sandbox> = Comlink.wrap(workerRef.current);
         workerSandbox
@@ -173,15 +172,16 @@ export const GameStateProvider = ({ config, children }: DSContextProviderProps) 
                 const { plugins: activePlugins } = makeAutoloadPlugins(availablePlugins, selection, world);
                 const ui = makePluginUI(activePlugins, workerSandbox, logger, questMsgSender, state, block);
 
-                pipe(
-                    ui,
-                    subscribe((responses) => {
-                        if (responses.some((res) => res.error === 'SANDBOX_OOM')) {
-                            console.error('sandbox OOM detected, restarting?');
-                            setSandboxDeaths((prev) => prev + 1);
-                        }
-                    })
-                );
+                // re-enable if using sandbox instead of snowsphere
+                // pipe(
+                //     ui,
+                //     subscribe((responses) => {
+                //         if (responses.some((res) => res.error === 'SANDBOX_OOM')) {
+                //             console.error('sandbox OOM detected, restarting?');
+                //             setSandboxDeaths((prev) => prev + 1);
+                //         }
+                //     })
+                // );
                 setSources2({
                     ...sources1,
                     ui,
@@ -190,7 +190,7 @@ export const GameStateProvider = ({ config, children }: DSContextProviderProps) 
                 });
             })
             .catch(() => console.error(`sandbox init fail`));
-    }, [sandboxDeaths, sources1, config]);
+    }, [sources1, config]);
 
     const { selectProvider } = sources1 || {};
 

--- a/frontend/src/hooks/use-game-state.tsx
+++ b/frontend/src/hooks/use-game-state.tsx
@@ -163,7 +163,7 @@ export const GameStateProvider = ({ config, children }: DSContextProviderProps) 
             return;
         }
         console.log('restart count', sandboxDeaths);
-        workerRef.current = new Worker(new URL('../workers/sandbox.ts', import.meta.url));
+        workerRef.current = new Worker(new URL('../workers/snowsphere.ts', import.meta.url));
         const workerSandbox: Comlink.Remote<Sandbox> = Comlink.wrap(workerRef.current);
         workerSandbox
             .init(config)

--- a/frontend/src/hooks/use-session.tsx
+++ b/frontend/src/hooks/use-session.tsx
@@ -6,7 +6,7 @@ import { ethers } from 'ethers';
 import Image from 'next/image';
 import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { usePlayer } from './use-game-state';
-import { useLocalStorage } from './use-localstorage';
+// import { useLocalStorage } from './use-localstorage';
 import { useWalletProvider } from './use-wallet-provider';
 
 export const disableSessionRefresh = 'this export only exists to disable fast-refresh of this file';
@@ -49,7 +49,8 @@ export const SessionProvider = ({ children }: { children: ReactNode }) => {
     const [authorizing, setAuthorizing] = useState<boolean>(false);
     const player = usePlayer();
     const closeAuthroizer = useCallback(() => setAuthorizing(false), []);
-    const [sessionData, setSessionData] = useLocalStorage<SessionData | null>(SESSION_LOCALSTORAGE_KEY, null);
+    // const [sessionData, setSessionData] = useLocalStorage<SessionData | null>(SESSION_LOCALSTORAGE_KEY, null);
+    const [sessionData, setSessionData] = useState<SessionData | null>(null);
     const [loadingSession, setLoading] = useState<boolean>(!!sessionData);
     const session = useMemo(() => (sessionData ? decodeSessionData(sessionData) : undefined), [sessionData]);
     const [sessionLoaded, setSessionLoaded] = useState<boolean>(false);

--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -6,6 +6,7 @@ import {
     PluginDispatchFunc,
     Sandbox,
     GameConfig,
+    PluginUpdateResponse,
 } from '@downstream/core';
 import * as Comlink from 'comlink';
 import { QuickJSContext, QuickJSRuntime, getQuickJS } from 'quickjs-emscripten';
@@ -85,7 +86,7 @@ function pollPendingJobs() {
     setTimeout(() => pollPendingJobs(), ms);
 }
 
-export async function init(cfg: Partial<GameConfig>) {
+async function init(cfg: Partial<GameConfig>) {
     config = cfg;
     const qjs = await getQuickJS();
 
@@ -94,16 +95,10 @@ export async function init(cfg: Partial<GameConfig>) {
     runtime.setMaxStackSize(1024 * 320);
 
     pollPendingJobs();
-
-    // let interruptCycles = 0;
-    // runtime.setInterruptHandler(() => {
-    //     console.log('int');
-    //     return ++interruptCycles > 1024;
-    // });
 }
 
 // can also die at update time
-export async function setState(newState: GameStatePlugin, newBlock: number) {
+async function setState(newState: GameStatePlugin, newBlock: number) {
     contexts.forEach(async (context) => {
         if (context && context.alive) {
             try {
@@ -120,7 +115,7 @@ export async function setState(newState: GameStatePlugin, newBlock: number) {
     });
 }
 
-export async function deleteContext(contextID: number) {
+async function deleteContext(contextID: number) {
     try {
         contexts[contextID].dispose();
         console.log('just disposed context ', contextID);
@@ -129,12 +124,12 @@ export async function deleteContext(contextID: number) {
     }
 }
 
-export async function hasContext(contextID: number) {
+async function hasContext(contextID: number) {
     const context = contexts[contextID];
     return context?.alive;
 }
 
-export async function evalCode(contextID: number, code: string) {
+async function evalCode(contextID: number, code: string) {
     const context = contexts[contextID];
     if (!context || !context.alive) {
         return;
@@ -160,7 +155,7 @@ export async function evalCode(contextID: number, code: string) {
     }
 }
 
-export async function newContext(
+async function newContext(
     dispatch: PluginDispatchFunc,
     logMessage: Logger,
     questMessage: Logger,
@@ -179,7 +174,7 @@ export async function newContext(
         }
     }
 }
-export async function _newContext(
+async function _newContext(
     dispatch: PluginDispatchFunc,
     logMessage: Logger,
     questMessage: Logger,
@@ -559,6 +554,26 @@ export async function _newContext(
     return contextID;
 }
 
-const sandbox: Sandbox = { init, newContext, deleteContext, hasContext, evalCode, setState };
+async function update(contextId: number): Promise<PluginUpdateResponse> {
+    return await evalCode(
+        contextId,
+        `(async () => {
+            return globalThis.__update();
+        })()`
+    );
+}
+
+async function submit(contextId: number, data: { ref: string; values: any }): Promise<void> {
+    await evalCode(
+        contextId,
+        `(async function({ref, values}){
+            const fn = globalThis.__refs[ref];
+            fn && fn(values);
+            return JSON.stringify({ok: true});
+        })(${JSON.stringify(data)})`
+    );
+}
+
+const sandbox: Sandbox = { init, newContext, deleteContext, hasContext, setState, update, submit };
 
 Comlink.expose(sandbox);

--- a/frontend/src/workers/snowsphere.ts
+++ b/frontend/src/workers/snowsphere.ts
@@ -1,0 +1,243 @@
+// ///////////////////////////////////////
+// snowsphere is the opposite of sandbox
+//
+// it is completely insecure!
+//
+// plugins executed with snowsphere has unrestricted
+// access to basically everything.
+//
+// they can read your indexdb
+// they can look at your cookies
+// they can start workers
+// they can request stuff as if they are the origin
+// they can probably steal the session key
+// they can probably get access to the DOM if they try hard enough
+// they can probably turn up at your house
+//
+// basically this offers no protection whatsoever
+//
+// but ... they are fast
+// and they can use the normal debugging instrumentation
+// so that's nice
+//
+// ////////////////////////////////////////
+//
+import {
+    GameConfig,
+    GameStatePlugin,
+    Logger,
+    PluginConfig,
+    PluginDispatchFunc,
+    PluginUpdateResponse,
+    Sandbox,
+    actionArgFromUnknown,
+} from '@downstream/core';
+import * as Comlink from 'comlink';
+import { ethers } from 'ethers';
+
+let globalPluginState: GameStatePlugin;
+let globalPluginBlock: number = 0;
+let globalConfig: Partial<GameConfig> = {};
+let globalContextSeq = 1;
+const contexts: Map<number, PluginContext> = new Map();
+
+type PluginModule = { default: (s: GameStatePlugin, block: number) => any | Promise<any> };
+
+function esm(raw: ReturnType<typeof String.raw>, ...vals: any[]) {
+    return URL.createObjectURL(new Blob([String.raw({ raw }, ...vals)], { type: 'application/javascript' }));
+}
+
+class PluginContext {
+    __module: PluginModule;
+    __refs: { [key: string]: (values: any) => void };
+    __id: number;
+
+    constructor({ mod, id }: { mod: PluginModule; id: number }) {
+        this.__module = mod;
+        this.__refs = {};
+        this.__id = id;
+    }
+
+    id() {
+        return this.__id;
+    }
+
+    async update(): Promise<PluginUpdateResponse> {
+        if (!globalPluginState) {
+            throw new Error('no state set yet');
+        }
+        let res = await Promise.resolve(this.__module.default(globalPluginState, globalPluginBlock));
+
+        // replace funcs with refs
+        const refs = {};
+        if (!res) {
+            res = {};
+        }
+        if (res.components) {
+            res.components.forEach((comp) => {
+                if (!comp.content || !comp.content.forEach) {
+                    return;
+                }
+                comp.content.forEach((cont) => {
+                    if (!cont.id) {
+                        return;
+                    }
+                    if (typeof cont.submit === 'function') {
+                        const ref = Math.random().toString(36);
+                        if (refs[ref]) {
+                            throw new Error('bang, need better ref picker');
+                        }
+                        refs[ref] = cont.submit;
+                        cont.submit = ref;
+                    }
+                    if (!cont.buttons || !cont.buttons.forEach) {
+                        return;
+                    }
+                    cont.buttons.forEach((btn, idx) => {
+                        if (typeof btn.action === 'function') {
+                            const ref = comp.id + '/' + cont.id + '/' + idx;
+                            if (refs[ref]) {
+                                throw new Error('bang, need better ref picker');
+                            }
+                            refs[ref] = btn.action;
+                            btn.action = ref;
+                        }
+                    });
+                });
+            });
+        }
+
+        // stick the refs somewhere we can find them later
+        this.__refs = refs;
+
+        return res;
+    }
+
+    async submit({ ref, values }: { ref: string; values: any }): Promise<void> {
+        const fn = this.__refs[ref];
+
+        fn && fn(values);
+    }
+}
+
+async function init(cfg: Partial<GameConfig>) {
+    globalConfig = cfg;
+}
+
+async function setState(newState: GameStatePlugin, newBlock: number) {
+    globalPluginState = newState;
+    globalPluginBlock = newBlock;
+}
+
+async function deleteContext(id: number) {
+    contexts.delete(id);
+}
+
+async function hasContext(id: number) {
+    return contexts.has(id);
+}
+
+// strip imports and inject the "ds" module into scope
+function rewriteModuleCode(code: string): string {
+    code = code.replace(/\s*import.+from.*$/gm, '');
+    code = `
+        let ds = undefined;
+        export function __setDS(o) {
+            ds = o;
+        }
+        ${code}
+    `;
+    return code;
+}
+
+async function newContext(
+    dispatch: PluginDispatchFunc,
+    logMessage: Logger,
+    questMessage: Logger,
+    config: PluginConfig
+): Promise<number> {
+    const id = ++globalContextSeq;
+    const code = rewriteModuleCode(config.src);
+    const mod = await import(/*webpackIgnore: true*/ esm(code));
+
+    // all the stuff available via ds.etc
+    mod.__setDS({
+        dispatch(...actions: any[]) {
+            try {
+                if (typeof actions === 'undefined' || !Array.isArray(actions)) {
+                    console.warn(`plugin-${config.id}: invalid dispatch call`, actions);
+                    return;
+                }
+                dispatch(...actions)
+                    .then(() => console.log(`plugin-${config.id}: dispatched`, actions))
+                    .catch((err) => console.error(`plugin-${config.id}: failed dispatch: ${err}`));
+                return 'ok'; // TODO: return queue id
+            } catch (err) {
+                console.error(`plugin-${config.id}: failure attempting to dispatch: ${err}`);
+                return;
+            }
+        },
+
+        encodeCall(...req: any[]) {
+            try {
+                const [funcsig, args] = req;
+                const callInterface = new ethers.Interface([funcsig]);
+                const callFunc = callInterface.getFunction(funcsig);
+                if (!callFunc) {
+                    throw new Error(`no func found for signature ${funcsig}`);
+                }
+                const callArgs = callFunc.inputs.map((wanted, idx) => actionArgFromUnknown(wanted, args[idx]));
+                const callData = callInterface.encodeFunctionData(callFunc.name, callArgs);
+                return callData;
+            } catch (err) {
+                console.error(`plugin-${config.id}: failure attempting to encodeCall: ${err}`);
+                return;
+            }
+        },
+
+        log(...args: any[]) {
+            try {
+                logMessage.log(...args);
+            } catch (err) {
+                console.error(`plugin-${config.id}: error while attempting to deliver log message: ${err}`);
+            }
+            return;
+        },
+
+        sendQuestMessage(...args: any[]) {
+            try {
+                const [message] = args;
+                questMessage.log(message);
+            } catch (err) {
+                console.error(`plugin-${config.id}: error while attempting to send quest message: ${err}`);
+            }
+            return context;
+        },
+
+        config: globalConfig,
+    });
+
+    const context = new PluginContext({ mod, id });
+    contexts.set(id, context);
+    return id;
+}
+
+async function submit(id: number, data: { ref: string; values: any }): Promise<void> {
+    const context = contexts.get(id);
+    if (!context) {
+        return;
+    }
+    return context.submit(data);
+}
+
+async function update(id: number): Promise<PluginUpdateResponse> {
+    const context = contexts.get(id);
+    if (!context) {
+        throw new Error(`no context with id=${id}`);
+    }
+    return context.update();
+}
+
+const sandbox: Sandbox = { init, newContext, deleteContext, hasContext, setState, update, submit };
+
+Comlink.expose(sandbox);

--- a/frontend/src/workers/snowsphere.ts
+++ b/frontend/src/workers/snowsphere.ts
@@ -141,7 +141,7 @@ async function hasContext(id: number) {
 function rewriteModuleCode(code: string): string {
     code = code.replace(/\s*import.+from.*$/gm, '');
     code = `
-        let ds = undefined;
+        let ds = {config: ${JSON.stringify(globalConfig)}};
         export function __setDS(o) {
             ds = o;
         }

--- a/frontend/src/workers/snowsphere.ts
+++ b/frontend/src/workers/snowsphere.ts
@@ -196,6 +196,28 @@ async function newContext(
             return context;
         },
 
+        solidityPackedKeccak256(...args: any[]) {
+            const [types, values] = args;
+            return ethers.solidityPackedKeccak256(types, values);
+        },
+
+        keccak256(...args: any[]) {
+            const [bytesHex] = args;
+            return ethers.keccak256(bytesHex);
+        },
+
+        abiEncode(...args: any[]) {
+            const [types, values] = args;
+            const coder = ethers.AbiCoder.defaultAbiCoder();
+            return coder.encode(types, values);
+        },
+
+        abiDecode(...args: any[]) {
+            const [types, data] = args;
+            const coder = ethers.AbiCoder.defaultAbiCoder();
+            return coder.decode(types, data);
+        },
+
         config: globalConfig,
     });
 


### PR DESCRIPTION
### what

This PR is attempting to resolves issues with flakey and unresponse plugin execution

...the main part is:

* cleans up the interface between the game and the sandbox
* adds (and enables) a new totally unsafe implementation of the sandbox interface

...and then also some bug fixes to improve the general plugin situation:

* ensure that plugins never execute concurrently ... it was unexpected that they were doing this
* add a max execution time timeout so that slow plugins don't cause an ever growing backlog (currently 1s)
* fix issue where item plugin would be loaded even if balance of the item is 0
* try to stop tonk plugin crash looping by catching errors in the plugin and fixup a couple of bugs
* stop storing old session data ... there's a chance this is causing the "cant craft" issue
* stop using random plugin function ref ids .... there's a chance this is causing the "cant craft" issue

### why

we are having problems with plugins executing within the sandbox. 

it is very likely these issues are due to the large memory requirements of serializing and process the large `state` object that is passed into plugins over and over again, but debugging and visibility is poor within the sandbox vm. this un-sandbox let's us execute plugins "normally" and lets us use the profiling tooling directly.

it also means plugin loading and state serialization is drastically reduced, so could be used as a stop-gap until we decide to fix the state serialization problem properly


### related

* fixes: #1086 
* fixes: #1087 

### before merge (if we even want that!)

* [x] test with lots of plugins 
* [x] have a team playtest with this branch on croissant map
* [x] support the new ds exports in https://github.com/playmint/ds/pull/1097