### PR TITLE
Exposing keccak256 and other ether's abi functions to plugins

### DIFF
--- a/frontend/src/workers/sandbox.ts
+++ b/frontend/src/workers/sandbox.ts
@@ -9,7 +9,7 @@ import {
 } from '@downstream/core';
 import * as Comlink from 'comlink';
 import { QuickJSContext, QuickJSRuntime, getQuickJS } from 'quickjs-emscripten';
-import { ethers, solidityPackedKeccak256 } from 'ethers';
+import { AbiCoder, ethers, keccak256, solidityPackedKeccak256 } from 'ethers';
 
 let runtime: QuickJSRuntime;
 let config: Partial<GameConfig> = {};
@@ -46,6 +46,21 @@ export function solidityPackedKeccak256(...args) {
     return globalThis.__ds.solidityPackedKeccak256(req);
 }
 
+export function keccak256(...args) {
+    const req = JSON.stringify(args);
+    return globalThis.__ds.keccak256(req);
+}
+
+export function abiEncode(...args) {
+    const req = JSON.stringify(args);
+    return globalThis.__ds.abiEncode(req);
+}
+
+export function abiDecode(...args) {
+    const req = JSON.stringify(args);
+    return globalThis.__ds.abiDecode(req);
+}
+
 export const config = ${JSON.stringify(config)};
 
 export default {
@@ -55,6 +70,10 @@ export default {
     sendQuestMessage,
     config,
     solidityPackedKeccak256,
+    keccak256,
+    abiEncode,
+    abiDecode
+
 };
 `;
 
@@ -262,7 +281,6 @@ export async function _newContext(
     // expose keccack256 function
     context
         .newFunction('solidityPackedKeccak256', (reqHandle) => {
-            console.log(`calling solidityPackedKeccak256`);
             try {
                 if (!api.enabled) {
                     console.warn(`plugin-${config.id}: ds api is unavilable outside of event handlers`);
@@ -277,6 +295,62 @@ export async function _newContext(
             return context.undefined;
         })
         .consume((fn: any) => context.setProp(dsHandle, 'solidityPackedKeccak256', fn));
+
+    // expose keccack256 function
+    context
+        .newFunction('keccak256', (reqHandle) => {
+            try {
+                if (!api.enabled) {
+                    console.warn(`plugin-${config.id}: ds api is unavilable outside of event handlers`);
+                    return context.undefined;
+                }
+                const [bytesHex] = JSON.parse(context.getString(reqHandle));
+                const res = keccak256(bytesHex);
+                return context.newString(res);
+            } catch (err) {
+                console.error(`plugin-${config.id}: error while attempting to keccak256: ${err}`);
+            }
+            return context.undefined;
+        })
+        .consume((fn: any) => context.setProp(dsHandle, 'keccak256', fn));
+
+    // expose encode function
+    context
+        .newFunction('abiEncode', (reqHandle) => {
+            try {
+                if (!api.enabled) {
+                    console.warn(`plugin-${config.id}: ds api is unavilable outside of event handlers`);
+                    return context.undefined;
+                }
+                const [types, values] = JSON.parse(context.getString(reqHandle));
+                const coder = AbiCoder.defaultAbiCoder();
+                const res = coder.encode(types, values);
+                return context.newString(res);
+            } catch (err) {
+                console.error(`plugin-${config.id}: error while attempting to abiEncode: ${err}`);
+            }
+            return context.undefined;
+        })
+        .consume((fn: any) => context.setProp(dsHandle, 'abiEncode', fn));
+
+    // expose encode function
+    context
+        .newFunction('abiDecode', (reqHandle) => {
+            try {
+                if (!api.enabled) {
+                    console.warn(`plugin-${config.id}: ds api is unavilable outside of event handlers`);
+                    return context.undefined;
+                }
+                const [types, data] = JSON.parse(context.getString(reqHandle));
+                const coder = AbiCoder.defaultAbiCoder();
+                const res = coder.decode(types, data);
+                return context.newString(JSON.stringify(res));
+            } catch (err) {
+                console.error(`plugin-${config.id}: error while attempting to abiDecode: ${err}`);
+            }
+            return context.undefined;
+        })
+        .consume((fn: any) => context.setProp(dsHandle, 'abiDecode', fn));
 
     // attach the __ds proxy to global object
     context.setProp(context.global, '__ds', dsHandle);


### PR DESCRIPTION
# What

Exposed more of ethers to the plugin sandbox:

`solidityPackedKeccak256`
`keccak256`
`abiEncode` (maps to ethers `encoder.encode`)
`abiDecode` (maps to ethers `encoder.decode`)

# Why

Added to fulfil a request from a plugin author. These functions are very common when working with contract data

# Example of use

```
        const keccakResult = ds.solidityPackedKeccak256(
            ["bytes24", "bytes24"],
            [selectedBuilding.id, mobileUnit.id],
        );
        console.log(`keccakResult: ${keccakResult}`);

        const encodeResult = ds.abiEncode(
            ["bytes24", "bytes24"],
            [selectedBuilding.id, mobileUnit.id],
        );
        console.log(`encodeResult: ${encodeResult}`);

        const rawKeccak = ds.keccak256(encodeResult);
        console.log(`rawKeccak: ${rawKeccak}`);

        const decodeResult = ds.abiDecode(["bytes24", "bytes24"], encodeResult);
        console.log(`decodeResult: ${decodeResult}`);
```