### PR TITLE
Added `offset` command to cli

### DIFF
--- a/cli/src/commands/apply.ts
+++ b/cli/src/commands/apply.ts
@@ -3,10 +3,7 @@ import { globSync } from 'glob';
 import path from 'path';
 import { z } from 'zod';
 import { Op, getOpsForManifests } from '../utils/applier';
-import {
-    ContractSource,
-    readManifestsDocumentsSync
-} from '../utils/manifest';
+import { ContractSource, readManifestsDocumentsSync } from '../utils/manifest';
 import { compilePath } from '../utils/solidity';
 import { getAvailableBuildingKinds, getWorld } from './get';
 
@@ -16,7 +13,7 @@ type OpResult = {
     op: Op;
 };
 
-const getManifestFilenames = (filename: string, isRecursive: boolean): string[] => {
+export const getManifestFilenames = (filename: string, isRecursive: boolean): string[] => {
     if (filename === '-') {
         return [filename];
     }
@@ -27,7 +24,7 @@ const getManifestFilenames = (filename: string, isRecursive: boolean): string[] 
         }
         // must be posix path, even on windows
         const globPath = path.join(filename, '**/*.yaml').replace(/\\/g, '/');
-        return globSync(globPath, {follow:true});
+        return globSync(globPath, { follow: true });
     } else if (isRecursive) {
         throw new Error(`--filename must be a directory when used with --recursive`);
     } else {
@@ -83,11 +80,10 @@ const deploy = {
         const compiler = async (source: z.infer<typeof ContractSource>, manifestDir: string): Promise<string> => {
             const relativeFilename = path.join(manifestDir, source.file || 'inline.sol');
             const libs = [path.join(path.dirname(relativeFilename)), ...(source.includes || [])];
-            const opts = {libs, verbose: false};
+            const opts = { libs, verbose: false };
             const { bytecode } = await (source.file
                 ? compilePath(relativeFilename, opts)
-                : {bytecode: source.bytecode}
-            );
+                : { bytecode: source.bytecode });
             return bytecode;
         };
 

--- a/cli/src/commands/offset.ts
+++ b/cli/src/commands/offset.ts
@@ -22,7 +22,7 @@ export const offset = {
                 type: '',
             })
             .check((ctx) => {
-                const coord = ctx.coordinate.split(',').map((c: string) => parseInt(c));
+                const coord = getCoordFromString(ctx.coordinate);
                 if (coord.length !== 3) {
                     throw new Error('invalid coord; must be in the format "q,r,s"');
                 }
@@ -46,7 +46,7 @@ export const offset = {
             .demand(['filename'])
             .example([[`$0 offset 0,2,-2 -f ./map.yaml`, `Offset a single map`]]),
     handler: async (ctx) => {
-        const offsetCoord = ctx.coordinate.split(',').map((c: string) => parseInt(c));
+        const offsetCoord = getCoordFromString(ctx.coordinate);
 
         const manifestFilenames = getManifestFilenames(ctx.filename, ctx.recursive);
         const docs = (await Promise.all(manifestFilenames.map(readManifestsDocumentsSync))).flatMap((docs) => docs);
@@ -54,7 +54,7 @@ export const offset = {
         const offsetDocs = docs.map((doc) => offsetDocument(doc, offsetCoord));
         const yamlDocs = offsetDocs.map((doc) => YAML.stringify(doc.manifest));
 
-        yamlDocs.forEach((doc) => console.log(`---\n${doc}`));
+        yamlDocs.forEach((doc) => process.stdout.write(`---\n${doc}\n`));
     },
 };
 
@@ -69,3 +69,9 @@ const offsetDocument = (doc: z.infer<typeof ManifestDocument>, offsetCoord: [num
 
     return doc;
 };
+
+const getCoordFromString = (coord: string) =>
+    coord
+        .replace(/[\[\]]/g, '')
+        .split(',')
+        .map((c: string) => parseInt(c)) as [number, number, number];

--- a/cli/src/commands/offset.ts
+++ b/cli/src/commands/offset.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import { getManifestFilenames } from './apply';
+import { ManifestDocument, readManifestsDocumentsSync } from '../utils/manifest';
+import { z } from 'zod';
+import YAML from 'yaml';
+
+export const offset = {
+    command: 'offset <coordinate>',
+    describe: 'offset a manifest document by the given qrs coordinate and output the result to stdout.',
+    builder: (yargs) =>
+        yargs
+            .positional('coordinate', { describe: 'the qrs coordinate to offset the document by', type: 'string' })
+            .option('filename', {
+                alias: 'f',
+                describe: 'path to manifest that contain the configurations to apply, use "-" to read from stdin',
+                type: 'string',
+            })
+            .option('recursive', {
+                alias: 'R',
+                describe:
+                    'process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory',
+                type: '',
+            })
+            .check((ctx) => {
+                const coord = ctx.coordinate.split(',').map((c: string) => parseInt(c));
+                if (coord.length !== 3) {
+                    throw new Error('invalid coord; must be in the format "q,r,s"');
+                }
+
+                const coordSum = coord.reduce((a, b) => a + b, 0);
+                if (coordSum !== 0) {
+                    throw new Error('invalid coord; qrs coordinates must sum to 0');
+                }
+
+                return true;
+            })
+            .check((ctx) => {
+                if (ctx.filename === '-') {
+                    return true;
+                }
+                if (!fs.existsSync(ctx.filename)) {
+                    throw new Error(`file not found: ${ctx.filename}`);
+                }
+                return true;
+            })
+            .demand(['filename'])
+            .example([[`$0 offset 0,2,-2 -f ./map.yaml`, `Offset a single map`]]),
+    handler: async (ctx) => {
+        const offsetCoord = ctx.coordinate.split(',').map((c: string) => parseInt(c));
+
+        const manifestFilenames = getManifestFilenames(ctx.filename, ctx.recursive);
+        const docs = (await Promise.all(manifestFilenames.map(readManifestsDocumentsSync))).flatMap((docs) => docs);
+
+        const offsetDocs = docs.map((doc) => offsetDocument(doc, offsetCoord));
+        const yamlDocs = offsetDocs.map((doc) => YAML.stringify(doc.manifest));
+
+        yamlDocs.forEach((doc) => console.log(`---\n${doc}`));
+    },
+};
+
+const offsetDocument = (doc: z.infer<typeof ManifestDocument>, offsetCoord: [number, number, number]) => {
+    if ('location' in doc.manifest.spec && doc.manifest.spec.location !== undefined) {
+        doc.manifest.spec.location = doc.manifest.spec.location.map((elm, index) => elm + offsetCoord[index]) as [
+            number,
+            number,
+            number
+        ];
+    }
+
+    return doc;
+};

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -13,6 +13,7 @@ import getter from './commands/get';
 import apply from './commands/apply';
 import { test } from './commands/test';
 import chalk from 'chalk';
+import { offset } from './commands/offset';
 
 const yargs = _yargs(hideBin(process.argv));
 
@@ -80,6 +81,7 @@ yargs
     .command(getter)
     .command(apply)
     .command(test)
+    .command(offset)
     .command({
         command: 'version',
         describe: 'show the current version and exit',


### PR DESCRIPTION
# What

- Added `offset` command to cli to offset location fields in manifests by a given coordinate. 
- Result is output to stdout
- Works with `-R` flag

example:
`ds offset 15,0,-15 -R -f contracts/src/maps/example-gate/ > ~/temp/offset.yaml `

Below I've deployed the example-gate map with different offsets to get two copies of it in the world

![image](https://github.com/playmint/ds/assets/51167118/272a3c71-2cf6-4a9f-b123-e2822ab4fd34)

# Why

Allows us to compose a large map from smaller maps without having to manually edit each location field

# Note

I had a problem with coords that started with a negative number as it tripped up the command line parser. To get round this you can specify QRS coords like this: 
`ds offset "[-10,10,0]" -R -f contracts/src/maps/example-gate/ > ~/temp/offset.yaml`