### PR TITLE
Optimised Combat Finalisation

### DIFF
--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -328,6 +328,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                     }
                     return () => clearTimeout(timeoutId);
                 }
+                return;
             }, sleepFor);
         }
     }, [combatSessionTick, player, prevCombatSessionTick, blockNumber, selectedMobileUnit, world?.mobileUnits]);

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -79,17 +79,14 @@ export const Shell: FunctionComponent<ShellProps> = () => {
     }, [player?.quests]);
     const unfinalisedCombatSessions = useMemo(
         () =>
-            (world?.sessions || [])
-                .filter((s) => {
-                    return !s.isFinalised;
-                })
-                .filter((s) => {
-                    const oneSideZero =
-                        s.attackers.filter((paticipant) => paticipant.node.id != nullBytes24).length == 0 ||
-                        s.defenders.filter((paticipant) => paticipant.node.id != nullBytes24).length == 0;
-                    const combatStarted = blockNumber && blockNumber >= (s.attackTile?.startBlock || 0);
-                    return oneSideZero || combatStarted;
-                }),
+            (world?.sessions || []).filter((s) => {
+                const isNotFinalised = !s.isFinalised;
+                const oneSideZero =
+                    s.attackers.filter((paticipant) => paticipant.node.id != nullBytes24).length == 0 ||
+                    s.defenders.filter((paticipant) => paticipant.node.id != nullBytes24).length == 0;
+                const combatStarted = blockNumber && blockNumber >= (s.attackTile?.startBlock || 0);
+                return isNotFinalised && (oneSideZero || combatStarted);
+            }),
 
         [world?.sessions, blockNumber]
     );

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -295,7 +295,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
         const jitter = Math.random() * 1000; // For cases where multiple units moved on the same block
         const sleepFor = selectedIndex > -1 ? selectedIndex * (2000 + jitter) : 0;
 
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
             const currentUnfinalisedCombatSessions = unfinalisedCombatSessionsRef.current;
             const finaliseActions = currentUnfinalisedCombatSessions.map(
                 (s) =>
@@ -306,8 +306,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
             );
 
             if (finaliseActions.length > 0) {
-                console.log(`Slept for ${sleepFor}ms before finalising combat`);
-                console.log(`I'm finalising the combat 🙋‍♂️`, finaliseActions);
+                console.log(`I'm finalising combat because I moved last 🙋‍♂️`, finaliseActions);
                 // player.dispatchAndWait(...finaliseActions).catch((err) => console.warn(err));
 
                 // Dispatching all at once could prevent future combat sessions from finalising if
@@ -317,6 +316,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                 );
             }
         }, sleepFor);
+        return () => clearTimeout(timeoutId);
     }, [combatSessionTick, player, prevCombatSessionTick, blockNumber, selectedMobileUnit, world?.mobileUnits]);
 
     const tileClick = useCallback(

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -295,15 +295,6 @@ export const Shell: FunctionComponent<ShellProps> = () => {
         const jitter = Math.random() * 500; // For cases where multiple units moved on the same block
         const sleepFor = selectedIndex > -1 ? selectedIndex * (1000 + jitter) : 0;
 
-        /*console.log(
-            "I'm waiting for",
-            Math.floor(sleepFor),
-            'ms, unfinalised sessions:',
-            unfinalisedCombatSessionsRef.current,
-            'selectedIndex:',
-            selectedIndex
-        );*/
-
         if (unfinalisedCombatSessionsRef.current.length > 0) {
             const timeoutId = setTimeout(() => {
                 const currentUnfinalisedCombatSessions = unfinalisedCombatSessionsRef.current;
@@ -317,7 +308,10 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                     );
 
                     if (finaliseActions.length > 0) {
-                        console.log(`I'm finalising combat because I moved last 🙋‍♂️`, finaliseActions);
+                        console.log(
+                            `⚔️ Finalising combat because your selected unit was one of the last to move`,
+                            finaliseActions
+                        );
                         // player.dispatchAndWait(...finaliseActions).catch((err) => console.warn(err));
 
                         // Dispatching all at once could prevent future combat sessions from finalising if

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -292,31 +292,44 @@ export const Shell: FunctionComponent<ShellProps> = () => {
             }
         }
 
-        const jitter = Math.random() * 1000; // For cases where multiple units moved on the same block
-        const sleepFor = selectedIndex > -1 ? selectedIndex * (2000 + jitter) : 0;
+        const jitter = Math.random() * 500; // For cases where multiple units moved on the same block
+        const sleepFor = selectedIndex > -1 ? selectedIndex * (1000 + jitter) : 0;
 
-        const timeoutId = setTimeout(() => {
-            const currentUnfinalisedCombatSessions = unfinalisedCombatSessionsRef.current;
-            const finaliseActions = currentUnfinalisedCombatSessions.map(
-                (s) =>
-                    ({
-                        name: 'FINALISE_COMBAT',
-                        args: [s.id],
-                    } as CogAction)
-            );
+        /*console.log(
+            "I'm waiting for",
+            Math.floor(sleepFor),
+            'ms, unfinalised sessions:',
+            unfinalisedCombatSessionsRef.current,
+            'selectedIndex:',
+            selectedIndex
+        );*/
 
-            if (finaliseActions.length > 0) {
-                console.log(`I'm finalising combat because I moved last 🙋‍♂️`, finaliseActions);
-                // player.dispatchAndWait(...finaliseActions).catch((err) => console.warn(err));
+        if (unfinalisedCombatSessionsRef.current.length > 0) {
+            const timeoutId = setTimeout(() => {
+                const currentUnfinalisedCombatSessions = unfinalisedCombatSessionsRef.current;
+                if (currentUnfinalisedCombatSessions.length > 0) {
+                    const finaliseActions = currentUnfinalisedCombatSessions.map(
+                        (s) =>
+                            ({
+                                name: 'FINALISE_COMBAT',
+                                args: [s.id],
+                            } as CogAction)
+                    );
 
-                // Dispatching all at once could prevent future combat sessions from finalising if
-                // one of the finalise transactions fail so we dispatch them one by one
-                Promise.all(finaliseActions.map((action) => player.dispatchAndWait(action))).catch((err) =>
-                    console.warn(err)
-                );
-            }
-        }, sleepFor);
-        return () => clearTimeout(timeoutId);
+                    if (finaliseActions.length > 0) {
+                        console.log(`I'm finalising combat because I moved last 🙋‍♂️`, finaliseActions);
+                        // player.dispatchAndWait(...finaliseActions).catch((err) => console.warn(err));
+
+                        // Dispatching all at once could prevent future combat sessions from finalising if
+                        // one of the finalise transactions fail so we dispatch them one by one
+                        Promise.all(finaliseActions.map((action) => player.dispatchAndWait(action))).catch((err) =>
+                            console.warn(err)
+                        );
+                    }
+                    return () => clearTimeout(timeoutId);
+                }
+            }, sleepFor);
+        }
     }, [combatSessionTick, player, prevCombatSessionTick, blockNumber, selectedMobileUnit, world?.mobileUnits]);
 
     const tileClick = useCallback(


### PR DESCRIPTION
## What
This change intends to make it so that the last unit that moved is **only** & most likely to be the one to send the `FINALISE_COMBAT` action.

In this screenshot, combat vs a building has just finished, and unit#193d is the only one who attempted to send the action because this was the last unit that moved:
![image](https://github.com/playmint/ds/assets/27741109/11ec4002-722a-4039-acae-e8154998c50c)


## Why
While playtesting Duck Burger with 10+ players, move of our clients were not updating throughout the game, and we think this was caused by everyone trying to execute the `FINALISE_COMBAT` action at the same time. (See [this comment](https://github.com/playmint/ds/issues/1095#issue-2160984833))

## How
It ranks all units on the map by when they last moved, placing the unit that moved closest to the current world block time first:
```js
const sortedMobileUnits =
            world?.mobileUnits?.sort((a, b) => {
                const diffA = Math.abs((a.nextLocation?.time || 0) - blockNumber);
                const diffB = Math.abs((b.nextLocation?.time || 0) - blockNumber);
                return diffA - diffB;
            }) || [];
```

Using this, it calculates a sleep time, and uses setTimeout to make sure the most recently active units are prioritized and sequentially try to send the action:
```js
const jitter = Math.random() * 1000; // For cases where multiple units moved on the same block
        const sleepFor = selectedIndex > -1 ? selectedIndex * (2000 + jitter) : 0;
```

Therefore, if another client is running this `useEffect` but has more of a delay than another client, it won't try to send the action because the combat at that point is already finalized.

Resolves #1095 