### PR TITLE
Duck Burger: 3 Minute Timer by Default

### DIFF
--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.sol
@@ -138,9 +138,9 @@ contract DuckBurgerHQ is BuildingKind {
         _setDataOnBuilding(dispatcher, buildingId, "buildingKindIdBurger", burgerBuildingID);
         // todo if the game length is a parameter, we could calculate this from the endBlock
         _setDataOnBuilding(dispatcher, buildingId, "startBlock", bytes32(block.number));
-        // set endblock to now plus 1 minute (assuming 2 second blocks)
+        // set endblock to now plus 3 minutes (assuming 2 second blocks)
         // todo do we take time as a param
-        _setDataOnBuilding(dispatcher, buildingId, "endBlock", bytes32(block.number + 1 * 30));
+        _setDataOnBuilding(dispatcher, buildingId, "endBlock", bytes32(block.number + 3 * 30));
 
         // set game active
         _setDataOnBuilding(dispatcher, buildingId, "gameActive", bytes32(uint256(1)));


### PR DESCRIPTION
## What
Default Duck Burger game time set to 3 minutes instead of 1.

## Why
So that the Duck Burger play tests can be a little bit less chaotic.

## How
```solidity
// set endblock to now plus 3 minutes (assuming 2 second blocks)
_setDataOnBuilding(dispatcher, buildingId, "endBlock", bytes32(block.number + 3 * 30));
```

Resolves #1088 