### PR TITLE
README: Note for Windows users to enabled symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ The repository needs cloning with LFS and recursive submodules.
   ```
   git clone --recurse-submodules https://github.com/playmint/ds
   ```
+
+### **_⚠️ 🖥 Windows_** 
+
+Windows users must ensure they have symlinks enabled.
+
+- **Go to ds**
+  ```
+  cd ds
+  ```
+- **Set symlinks to true**
+  ```
+  git config core.symlinks true
+  ```
 </details>
 
 <details>


### PR DESCRIPTION
## What
Updated README to include a note for Windows users to enable symlinks

## Why
Paul and I had an error on our laptops where it was not recognizing symlink files.

## How
To solve this problem, run `git config core.symlinks true` in `ds` dir.