### PR TITLE
Combat prediction

### DIFF
--- a/contracts/src/rules/CombatRule.sol
+++ b/contracts/src/rules/CombatRule.sol
@@ -30,7 +30,7 @@ import {ItemUtils} from "@ds/utils/ItemUtils.sol";
 
 using Schema for State;
 
-uint64 constant COMBAT_JOIN_WINDOW_BLOCKS = 15;
+uint64 constant COMBAT_JOIN_WINDOW_BLOCKS = 7;
 uint64 constant BLOCKS_PER_TICK = 1;
 uint64 constant MAX_TICKS = 300;
 uint8 constant MAX_ENTITIES_PER_SIDE = 100; // max allowed is 255 due to there being a reward bag for each entity and edges being 8 bit indices

--- a/frontend/src/plugins/combat/combat-summary/combat-summary.styles.ts
+++ b/frontend/src/plugins/combat/combat-summary/combat-summary.styles.ts
@@ -31,18 +31,12 @@ const baseStyles = (_: Partial<CombatSummaryProps>) => css`
         flex-direction: column;
         width: 100%;
 
-        .attackers,
-        .defenders {
-            width: 100%;
+        .countdown {
+            text-align: center;
         }
 
-        .attackers {
-            margin-top: 2rem;
-            margin-bottom: 0.5rem;
-        }
-
-        .defenders {
-            margin-bottom: 2rem;
+        .tileStats {
+            margin-top: 1rem;
         }
 
         > button {

--- a/frontend/src/plugins/combat/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat/combat-summary/index.tsx
@@ -135,11 +135,12 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
                 </Dialog>
             )}
             <div className="header">
-                <h3 className="title">Combat starts in {formattedTimeFromSeconds(combatStartRemainingSecs)}</h3>
+                <h3 className="title">Combat</h3>
                 <img src="/combat-header.png" alt="" className="icon" />
             </div>
             {
                 <div className="content">
+                    <h2>{formattedTimeFromSeconds(combatStartRemainingSecs)}</h2>
                     <div className="attackers">
                         <span className="heading">Attackers</span>
                         <ProgressBar maxValue={attackersMaxHealth} currentValue={attackersCurrentHealth} />

--- a/frontend/src/plugins/combat/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat/combat-summary/index.tsx
@@ -114,11 +114,26 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
             })
         );
 
-    // Sum up health state for both sides
-    const attackersMaxHealth = attackersStats.reduce((acc, stats) => acc + stats.life, 0);
-    const attackersCurrentHealth = attackersMaxHealth;
-    const defendersMaxHealth = defendersStats.reduce((acc, stats) => acc + stats.life, 0);
-    const defendersCurrentHealth = defendersMaxHealth;
+    // Sum up stats for both sides
+    const attackersHealth = attackersStats.reduce((acc, stats) => acc + stats.life, 0);
+    const attackersDefence = attackersStats.reduce((acc, stats) => acc + stats.def, 0);
+    const attackersAttack = attackersStats.reduce((acc, stats) => acc + stats.atk, 0);
+
+    const defendersHealth = defendersStats.reduce((acc, stats) => acc + stats.life, 0);
+    const defendersDefence = defendersStats.reduce((acc, stats) => acc + stats.def, 0);
+    const defendersAttack = defendersStats.reduce((acc, stats) => acc + stats.atk, 0);
+
+    const attackersAttackPerTick = Math.max(1, attackersAttack - defendersDefence);
+    const defendersAttackPerTick = Math.max(1, defendersAttack - attackersDefence);
+
+    // Calculate the number of ticks each side will survive
+    const attackerTicksAlive = Math.floor(attackersHealth / defendersAttackPerTick);
+    const defenderTicksAlive = Math.floor(defendersHealth / attackersAttackPerTick);
+    const tickDifference = Math.abs(attackerTicksAlive - defenderTicksAlive);
+
+    const isSelectedTileAttack = latestSession.attackTile.tile.id === selectedTiles[0].id;
+    const isAttackersWinning = attackerTicksAlive > defenderTicksAlive;
+    const isSelectedTileWinning = isSelectedTileAttack ? isAttackersWinning : !isAttackersWinning;
 
     return (
         <StyledCombatSummary>
@@ -135,22 +150,23 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
                 </Dialog>
             )}
             <div className="header">
-                <h3 className="title">Combat</h3>
+                <h3 className="title">Combat {isSelectedTileAttack ? `Attack` : `Defence`} Tile</h3>
                 <img src="/combat-header.png" alt="" className="icon" />
             </div>
             {
                 <div className="content">
-                    <h2>{formattedTimeFromSeconds(combatStartRemainingSecs)}</h2>
-                    <div className="attackers">
-                        <span className="heading">Attackers</span>
-                        <ProgressBar maxValue={attackersMaxHealth} currentValue={attackersCurrentHealth} />
+                    <p>Countdown until start of combat</p>
+                    <h2 className="countdown">{formattedTimeFromSeconds(combatStartRemainingSecs)}</h2>
+                    <div className="tileStats">
+                        <h3>This side is {isSelectedTileWinning ? `likely to win` : `likely to lose`}</h3>
+                        {/* <p>attacker health: {attackersHealth}</p>
+                        <p>defender health: {defendersHealth}</p>
+                        <p>attacker ticks alive: {attackerTicksAlive}</p>
+                        <p>defender ticks alive: {defenderTicksAlive}</p>
+                        <p>tick difference: {tickDifference}</p> */}
                     </div>
-                    <div className="defenders">
-                        <span className="heading">Defenders</span>
-                        <ProgressBar maxValue={defendersMaxHealth} currentValue={defendersCurrentHealth} />
-                    </div>
+
                     <ActionButton onClick={showModal}>View Combat</ActionButton>
-                    {/* {hasCombatStarted && <ActionButton onClick={handleFinaliseCombat}>End Combat</ActionButton>} */}
                 </div>
             }
         </StyledCombatSummary>

--- a/frontend/src/plugins/combat/combat-summary/index.tsx
+++ b/frontend/src/plugins/combat/combat-summary/index.tsx
@@ -3,7 +3,6 @@
 import { ConnectedPlayer, WorldMobileUnitFragment, WorldStateFragment, WorldTileFragment } from '@app/../../core/src';
 import { Dialog } from '@app/components/molecules/dialog';
 import { LIFE_MUL, getMaterialStats, getMobileUnitStats } from '@app/plugins/combat/helpers';
-import { ProgressBar } from '@app/plugins/combat/progress-bar';
 import { ComponentProps } from '@app/types/component-props';
 import { getSessionsAtTile } from '@downstream/core/src/utils';
 import { FunctionComponent, useCallback, useState } from 'react';
@@ -126,10 +125,12 @@ export const CombatSummary: FunctionComponent<CombatSummaryProps> = (props: Comb
     const attackersAttackPerTick = Math.max(1, attackersAttack - defendersDefence);
     const defendersAttackPerTick = Math.max(1, defendersAttack - attackersDefence);
 
-    // Calculate the number of ticks each side will survive
+    // Calculate the number of ticks each side will survive.
+    // It's a very rough estimate as it is subtracting the attack from the cumulative health
+    // of the other side. It doesn't take into account that the damage is only dealt to one participant per tick.
     const attackerTicksAlive = Math.floor(attackersHealth / defendersAttackPerTick);
     const defenderTicksAlive = Math.floor(defendersHealth / attackersAttackPerTick);
-    const tickDifference = Math.abs(attackerTicksAlive - defenderTicksAlive);
+    // const tickDifference = Math.abs(attackerTicksAlive - defenderTicksAlive);
 
     const isSelectedTileAttack = latestSession.attackTile.tile.id === selectedTiles[0].id;
     const isAttackersWinning = attackerTicksAlive > defenderTicksAlive;

--- a/frontend/src/plugins/combat/combat.ts
+++ b/frontend/src/plugins/combat/combat.ts
@@ -9,7 +9,7 @@ export const MAX_TICKS = 300;
 export const ATOM_LIFE = 0;
 export const ATOM_DEFENSE = 1;
 export const ATOM_ATTACK = 2;
-export const COMBAT_JOIN_WINDOW_BLOCKS = 15;
+export const COMBAT_JOIN_WINDOW_BLOCKS = 7;
 
 export interface EntityState {
     entityID: ethers.BytesLike;


### PR DESCRIPTION
# What

Showing a prediction of whether a particular combat tile is going to win or not

<img width="314" alt="image" src="https://github.com/playmint/ds/assets/51167118/e00ffaaf-10aa-461c-a32f-e2a61924a2cd">

When clicking on a tile now, it'll state if the tile is attacking or defending and whether or not it is likely to win or not. In kickoff we had discussed that we should also show if the opposing side is going to win or not but it's the opposite of the selected side's prediction so seems redundant. 

Also in this PR I have made the coundown timer larger and reduced combat time to 7 blocks (14 secs)

Fixes #1090
Fixes #1094
Fixes #1121