### PR TITLE
Removed Duplicate Panel Information

### DIFF
--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -228,17 +228,8 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, kinds, w
                     </PluginContent>
                 )}
                 {selectedTile && <TileInventory tile={selectedTile} bags={world?.bags || []} />}
-                <span className="label" style={{ width: '100%', marginTop: '2rem' }}>
-                    <strong>COORDINATES:</strong> {`${q}, ${r}, ${s}`}
-                </span>
-                {gooRatesInNameOrder.map((goo) => (
-                    <span key={goo?.name} className="label" style={{ width: '30%' }}>
-                        <strong>{goo?.name.toUpperCase().slice(0, 1)}:</strong>{' '}
-                        {`${Math.floor((goo?.gooPerSec || 0) * 3600)}/h`}
-                    </span>
-                ))}
                 {author && (
-                    <span className="label">
+                    <span className="label" style={{ marginTop: '2rem' }}>
                         <strong>AUTHOR:</strong> {author.name?.value ? author.name?.value : author.addr}
                     </span>
                 )}

--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -157,17 +157,14 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, kinds, w
     const inputBag = buildingBags.find((b) => b.equipee?.key == 0);
     const outputBag = buildingBags.find((b) => b.equipee?.key == 1);
 
-    const author = world?.players.find((p) => p.id === building?.kind?.owner?.id);
+    const author = world?.players.find((p) => p.id === building?.kind?.owner?.id) ?? {
+        addr: 'unknown',
+        name: { value: 'unknown' },
+    };
     const owner = world?.players.find((p) => p.id === building?.owner?.id);
 
     const name = building?.kind?.name?.value ?? 'Unnamed Building';
     const description = building?.kind?.description?.value;
-
-    const { q, r, s } = selectedTile ? getCoords(selectedTile) : { q: 0, r: 0, s: 0 };
-    const gooRates = selectedTile ? getGooRates(selectedTile) : [];
-    const gooRatesInNameOrder = [GOO_RED, GOO_GREEN, GOO_BLUE]
-        .map((idx) => gooRates.find((goo) => goo.index === idx))
-        .filter((goo) => !!goo);
 
     const content = (component?.content || []).find((c) => {
         if (mobileUnit) {
@@ -228,11 +225,9 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, kinds, w
                     </PluginContent>
                 )}
                 {selectedTile && <TileInventory tile={selectedTile} bags={world?.bags || []} />}
-                {author && (
-                    <span className="label" style={{ marginTop: '2rem' }}>
-                        <strong>AUTHOR:</strong> {author.name?.value ? author.name?.value : author.addr}
-                    </span>
-                )}
+                <span className="label" style={{ marginTop: '2rem' }}>
+                    <strong>AUTHOR:</strong> {author.name?.value ? author.name?.value : author.addr}
+                </span>
                 {owner && (
                     <span className="label">
                         <strong>OWNER:</strong> {owner.name?.value ? owner.name?.value : owner.addr}
@@ -313,7 +308,7 @@ const TileAvailable: FunctionComponent<TileAvailableProps> = ({ player, mobileUn
         <StyledTileInfoPanel>
             <div className="header">
                 <h3>{tileName}</h3>
-                <div className="description">{tileDescription}</div>
+                <div className="sub-title">{tileDescription}</div>
             </div>
             <div className="content">
                 {tileMobileUnits.length > 0 && (


### PR DESCRIPTION
## What
Removed duplicate information that appears on both the building panel, and tile panel.

### Before
![image](https://github.com/playmint/ds/assets/27741109/dc244d50-8928-4360-b6b0-e0030bcfd5a9)

### After
![image](https://github.com/playmint/ds/assets/27741109/1c607709-fed2-47c2-aa2a-2f996593c47c)


## Why
The issue that the information is repeated in these two panels was pointed out during the last playtest. This solves that problem, and helps reduce the overall screenspace the UI on the right is taking up.