### PR TITLE
Hexcraft: model now changes 1 block south of the HQ

### DIFF
--- a/contracts/src/maps/hexcraft/hc_kinds/game/hc_g_config/js/Headquarter.js
+++ b/contracts/src/maps/hexcraft/hc_kinds/game/hc_g_config/js/Headquarter.js
@@ -383,7 +383,7 @@ function distance(tileCoords, nextTile) {
 }
 
 function inHexcraftArea(unitCoords, hqCoords){
-    const inRange = unitCoords[1] >= hqCoords[1] && unitCoords[1] <= hqCoords[1] + 18;
+    const inRange = unitCoords[1] >= hqCoords[1] - 1 && unitCoords[1] <= hqCoords[1] + 18;
     const hexcraftMiddleCoords = [hqCoords[0], hqCoords[1] + 9, hqCoords[2]];
     const d = distance(hexcraftMiddleCoords, unitCoords);
     const inDistance = d <= 20;


### PR DESCRIPTION
## What
This tile is now considered when setting the unit model:
![image](https://github.com/playmint/ds/assets/27741109/db77a996-cc90-40aa-b475-2abcd663b75d)


## Why
Previously, you could join from this tile, but your unit's model wouldn't change until you are in line, or above the HQ which confused some players.

## How
Added `- 1`:
```js
    const inRange = unitCoords[1] >= hqCoords[1] - 1 && unitCoords[1] <= hqCoords[1] + 18;
```

Resolves #1140 