### PR TITLE
Door colors

### DIFF
--- a/contracts/src/maps/example-gate/Gate/Gate.js
+++ b/contracts/src/maps/example-gate/Gate/Gate.js
@@ -9,10 +9,6 @@ export default async function update(state) {
     const selectedBuilding =
         selectedTile && getBuildingOnTile(state, selectedTile);
 
-    if (selectedBuilding) {
-        console.log(selectedBuilding);
-    }
-
     const hasGateKey =
         getItemBalance(
             getMobileUnit(state),

--- a/contracts/src/maps/example-gate/Gate/Gate.js
+++ b/contracts/src/maps/example-gate/Gate/Gate.js
@@ -41,7 +41,7 @@ export default async function update(state) {
             type: "building",
             key: "model",
             id: t.id,
-            value: hasGateKey ? "door-open-3" : "door-closed-3",
+            value: hasGateKey ? "door-open-5" : "door-closed-5",
         };
     });
 

--- a/contracts/src/maps/example-gate/Gate/Gate.js
+++ b/contracts/src/maps/example-gate/Gate/Gate.js
@@ -45,7 +45,7 @@ export default async function update(state) {
             type: "building",
             key: "model",
             id: t.id,
-            value: hasGateKey ? "door-open" : "door-closed",
+            value: hasGateKey ? "door-open-3" : "door-closed-3",
         };
     });
 

--- a/map/Assets/3D_Assets/Buildings_2.0/Door_with_key.fbx
+++ b/map/Assets/3D_Assets/Buildings_2.0/Door_with_key.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc1628761ad64bb0bb8027600e31159eebc89c552cfe7cbaf33a0b74465e3827
-size 113868
+oid sha256:82535ebf369ab59ef73bb5094197e498c11fd524bcff39c1479708b8806c46b7
+size 92476

--- a/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/door-closed.prefab
+++ b/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/door-closed.prefab
@@ -1,5 +1,88 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1248452329988901492
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3849213866047007797}
+  - component: {fileID: 8413386460918125167}
+  - component: {fileID: 7863436812862693195}
+  m_Layer: 8
+  m_Name: Door_Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3849213866047007797
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1248452329988901492}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1688472339520512918}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8413386460918125167
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1248452329988901492}
+  m_Mesh: {fileID: 2619086233303812490, guid: 93683cd402344bf46a005909f934a688, type: 3}
+--- !u!23 &7863436812862693195
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1248452329988901492}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 350e1b89b29f442e1ae981fd04ecfca4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2272075605432351405
 GameObject:
   m_ObjectHideFlags: 0
@@ -49,7 +132,92 @@ MonoBehaviour:
   - {fileID: 596492472480548837}
   - {fileID: 478257406168002876}
   - {fileID: 6066214423017262402}
-  outlineRenderers: []
+  outlineRenderers:
+  - {fileID: 5441027060010310005}
+  - {fileID: 7863436812862693195}
+--- !u!1 &7849957600487992347
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4209592306305568283}
+  - component: {fileID: 6602322085019095471}
+  - component: {fileID: 5441027060010310005}
+  m_Layer: 8
+  m_Name: DoorFrame_Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4209592306305568283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7849957600487992347}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.16645424, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8361367328068805330}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6602322085019095471
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7849957600487992347}
+  m_Mesh: {fileID: 6274059880062070182, guid: 93683cd402344bf46a005909f934a688, type: 3}
+--- !u!23 &5441027060010310005
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7849957600487992347}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 350e1b89b29f442e1ae981fd04ecfca4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &8323551742421910841
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -228,6 +396,12 @@ MeshRenderer:
 --- !u!23 &596492472480548837 stripped
 MeshRenderer:
   m_CorrespondingSourceObject: {fileID: -305091885687274788, guid: 93683cd402344bf46a005909f934a688,
+    type: 3}
+  m_PrefabInstance: {fileID: 8323551742421910841}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1688472339520512918 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -1950733119399844177, guid: 93683cd402344bf46a005909f934a688,
     type: 3}
   m_PrefabInstance: {fileID: 8323551742421910841}
   m_PrefabAsset: {fileID: 0}

--- a/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/door-closed.prefab
+++ b/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/door-closed.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3429606118400950070}
+  - component: {fileID: 8043188209079292028}
   m_Layer: 0
   m_Name: door-closed
   m_TagString: Untagged
@@ -32,6 +33,23 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8043188209079292028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2272075605432351405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d5a9d936fda7475185e38b61b144a5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  renderers:
+  - {fileID: 596492472480548837}
+  - {fileID: 478257406168002876}
+  - {fileID: 6066214423017262402}
+  outlineRenderers: []
 --- !u!1001 &8323551742421910841
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -201,6 +219,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93683cd402344bf46a005909f934a688, type: 3}
+--- !u!23 &478257406168002876 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 8439796992618771461, guid: 93683cd402344bf46a005909f934a688,
+    type: 3}
+  m_PrefabInstance: {fileID: 8323551742421910841}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &596492472480548837 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -305091885687274788, guid: 93683cd402344bf46a005909f934a688,
+    type: 3}
+  m_PrefabInstance: {fileID: 8323551742421910841}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &6066214423017262402 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 2858861989129603195, guid: 93683cd402344bf46a005909f934a688,
+    type: 3}
+  m_PrefabInstance: {fileID: 8323551742421910841}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8361367328068805330 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 93683cd402344bf46a005909f934a688,

--- a/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/door-open.prefab
+++ b/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/door-open.prefab
@@ -49,7 +49,175 @@ MonoBehaviour:
   - {fileID: 1991224288655761114}
   - {fileID: 1532923568793774083}
   - {fileID: 5173106199580284029}
-  outlineRenderers: []
+  outlineRenderers:
+  - {fileID: 7760524886026700534}
+  - {fileID: 3365161248111641091}
+--- !u!1 &4555694264721137549
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6687951568114690903}
+  - component: {fileID: 2571218216000519703}
+  - component: {fileID: 7760524886026700534}
+  m_Layer: 8
+  m_Name: DoorFrame_Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6687951568114690903
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4555694264721137549}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.16645424, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7488534030460664813}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2571218216000519703
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4555694264721137549}
+  m_Mesh: {fileID: 6274059880062070182, guid: 93683cd402344bf46a005909f934a688, type: 3}
+--- !u!23 &7760524886026700534
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4555694264721137549}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 350e1b89b29f442e1ae981fd04ecfca4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &6478090481555264686
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 565192802660018519}
+  - component: {fileID: 7441887935787567172}
+  - component: {fileID: 3365161248111641091}
+  m_Layer: 8
+  m_Name: Door_Outline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &565192802660018519
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6478090481555264686}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 327564215434902185}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: -113.809, z: 0}
+--- !u!33 &7441887935787567172
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6478090481555264686}
+  m_Mesh: {fileID: 2619086233303812490, guid: 93683cd402344bf46a005909f934a688, type: 3}
+--- !u!23 &3365161248111641091
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6478090481555264686}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 350e1b89b29f442e1ae981fd04ecfca4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1001 &6946282885183003654
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -219,6 +387,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93683cd402344bf46a005909f934a688, type: 3}
+--- !u!4 &327564215434902185 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -1950733119399844177, guid: 93683cd402344bf46a005909f934a688,
+    type: 3}
+  m_PrefabInstance: {fileID: 6946282885183003654}
+  m_PrefabAsset: {fileID: 0}
 --- !u!23 &1532923568793774083 stripped
 MeshRenderer:
   m_CorrespondingSourceObject: {fileID: 8439796992618771461, guid: 93683cd402344bf46a005909f934a688,

--- a/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/door-open.prefab
+++ b/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/door-open.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3429606118400950070}
+  - component: {fileID: 3583313024808537028}
   m_Layer: 0
   m_Name: door-open
   m_TagString: Untagged
@@ -32,6 +33,23 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3583313024808537028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2272075605432351405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d5a9d936fda7475185e38b61b144a5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  renderers:
+  - {fileID: 1991224288655761114}
+  - {fileID: 1532923568793774083}
+  - {fileID: 5173106199580284029}
+  outlineRenderers: []
 --- !u!1001 &6946282885183003654
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -201,6 +219,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 93683cd402344bf46a005909f934a688, type: 3}
+--- !u!23 &1532923568793774083 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 8439796992618771461, guid: 93683cd402344bf46a005909f934a688,
+    type: 3}
+  m_PrefabInstance: {fileID: 6946282885183003654}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &1991224288655761114 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -305091885687274788, guid: 93683cd402344bf46a005909f934a688,
+    type: 3}
+  m_PrefabInstance: {fileID: 6946282885183003654}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &5173106199580284029 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 2858861989129603195, guid: 93683cd402344bf46a005909f934a688,
+    type: 3}
+  m_PrefabInstance: {fileID: 6946282885183003654}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &7488534030460664813 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 93683cd402344bf46a005909f934a688,

--- a/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs
+++ b/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs
@@ -166,6 +166,8 @@ public class FactoryBuildingController : BaseComponentController<FactoryBuilding
             rend.material.SetColor("_DynamicColor", dynamicColor);
             rend.material.SetColor("_DynamicShadowColor", shadowColor);
         }
+
+        _blocks.Add(controller);
     }
 
     void DestoryPreviousModels()

--- a/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs
+++ b/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs
@@ -77,11 +77,11 @@ public class FactoryBuildingController : BaseComponentController<FactoryBuilding
                     );
                     if (_currentAnimator != null && _nextData.model.Contains("open"))
                     {
-                        StartCoroutine(WaitForAnimationEndCR(prefab, "DoorUnlock"));
+                        StartCoroutine(WaitForAnimationEndCR(prefab, "DoorUnlock", dynamicColor, shadowColor));
                     }
                     else
                     {
-                        SwapModels(prefab);
+                        SwapModels(prefab, dynamicColor, shadowColor);
                     }
                 }
                 else
@@ -143,7 +143,7 @@ public class FactoryBuildingController : BaseComponentController<FactoryBuilding
         _prevData = _nextData;
     }
 
-    private IEnumerator WaitForAnimationEndCR(GameObject nextModel, string animName)
+    private IEnumerator WaitForAnimationEndCR(GameObject nextModel, string animName, Color dynamicColor, Color shadowColor)
     {
         _currentAnimator.Play(animName);
         yield return null;
@@ -151,16 +151,21 @@ public class FactoryBuildingController : BaseComponentController<FactoryBuilding
         {
             yield return null;
         }
-        SwapModels(nextModel);
+        SwapModels(nextModel, dynamicColor, shadowColor);
         yield return null;
     }
 
-    void SwapModels(GameObject nextModel)
+    void SwapModels(GameObject nextModel, Color dynamicColor, Color shadowColor)
     {
         DestoryPreviousModels();
-        Instantiate(nextModel, stackPositions[0]).transform
-            .GetChild(0)
-            .TryGetComponent(out _currentAnimator);
+        FactoryBuildingBlockController controller = Instantiate(nextModel, stackPositions[0]).GetComponent<FactoryBuildingBlockController>();
+        controller.transform.GetChild(0).TryGetComponent(out _currentAnimator);
+
+        foreach (Renderer rend in controller.renderers)
+        {
+            rend.material.SetColor("_DynamicColor", dynamicColor);
+            rend.material.SetColor("_DynamicShadowColor", shadowColor);
+        }
     }
 
     void DestoryPreviousModels()

--- a/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs
+++ b/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs
@@ -77,6 +77,7 @@ public class FactoryBuildingController : BaseComponentController<FactoryBuilding
                     );
                     if (_currentAnimator != null && _nextData.model.Contains("open"))
                     {
+                        StopAllCoroutines();
                         StartCoroutine(
                             WaitForAnimationEndCR(prefab, "DoorUnlock", dynamicColor, shadowColor)
                         );

--- a/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs
+++ b/map/Assets/Scripts/Components/FactoryBuilding/FactoryBuildingController.cs
@@ -77,7 +77,9 @@ public class FactoryBuildingController : BaseComponentController<FactoryBuilding
                     );
                     if (_currentAnimator != null && _nextData.model.Contains("open"))
                     {
-                        StartCoroutine(WaitForAnimationEndCR(prefab, "DoorUnlock", dynamicColor, shadowColor));
+                        StartCoroutine(
+                            WaitForAnimationEndCR(prefab, "DoorUnlock", dynamicColor, shadowColor)
+                        );
                     }
                     else
                     {
@@ -143,7 +145,12 @@ public class FactoryBuildingController : BaseComponentController<FactoryBuilding
         _prevData = _nextData;
     }
 
-    private IEnumerator WaitForAnimationEndCR(GameObject nextModel, string animName, Color dynamicColor, Color shadowColor)
+    private IEnumerator WaitForAnimationEndCR(
+        GameObject nextModel,
+        string animName,
+        Color dynamicColor,
+        Color shadowColor
+    )
     {
         _currentAnimator.Play(animName);
         yield return null;
@@ -158,7 +165,8 @@ public class FactoryBuildingController : BaseComponentController<FactoryBuilding
     void SwapModels(GameObject nextModel, Color dynamicColor, Color shadowColor)
     {
         DestoryPreviousModels();
-        FactoryBuildingBlockController controller = Instantiate(nextModel, stackPositions[0]).GetComponent<FactoryBuildingBlockController>();
+        FactoryBuildingBlockController controller = Instantiate(nextModel, stackPositions[0])
+            .GetComponent<FactoryBuildingBlockController>();
         controller.transform.GetChild(0).TryGetComponent(out _currentAnimator);
 
         foreach (Renderer rend in controller.renderers)


### PR DESCRIPTION
This PR adds the ability to assign different colours to the door models.
It also adds the missing highlight and outline features to the door model, so that it behaves as expected.

If you're not controlling the door model in js, the door will use the color value assigned in its yaml.
However, if you're swapping the door model in js to open and close it, you need to add the colour ID value to the end of the model name when you're controlling the model swap.

For example, instead of swapping to "door-open", you instead swap to "door-open-5" to assign the 5th colour ID (purple in this case) to the door model.

There's an example of this behaviour in the 'example-gate' map.