### PR TITLE
Rockaway bug fixes

### DIFF
--- a/contracts/src/maps/croissant/maps/labyrinth/room_4.yaml
+++ b/contracts/src/maps/croissant/maps/labyrinth/room_4.yaml
@@ -1,7 +1,7 @@
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 21
     - -27
@@ -10,7 +10,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 20
     - -27
@@ -19,7 +19,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 19
     - -26
@@ -28,7 +28,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 19
     - -27
@@ -37,7 +37,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Large Rocks
+  name: Large Boulders
   location:
     - 20
     - -28
@@ -46,7 +46,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 21
     - -28
@@ -55,7 +55,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Large Rocks
+  name: Large Boulders
   location:
     - 22
     - -28
@@ -64,7 +64,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 23
     - -28
@@ -73,7 +73,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 22
     - -29
@@ -82,7 +82,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 20
     - -29
@@ -91,7 +91,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location:
     - 21
     - -30
@@ -100,7 +100,7 @@ spec:
 ---
 kind: Building
 spec:
-  name: Large Rocks
+  name: Large Boulders
   location:
     - 22
     - -30
@@ -109,9 +109,8 @@ spec:
 ---
 kind: Building
 spec:
-  name: Large Rocks
+  name: Large Boulders
   location:
     - 20
     - -26
     - 6
-

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/LabyrinthCore.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/LabyrinthCore.sol
@@ -21,18 +21,36 @@ contract LabyrinthCore is BuildingKind {
         // Crafting the Playtest Pass
         ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
 
+        // Get location of buildingInstance
+        State state = ds.getState();
+        bytes24 buildingTile = state.getFixedLocation(buildingInstance);
+        int16 coreQ = int16(int192(uint192(buildingTile) >> 32));
+        int16 coreR = int16(int192(uint192(buildingTile) >> 16));
+        int16 coreS = int16(int192(uint192(buildingTile)));
+
         // resetting the map
         // rocks at room 4
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, 11, -10, -1)));
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, 13, -12, -1)));
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, 13, -14, 1)));
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, 11, -12, 1)));
+        ds.getDispatcher().dispatch(
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -4, coreS + -1))
+        ); // 11, -10, -1
+        ds.getDispatcher().dispatch(
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -6, coreS + -1))
+        ); // 13, -12, -1
+        ds.getDispatcher().dispatch(
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -8, coreS + 1))
+        ); // 13, -14, 1
+        ds.getDispatcher().dispatch(
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -6, coreS + 1))
+        ); // 11, -12, 1
         //crusher at room 5
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_CRUSHER, 6, -12, 6)));
+        ds.getDispatcher().dispatch(
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_CRUSHER, coreQ + 0, coreR + -6, coreS + 6))
+        ); // 6, -12, 6
+
         //items at room 3
-        int16 q = 14;
-        int16 r = -7;
-        int16 s = -7;
+        int16 q = coreQ + 8; // 14
+        int16 r = coreR + -1; // -7
+        int16 s = coreS + -7; // -7
         bytes24 bagId = bytes24(abi.encodePacked(Kind.Bag.selector, uint96(0), int16(0), q, r, s));
         bytes24 tileId = bytes24(abi.encodePacked(Kind.Tile.selector, uint96(0), int16(0), q, r, s));
         bytes24[] memory items = new bytes24[](4);
@@ -48,87 +66,5 @@ contract LabyrinthCore is BuildingKind {
         ds.getDispatcher().dispatch(
             abi.encodeCall(Actions.DEV_SPAWN_BAG, (bagId, address(0), tileId, 0, items, balances))
         );
-    }
-
-    // version of use that restricts crafting to building owner, author or allow list
-    // these restrictions will not be reflected in the UI unless you make
-    // similar changes in BasicFactory.js
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public override {
-        State state = GetState(ds);
-        CheckIsFriendlyUnit(state, actor, buildingInstance);
-
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
-    }*/
-
-    // version of use that restricts crafting to units carrying a certain item
-    /*function use(Game ds, bytes24 buildingInstance, bytes24 actor, bytes memory ) public override {
-        // require carrying an idCard
-        // you can change idCardItemId to another item id
-        CheckIsCarryingItem(state, actor, idCardItemId);
-    
-        ds.getDispatcher().dispatch(abi.encodeCall(Actions.CRAFT, (buildingInstance)));
-    }*/
-
-    function GetState(Game ds) internal returns (State) {
-        return ds.getState();
-    }
-
-    function GetBuildingOwner(State state, bytes24 buildingInstance) internal view returns (bytes24) {
-        return state.getOwner(buildingInstance);
-    }
-
-    function GetBuildingAuthor(State state, bytes24 buildingInstance) internal view returns (bytes24) {
-        bytes24 buildingKind = state.getBuildingKind(buildingInstance);
-        return state.getOwner(buildingKind);
-    }
-
-    function CheckIsFriendlyUnit(State state, bytes24 actor, bytes24 buildingInstance) internal view {
-        require(
-            UnitOwnsBuilding(state, actor, buildingInstance) || UnitAuthoredBuilding(state, actor, buildingInstance)
-                || UnitOwnedByFriendlyPlayer(state, actor),
-            "Unit does not have permission to use this building"
-        );
-    }
-
-    function UnitOwnsBuilding(State state, bytes24 actor, bytes24 buildingInstance) internal view returns (bool) {
-        return state.getOwner(actor) == GetBuildingOwner(state, buildingInstance);
-    }
-
-    function UnitAuthoredBuilding(State state, bytes24 actor, bytes24 buildingInstance) internal view returns (bool) {
-        return state.getOwner(actor) == GetBuildingAuthor(state, buildingInstance);
-    }
-
-    address[] private friendlyPlayerAddresses = [0x402462EefC217bf2cf4E6814395E1b61EA4c43F7];
-
-    function UnitOwnedByFriendlyPlayer(State state, bytes24 actor) internal view returns (bool) {
-        address ownerAddress = state.getOwnerAddress(actor);
-        for (uint256 i = 0; i < friendlyPlayerAddresses.length; i++) {
-            if (friendlyPlayerAddresses[i] == ownerAddress) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    // use cli command 'ds get items' for all current possible ids.
-    bytes24 idCardItemId = 0x6a7a67f0b29554460000000100000064000000640000004c;
-
-    function CheckIsCarryingItem(State state, bytes24 actor, bytes24 item) internal view {
-        require((UnitIsCarryingItem(state, actor, item)), "Unit must be carrying specified item");
-    }
-
-    function UnitIsCarryingItem(State state, bytes24 actor, bytes24 item) internal view returns (bool) {
-        for (uint8 bagIndex = 0; bagIndex < 2; bagIndex++) {
-            bytes24 bag = state.getEquipSlot(actor, bagIndex);
-            if (bag != 0) {
-                for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
     }
 }

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/LabyrinthCore.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/LabyrinthCore.sol
@@ -11,7 +11,7 @@ using Schema for State;
 
 contract LabyrinthCore is BuildingKind {
     // for respawn
-    bytes24 constant _LARGE_ROCKS = 0xbe92755c0000000000000000bdcf2b5d0000000000000001;
+    bytes24 constant _LARGE_ROCKS = 0xbe92755c0000000000000000d4c1c6880000000000000001;
     bytes24 constant _CRUSHER = 0xbe92755c0000000000000000e92c4edd0000000000000001;
     bytes24 constant sword = 0x6a7a67f01df41ea10000000000000001000000010000001e;
     bytes24 constant shield = 0x6a7a67f0ab4f7a160000000000000014000000280000000a;

--- a/contracts/src/maps/labyrinth/kinds/custom/blockers.yaml
+++ b/contracts/src/maps/labyrinth/kinds/custom/blockers.yaml
@@ -1,6 +1,7 @@
+---
 kind: BuildingKind
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   category: blocker
   model: rocksLarge
   materials:
@@ -10,3 +11,17 @@ spec:
       quantity: 100
     - name: Red Goo
       quantity: 100
+
+---
+kind: BuildingKind
+spec:
+  name: Large Boulders
+  category: blocker
+  model: rocksLarge
+  materials:
+    - name: Green Goo
+      quantity: 100
+    - name: Blue Goo
+      quantity: 10
+    - name: Red Goo
+      quantity: 20

--- a/contracts/src/maps/labyrinth/rooms/room_4.yaml
+++ b/contracts/src/maps/labyrinth/rooms/room_4.yaml
@@ -1,75 +1,75 @@
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [12, -11, -1]
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [11, -11, 0]
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [10, -10, 0]
 
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [10, -11, 1]
 
 ---
 kind: Building
 spec:
-  name: Large Rocks
+  name: Large Boulders
   location: [11, -12, 1]
 
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [12, -12, 0]
 
 ---
 kind: Building
 spec:
-  name: Large Rocks
+  name: Large Boulders
   location: [13, -12, -1]
 
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [14, -12, -2]
 
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [13, -13, 0]
 
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [11, -13, 2]
 
 ---
 kind: Building
 spec:
-  name: Very Large Rocks
+  name: Very Large Boulders
   location: [12, -14, 2]
 
 ---
 kind: Building
 spec:
-  name: Large Rocks
+  name: Large Boulders
   location: [13, -14, 1]
 
 ---
 kind: Building
 spec:
-  name: Large Rocks
+  name: Large Boulders
   location: [11, -10, -1]


### PR DESCRIPTION
# What

- Fixed resetting of the map by relatively positioning buildings / bags from the Labyrinth Core building
- Fixed problem where the croissant version of Labyrinth was using the common version of Large Rocks. The common version has lower stats which makes the game uncompletable so I have added the Large rocks to their custom.yaml and renamed both very large and large rocks to 'boulders' so they don't clash.
- Removed all the unused functions from LabyrinthCore just as a tidy up