### PR TITLE
Key check bug fix for labyrinth

### DIFF
--- a/contracts/src/maps/labyrinth/kinds/buildings/Gates/Gate.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/Gates/Gate.sol
@@ -51,7 +51,7 @@ abstract contract Gate is BuildingKind {
             for (itemSlot = 0; itemSlot < 4; itemSlot++) {
                 bytes24 bagItemId;
                 (bagItemId, balance) = state.getItemSlot(bagId, itemSlot);
-                if (bagItemId == itemId) {
+                if (bagItemId == itemId && balance > 0) {
                     // Found item
                     return (bagSlot, itemSlot, balance);
                 }


### PR DESCRIPTION
### What
Moving a key from unit inventory to wallet inventory and back could break the labyrinth key check code if using a different slot when moving it back.

This is fixed.

### How
In the gate solidity code, we now confirm an item in a slot actually has a balance before declaring it found.

This is becessary because there is a bug where an item removed from a slot can leave a 0 balance item entry for that item.

fixes #1123 

before:
https://github.com/playmint/ds/assets/90266137/7eb13c23-a97d-4b47-addd-b410d7c736ec

after:
https://github.com/playmint/ds/assets/90266137/229b7e36-cf81-44e9-a652-04eeecce06a1

