### PR TITLE
Duck Burger - Croissant: Moved Display Buildings Down

### DIFF
--- a/contracts/src/maps/croissant/map.yaml
+++ b/contracts/src/maps/croissant/map.yaml
@@ -39,7 +39,7 @@ spec:
 kind: Building
 spec:
   name: Burger Display Building
-  location: [ 15, -2, -13 ]
+  location: [ 19, -10, -9 ]
 
 ---
 kind: Tile
@@ -51,7 +51,7 @@ spec:
 kind: Building
 spec:
   name: Countdown Building
-  location: [ 16, -2, -14 ]
+  location: [ 20, -10, -10 ]
 
 ---
 kind: Tile
@@ -63,7 +63,7 @@ spec:
 kind: Building
 spec:
   name: Duck Display Building
-  location: [ 17, -2, -15 ]
+  location: [ 21, -10, -11 ]
 
 ---
 kind: Tile


### PR DESCRIPTION
## What
The duck burger display buildings have been moved to the bottom of the arena in the croissant map.
![image](https://github.com/playmint/ds/assets/27741109/f9cad0b2-eb09-4a68-8fbb-069e25c45190)

## Why
Because the displays on these buildings would previously become hidden when there were Weak Ducks/Burgers placed in front of them.

## How
Edited locations in the croissant map.yaml

Resolves #1137 