### PR TITLE
Item tooltip positioning falling off top of screen

### DIFF
--- a/frontend/src/plugins/tooltip/tooltip.styles.ts
+++ b/frontend/src/plugins/tooltip/tooltip.styles.ts
@@ -10,7 +10,9 @@ export const TooltipWrapper = styled.div`
     position: relative;
 `;
 
-export const TooltipTip = styled.div<{ direction?: 'top' | 'right' | 'bottom' | 'left' }>`
+export const TooltipTip = styled.div<
+    { direction?: 'top' | 'right' | 'bottom' | 'left' } & React.HTMLAttributes<HTMLDivElement>
+>`
     position: absolute;
     border-radius: 4px;
     left: 50%;
@@ -70,10 +72,10 @@ export const TooltipTip = styled.div<{ direction?: 'top' | 'right' | 'bottom' | 
   ${(props) =>
         props.direction === 'bottom' &&
         css`
-            bottom: calc(${tooltipMargin} * -1);
-
+            transform: translate(-50%, calc(100% - 20px));
             &::before {
-                bottom: 100%;
+                top: 0;
+                transform: translateY(-100%);
                 border-bottom-color: ${tooltipBackgroundColor};
             }
         `}

--- a/frontend/src/plugins/tooltip/tooltip.tsx
+++ b/frontend/src/plugins/tooltip/tooltip.tsx
@@ -36,8 +36,6 @@ const Tooltip: React.FC<TooltipProps> = ({ children, delay = 400, direction = 't
         }
 
         const rect = tooltipRef.current.getBoundingClientRect();
-        // console.log('rect:', rect);
-
         if (rect.y < 0 && tooltipDirection === 'top') {
             setTooltipDirection('bottom');
         }

--- a/frontend/src/plugins/tooltip/tooltip.tsx
+++ b/frontend/src/plugins/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode } from 'react';
+import React, { useState, ReactNode, useEffect, useRef } from 'react';
 import { TooltipWrapper, TooltipTip } from './tooltip.styles';
 
 interface TooltipProps {
@@ -12,6 +12,8 @@ const Tooltip: React.FC<TooltipProps> = ({ children, delay = 400, direction = 't
     let timeout: NodeJS.Timeout;
 
     const [active, setActive] = useState<boolean>(false);
+    const tooltipRef = useRef<HTMLDivElement>(null);
+    const [tooltipDirection, setTooltipDirection] = useState<'top' | 'right' | 'bottom' | 'left'>(direction);
 
     const showTip = () => {
         timeout = setTimeout(() => {
@@ -24,11 +26,32 @@ const Tooltip: React.FC<TooltipProps> = ({ children, delay = 400, direction = 't
         setActive(false);
     };
 
+    useEffect(() => {
+        if (!active) {
+            return;
+        }
+
+        if (!tooltipRef.current) {
+            return;
+        }
+
+        const rect = tooltipRef.current.getBoundingClientRect();
+        // console.log('rect:', rect);
+
+        if (rect.y < 0 && tooltipDirection === 'top') {
+            setTooltipDirection('bottom');
+        }
+    }, [active, tooltipDirection]);
+
     return (
         <TooltipWrapper onMouseEnter={showTip} onMouseLeave={hideTip}>
             <span>
                 {children}
-                {active && <TooltipTip direction={direction}>{content}</TooltipTip>}
+                {active && (
+                    <TooltipTip ref={tooltipRef} direction={tooltipDirection}>
+                        {content}
+                    </TooltipTip>
+                )}
             </span>
         </TooltipWrapper>
     );


### PR DESCRIPTION
# What

- If an item tooltip is set to be `top` and it falls off the screen, the position will be changed to `bottom`
- Fixed CSS used for 'bottom' position as the pointer and tooltip box were not in the expected place. I think something had bit rotted in the CSS and as we never used bottom positioning we didn't realise it had stopped working

<img width="253" alt="image" src="https://github.com/playmint/ds/assets/51167118/06002977-76fd-49ce-9196-84777ff35c49">

# Why

Item tooltips were falling off the top of the screen making them unreadable. This was a problem for the Labyrinth game as item names are important to solve one the puzzle rooms

Fixes #1118 