### PR TITLE
Duck Burger: Default frontend time to 3 minutes

### DIFF
--- a/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
+++ b/contracts/src/example-plugins/DuckBurger/DuckBurgerHQ.js
@@ -10,7 +10,7 @@ const burgerBuildingTopId = "17";
 const burgerCounterKindId = "Burger Display Building";
 const duckCounterKindId = "Duck Display Building";
 const countdownBuildingKindId = "Countdown Building";
-const countdownTotalTime = 60000;
+const countdownTotalTime = 60000 * 3;
 
 let burgerCounter;
 let duckCounter;


### PR DESCRIPTION
## What
Duck Burger Countdown building default display time changed from 1 minute to 3 minutes.
![image](https://github.com/playmint/ds/assets/27741109/e79bbe69-0883-406f-8ec1-68c092932e91)

## Why
To match it with the actual Duck Burger game time which is set in the solidity code.

## How
By modifying `countdownTotalTime` in `DuckBurgerHQ.js`
```js
const countdownTotalTime = 60000 * 3;
```

## Notes
During kick-off, we thought we may have had to modify all the display building code to take `duration` instead of `endTime` and handle that slightly differently to allow the plugin to set it dynamically. However, it's already able to dynamically set the default time, so no further change is necessary.

Resolves #1138 