### PR TITLE
Added 'Facing Direction' to buildings

### DIFF
--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { WorldStateFragment, getCoords } from '@downstream/core';
 import { pipe, take, toPromise } from 'wonka';
-import { BiomeTypes, Manifest, Slot } from '../utils/manifest';
+import { BiomeTypes, FacingDirectionTypes, Manifest, Slot } from '../utils/manifest';
 import { BuildingKindFragment, GetAvailableBuildingKindsDocument, GetWorldDocument } from '@downstream/core/src/gql/graphql';
 
 const SLOT_FRAGMENT = `
@@ -110,7 +110,7 @@ const nodeToManifest = (node): z.infer<typeof Manifest> => {
             .map((l) => getCoords(l.tile))
             .map(({ q, r, s }) => [q, r, s])
             .find(() => true);
-        const spec = { name: buildingKindName, location };
+        const spec = { name: buildingKindName, location, facingDirection: node.facingDirection?.value || FacingDirectionTypes[0] };
         const status = { owner, id };
         return { kind, spec, status };
     } else if (node.kind == 'MobileUnit') {

--- a/cli/src/commands/test.ts
+++ b/cli/src/commands/test.ts
@@ -4,6 +4,7 @@ import { CompoundKeyEncoder, NodeSelectors, getCoords } from "@downstream/core";
 import util from 'node:util';
 import { spawn } from 'node:child_process';
 import { getWorld } from './get';
+import { FacingDirectionKind } from '@downstream/core';
 
 const spawnAsync = util.promisify(spawn);
 
@@ -95,7 +96,7 @@ const chaosUnit = {
                 const world = await getWorld(ctx);
                 const buildingOnTargetTile = getBuildingOnTile(world.buildings, targetTileID);
                 if (typeof buildingOnTargetTile === 'undefined'){
-                    await player.dispatch({ name: 'DEV_SPAWN_BUILDING', args: [selectedBuilding, q, r, s] }).then(res => res.wait());
+                    await player.dispatch({ name: 'DEV_SPAWN_BUILDING', args: [selectedBuilding, q, r, s, FacingDirectionKind.RIGHT] }).then(res => res.wait());
                 }
             }
             await sleep(Math.floor(Math.random() * 1000));

--- a/cli/src/utils/applier.ts
+++ b/cli/src/utils/applier.ts
@@ -10,6 +10,7 @@ import {
     ContractSource,
     ManifestDocument,
     Slot,
+    FacingDirectionTypes,
 } from '../utils/manifest';
 
 const null24bytes = '0x000000000000000000000000000000000000000000000000';
@@ -456,6 +457,7 @@ export const getOpsForManifests = async (
                     args: [
                         getBuildingKindIDByName(existingBuildingKinds, pendingBuildingKinds, spec.name),
                         ...spec.location,
+                        FacingDirectionTypes.indexOf(spec.facingDirection),
                     ],
                 },
             ],

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -165,9 +165,12 @@ export const BuildingKind = z.object({
         .optional(),
 });
 
+export const FacingDirectionTypes = ['RIGHT', 'LEFT'] as const;
+
 export const BuildingSpec = z.object({
     name: Name,
     location: Coords,
+    facingDirection: z.enum(FacingDirectionTypes).default(FacingDirectionTypes[0]),
 });
 
 export const Building = z.object({

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -78,6 +78,7 @@ contract DownstreamGame is BaseGame {
         state.registerEdgeType(Rel.Output.selector, "Output", WeightKind.UINT64);
         state.registerEdgeType(Rel.Material.selector, "Material", WeightKind.UINT64);
         state.registerEdgeType(Rel.Biome.selector, "Biome", WeightKind.UINT64);
+        state.registerEdgeType(Rel.FacingDirection.selector, "FacingDirection", WeightKind.UINT64);
         state.registerEdgeType(Rel.Equip.selector, "Equip", WeightKind.UINT64);
         state.registerEdgeType(Rel.Is.selector, "Is", WeightKind.UINT64);
         state.registerEdgeType(Rel.Implementation.selector, "Implementation", WeightKind.UINT64);

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -170,7 +170,8 @@ interface Actions {
     function DEV_SPAWN_TILE(int16 q, int16 r, int16 s) external;
 
     // spawn a building at any location
-    function DEV_SPAWN_BUILDING(bytes24 buildingKind, int16 q, int16 r, int16 s, FacingDirectionKind facingDirection) external;
+    function DEV_SPAWN_BUILDING(bytes24 buildingKind, int16 q, int16 r, int16 s, FacingDirectionKind facingDirection)
+        external;
 
     // spawn a bag with resources equip somewhere
     function DEV_SPAWN_BAG(

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -9,6 +9,11 @@ enum BiomeKind {
     DISCOVERED
 }
 
+enum FacingDirectionKind {
+    RIGHT,
+    LEFT
+}
+
 struct CombatAction {
     CombatActionKind kind;
     bytes24 entityID; // Can be mobileUnit or building
@@ -165,7 +170,7 @@ interface Actions {
     function DEV_SPAWN_TILE(int16 q, int16 r, int16 s) external;
 
     // spawn a building at any location
-    function DEV_SPAWN_BUILDING(bytes24 buildingKind, int16 q, int16 r, int16 s) external;
+    function DEV_SPAWN_BUILDING(bytes24 buildingKind, int16 q, int16 r, int16 s, FacingDirectionKind facingDirection) external;
 
     // spawn a bag with resources equip somewhere
     function DEV_SPAWN_BAG(

--- a/contracts/src/maps/croissant/maps/labyrinth/room_1.yaml
+++ b/contracts/src/maps/croissant/maps/labyrinth/room_1.yaml
@@ -15,6 +15,7 @@ spec:
     - 12
     - -16
     - 4
+  facingDirection: LEFT
 
 ---
 kind: Bag

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/LabyrinthCore.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/LabyrinthCore.sol
@@ -47,20 +47,30 @@ contract LabyrinthCore is ILabyrinthCore, BuildingKind {
         // resetting the map
         // rocks at room 4
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -4, coreS + -1, FacingDirectionKind.RIGHT))
+            abi.encodeCall(
+                Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -4, coreS + -1, FacingDirectionKind.RIGHT)
+            )
         ); // 11, -10, -1
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -6, coreS + -1, FacingDirectionKind.RIGHT))
+            abi.encodeCall(
+                Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -6, coreS + -1, FacingDirectionKind.RIGHT)
+            )
         ); // 13, -12, -1
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -8, coreS + 1, FacingDirectionKind.RIGHT))
+            abi.encodeCall(
+                Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -8, coreS + 1, FacingDirectionKind.RIGHT)
+            )
         ); // 13, -14, 1
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -6, coreS + 1, FacingDirectionKind.RIGHT))
+            abi.encodeCall(
+                Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -6, coreS + 1, FacingDirectionKind.RIGHT)
+            )
         ); // 11, -12, 1
         //crusher at room 5
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_CRUSHER, coreQ + 0, coreR + -6, coreS + 6, FacingDirectionKind.RIGHT))
+            abi.encodeCall(
+                Actions.DEV_SPAWN_BUILDING, (_CRUSHER, coreQ + 0, coreR + -6, coreS + 6, FacingDirectionKind.RIGHT)
+            )
         ); // 6, -12, 6
 
         //items at room 3

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/LabyrinthCore.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/LabyrinthCore.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import {Game} from "cog/IGame.sol";
 import {State} from "cog/IState.sol";
 import {Schema, Kind} from "@ds/schema/Schema.sol";
-import {Actions} from "@ds/actions/Actions.sol";
+import {Actions, FacingDirectionKind} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
 import {ILabyrinthCore} from "./ILabyrinthCore.sol";
 
@@ -47,20 +47,20 @@ contract LabyrinthCore is ILabyrinthCore, BuildingKind {
         // resetting the map
         // rocks at room 4
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -4, coreS + -1))
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -4, coreS + -1, FacingDirectionKind.RIGHT))
         ); // 11, -10, -1
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -6, coreS + -1))
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -6, coreS + -1, FacingDirectionKind.RIGHT))
         ); // 13, -12, -1
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -8, coreS + 1))
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 7, coreR + -8, coreS + 1, FacingDirectionKind.RIGHT))
         ); // 13, -14, 1
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -6, coreS + 1))
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_LARGE_ROCKS, coreQ + 5, coreR + -6, coreS + 1, FacingDirectionKind.RIGHT))
         ); // 11, -12, 1
         //crusher at room 5
         ds.getDispatcher().dispatch(
-            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_CRUSHER, coreQ + 0, coreR + -6, coreS + 6))
+            abi.encodeCall(Actions.DEV_SPAWN_BUILDING, (_CRUSHER, coreQ + 0, coreR + -6, coreS + 6, FacingDirectionKind.RIGHT))
         ); // 6, -12, 6
 
         //items at room 3

--- a/contracts/src/maps/labyrinth/rooms/room_1.yaml
+++ b/contracts/src/maps/labyrinth/rooms/room_1.yaml
@@ -8,6 +8,7 @@ kind: Building
 spec:
   name: Iron Gate
   location: [3, 0, -3]
+  facingDirection: LEFT
 ---
 kind: Bag
 spec:

--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "cog/IState.sol";
 import "cog/IRule.sol";
 
-import {Schema, Node, BiomeKind, BuildingCategory, BuildingBlockNumKey, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
+import {Schema, Node, BiomeKind, FacingDirectionKind, BuildingCategory, BuildingBlockNumKey, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 
 using Schema for State;
@@ -50,8 +50,8 @@ contract CheatsRule is Rule {
         } else if (bytes4(action) == Actions.DEV_SPAWN_BUILDING.selector) {
             require(isCheatAllowed(ctx.sender), "DEV_SPAWN_BUILDING not allowed");
 
-            (bytes24 buildingKind, int16 q, int16 r, int16 s) = abi.decode(action[4:], (bytes24, int16, int16, int16));
-            _construct(state, ctx, buildingKind, q, r, s);
+            (bytes24 buildingKind, int16 q, int16 r, int16 s, FacingDirectionKind facingDirection) = abi.decode(action[4:], (bytes24, int16, int16, int16, FacingDirectionKind));
+            _construct(state, ctx, buildingKind, q, r, s, facingDirection);
         } else if (bytes4(action) == Actions.DEV_DISABLE_CHEATS.selector) {
             require(isCheatAllowed(ctx.sender), "DEV_DISABLE_CHEATS not allowed");
 
@@ -84,7 +84,7 @@ contract CheatsRule is Rule {
     }
 
     // allow constructing a building without any materials
-    function _construct(State state, Context calldata ctx, bytes24 buildingKind, int16 q, int16 r, int16 s) internal {
+    function _construct(State state, Context calldata ctx, bytes24 buildingKind, int16 q, int16 r, int16 s, FacingDirectionKind facingDirection) internal {
         _spawnTile(state, q, r, s);
         bytes24 targetTile = Node.Tile(0, q, r, s);
         bytes24 buildingInstance = Node.Building(0, q, r, s);
@@ -96,6 +96,8 @@ contract CheatsRule is Rule {
         bytes24 outputBag = Node.Bag(uint64(uint256(keccak256(abi.encode(buildingInstance, "output")))));
         state.setEquipSlot(buildingInstance, 0, inputBag);
         state.setEquipSlot(buildingInstance, 1, outputBag);
+
+        state.setFacingDirection(buildingInstance, facingDirection);
 
         // -- Category specific calls
 

--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -4,7 +4,15 @@ pragma solidity ^0.8.13;
 import "cog/IState.sol";
 import "cog/IRule.sol";
 
-import {Schema, Node, BiomeKind, FacingDirectionKind, BuildingCategory, BuildingBlockNumKey, DEFAULT_ZONE} from "@ds/schema/Schema.sol";
+import {
+    Schema,
+    Node,
+    BiomeKind,
+    FacingDirectionKind,
+    BuildingCategory,
+    BuildingBlockNumKey,
+    DEFAULT_ZONE
+} from "@ds/schema/Schema.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 
 using Schema for State;
@@ -50,7 +58,8 @@ contract CheatsRule is Rule {
         } else if (bytes4(action) == Actions.DEV_SPAWN_BUILDING.selector) {
             require(isCheatAllowed(ctx.sender), "DEV_SPAWN_BUILDING not allowed");
 
-            (bytes24 buildingKind, int16 q, int16 r, int16 s, FacingDirectionKind facingDirection) = abi.decode(action[4:], (bytes24, int16, int16, int16, FacingDirectionKind));
+            (bytes24 buildingKind, int16 q, int16 r, int16 s, FacingDirectionKind facingDirection) =
+                abi.decode(action[4:], (bytes24, int16, int16, int16, FacingDirectionKind));
             _construct(state, ctx, buildingKind, q, r, s, facingDirection);
         } else if (bytes4(action) == Actions.DEV_DISABLE_CHEATS.selector) {
             require(isCheatAllowed(ctx.sender), "DEV_DISABLE_CHEATS not allowed");
@@ -84,7 +93,15 @@ contract CheatsRule is Rule {
     }
 
     // allow constructing a building without any materials
-    function _construct(State state, Context calldata ctx, bytes24 buildingKind, int16 q, int16 r, int16 s, FacingDirectionKind facingDirection) internal {
+    function _construct(
+        State state,
+        Context calldata ctx,
+        bytes24 buildingKind,
+        int16 q,
+        int16 r,
+        int16 s,
+        FacingDirectionKind facingDirection
+    ) internal {
         _spawnTile(state, q, r, s);
         bytes24 targetTile = Node.Tile(0, q, r, s);
         bytes24 buildingInstance = Node.Building(0, q, r, s);

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -2,12 +2,13 @@
 pragma solidity ^0.8.13;
 
 import {State, CompoundKeyEncoder, CompoundKeyDecoder} from "cog/IState.sol";
-import {BiomeKind} from "@ds/actions/Actions.sol";
+import {BiomeKind, FacingDirectionKind} from "@ds/actions/Actions.sol";
 
 interface Rel {
     function Owner() external;
     function Location() external;
     function Biome() external;
+    function FacingDirection() external;
     function Balance() external;
     function Equip() external;
     function Is() external;
@@ -290,6 +291,15 @@ library Schema {
     function getBiome(State state, bytes24 node) internal view returns (BiomeKind) {
         (, uint160 biome) = state.get(Rel.Biome.selector, 0x0, node);
         return BiomeKind(uint8(biome));
+    }
+
+    function setFacingDirection(State state, bytes24 node, FacingDirectionKind facingDirection) internal {
+        return state.set(Rel.FacingDirection.selector, 0x0, node, 0x0, uint64(facingDirection));
+    }
+
+    function getFacingDirection(State state, bytes24 node) internal view returns (FacingDirectionKind) {
+        (, uint160 facingDirection) = state.get(Rel.FacingDirection.selector, 0x0, node);
+        return FacingDirectionKind(uint8(facingDirection));
     }
 
     function setOwner(State state, bytes24 node, bytes24 ownerNode) internal {

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -75,6 +75,11 @@ export enum BiomeKind {
     DISCOVERED = 1,
 }
 
+export enum FacingDirectionKind {
+    RIGHT = 0,
+    LEFT = 1,
+}
+
 export interface GameConfig {
     gameID: string;
     authMessage: (addr: string, ttl: number) => string;

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -105,6 +105,7 @@ fragment WorldBuilding on Node {
         name
         value
     }
+    facingDirection: value(match: { via: { rel: "FacingDirection" } }) # 0=RIGHT, 1=LEFT
 }
 
 fragment WorldCombatSession on Node {

--- a/frontend/src/components/map/Buildings.tsx
+++ b/frontend/src/components/map/Buildings.tsx
@@ -47,8 +47,6 @@ const getGooIndexFromBuildingOutput = (buildingKind?: BuildingKindFragment) => {
     return -1;
 };
 
-const lerp = (x, y, a) => x * (1 - a) + y * a;
-
 export const Buildings = memo(
     ({
         tiles,

--- a/frontend/src/components/map/Buildings.tsx
+++ b/frontend/src/components/map/Buildings.tsx
@@ -1,5 +1,5 @@
 import { BuildingCategory, getBuildingCategory } from '@app/helpers/building';
-import { GOO_BLUE, GOO_GREEN, GOO_RED, getTileHeightFromCoords, getUnscaledNoiseFromCoords } from '@app/helpers/tile';
+import { GOO_BLUE, GOO_GREEN, GOO_RED, getTileHeightFromCoords } from '@app/helpers/tile';
 import {
     BuildingKindFragment,
     FacingDirectionKind,

--- a/frontend/src/components/map/Buildings.tsx
+++ b/frontend/src/components/map/Buildings.tsx
@@ -2,6 +2,7 @@ import { BuildingCategory, getBuildingCategory } from '@app/helpers/building';
 import { GOO_BLUE, GOO_GREEN, GOO_RED, getTileHeightFromCoords, getUnscaledNoiseFromCoords } from '@app/helpers/tile';
 import {
     BuildingKindFragment,
+    FacingDirectionKind,
     PluginMapProperty,
     WorldBuildingFragment,
     WorldTileFragment,
@@ -74,7 +75,7 @@ export const Buildings = memo(
                     const coords = getCoords(b.location.tile);
                     const height = getTileHeightFromCoords(coords);
                     const selected = selectedElementID === b.id ? 'outline' : 'none';
-                    const rotation = lerp(-20, 20, 0.5 - getUnscaledNoiseFromCoords(coords));
+                    const rotation = b.facingDirection == FacingDirectionKind.RIGHT ? -30 : 30;
                     const tile = tiles.find(({ id }) => id === b.location?.tile.id);
                     const overrideModel = pluginBuildingProperties
                         .find((prop) => prop.id == b.id && prop.key == 'model')
@@ -162,7 +163,7 @@ export const Buildings = memo(
                                 id={b.id}
                                 height={height}
                                 model={overrideModel ? overrideModel : b.kind?.model?.value}
-                                rotation={-30}
+                                rotation={rotation}
                                 selected={selected}
                                 onPointerClick={onClickBuilding}
                                 {...coords}

--- a/frontend/src/pages/tile-fabricator.tsx
+++ b/frontend/src/pages/tile-fabricator.tsx
@@ -265,7 +265,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                             spec: {
                                 name: buildingKind.spec.name,
                                 location: t.location,
-                                facingDirection: FacingDirectionTypes[facing === 'RIGHT' ? 0 : 1],
+                                facingDirection: facing as (typeof FacingDirectionTypes)[number],
                             },
                         },
                     ];

--- a/frontend/src/pages/tile-fabricator.tsx
+++ b/frontend/src/pages/tile-fabricator.tsx
@@ -266,7 +266,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                             spec: {
                                 name: buildingKind.spec.name,
                                 location: t.location,
-                                facingDirection: FacingDirectionKind[facing],
+                                facingDirection: facing as FacingDirectionKind,
                             },
                         },
                     ];

--- a/frontend/src/pages/tile-fabricator.tsx
+++ b/frontend/src/pages/tile-fabricator.tsx
@@ -7,7 +7,7 @@ import { useConfig } from '@app/hooks/use-config';
 import { GameStateProvider } from '@app/hooks/use-game-state';
 import { useThrottle } from '@app/hooks/use-throttle';
 import { UnityMapProvider, useUnityMap } from '@app/hooks/use-unity-map';
-import { BuildingKind, Manifest, parseManifestDocuments } from '@downstream/cli/utils/manifest';
+import { BuildingKind, FacingDirectionTypes, Manifest, parseManifestDocuments } from '@downstream/cli/utils/manifest';
 import {
     BiomeKind,
     CompoundKeyEncoder,
@@ -265,7 +265,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                             spec: {
                                 name: buildingKind.spec.name,
                                 location: t.location,
-                                facingDirection: facing,
+                                facingDirection: FacingDirectionTypes[facing === 'RIGHT' ? 0 : 1],
                             },
                         },
                     ];

--- a/frontend/src/pages/tile-fabricator.tsx
+++ b/frontend/src/pages/tile-fabricator.tsx
@@ -10,6 +10,7 @@ import { UnityMapProvider, useUnityMap } from '@app/hooks/use-unity-map';
 import { BuildingKind, Manifest, parseManifestDocuments } from '@downstream/cli/utils/manifest';
 import {
     BiomeKind,
+    FacingDirectionKind,
     CompoundKeyEncoder,
     NodeSelectors,
     WorldBuildingFragment,
@@ -265,7 +266,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                             spec: {
                                 name: buildingKind.spec.name,
                                 location: t.location,
-                                facingDirection: facing,
+                                facingDirection: FacingDirectionKind[facing],
                             },
                         },
                     ];

--- a/frontend/src/pages/tile-fabricator.tsx
+++ b/frontend/src/pages/tile-fabricator.tsx
@@ -167,7 +167,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
     const [buildingKinds, setBuildingKinds] = useState<BuildingKindMap>(new Map());
     const { sendMessage, ready } = useUnityMap();
 
-    const [{ diameter, brush, labels }] = useControls(
+    const [{ diameter, brush, facing, labels }] = useControls(
         'Tiles',
         () => {
             return {
@@ -179,6 +179,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                             .sort()
                     ),
                 },
+                facing: { options: ['RIGHT', 'LEFT'] },
                 labels: false,
             };
         },
@@ -264,6 +265,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                             spec: {
                                 name: buildingKind.spec.name,
                                 location: t.location,
+                                facingDirection: facing,
                             },
                         },
                     ];
@@ -273,7 +275,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                 setManifests((prev) => new Map(prev.set(t.id, newManifestsForTile)));
             }
         },
-        [mouseDown, brush, buildingKinds, manifests]
+        [mouseDown, brush, facing, buildingKinds, manifests]
     );
 
     const onLoadManifests = useCallback(() => {

--- a/frontend/src/pages/tile-fabricator.tsx
+++ b/frontend/src/pages/tile-fabricator.tsx
@@ -10,7 +10,6 @@ import { UnityMapProvider, useUnityMap } from '@app/hooks/use-unity-map';
 import { BuildingKind, Manifest, parseManifestDocuments } from '@downstream/cli/utils/manifest';
 import {
     BiomeKind,
-    FacingDirectionKind,
     CompoundKeyEncoder,
     NodeSelectors,
     WorldBuildingFragment,
@@ -266,7 +265,7 @@ const TileFab: FunctionComponent<PageProps> = ({}: PageProps) => {
                             spec: {
                                 name: buildingKind.spec.name,
                                 location: t.location,
-                                facingDirection: facing as FacingDirectionKind,
+                                facingDirection: facing,
                             },
                         },
                     ];


### PR DESCRIPTION
This PR adds a way to control the rotation of buildings, while also aligning all buildings to a set direction by default.

It adds the concept of 'Facing Direction' which can have a value of either RIGHT or LEFT.
By default, all buildings face to the right of the screen, however this can be overridden in the map manifest on a per-instance basis. For example:
```
kind: Building
spec:
  name: Iron Gate
  location:
    - 12
    - -16
    - 4
  facingDirection: LEFT
``` 
I have added the above example to one of the buildings in the croissant labyrinth game, however I have not converted the gates to door models or applied correct rotations to the other gates.
