### PR TITLE
Labyrinth reset tower

### DIFF
--- a/contracts/src/maps/croissant/maps/labyrinth/room_1.yaml
+++ b/contracts/src/maps/croissant/maps/labyrinth/room_1.yaml
@@ -29,4 +29,4 @@ spec:
 kind: Building
 spec:
   name: Reset Tower
-  location: [9, -18, 9]
+  location: [7, -14, 7]

--- a/contracts/src/maps/croissant/maps/labyrinth/room_1.yaml
+++ b/contracts/src/maps/croissant/maps/labyrinth/room_1.yaml
@@ -25,3 +25,8 @@ spec:
     - 8
   items: []
 
+---
+kind: Building
+spec:
+  name: Reset Tower
+  location: [9, -18, 9]

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ILabyrinthCore.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ILabyrinthCore.sol
@@ -4,5 +4,5 @@ pragma solidity ^0.8.13;
 import {Game} from "cog/IGame.sol";
 
 interface ILabyrinthCore {
-    function reset(Game ds, bytes24 buildingInstance, bytes24 coreBuildingInstance) external;
+    function reset(Game ds, bytes24 coreBuildingInstance) external;
 }

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ILabyrinthCore.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ILabyrinthCore.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+
+interface ILabyrinthCore {
+    function reset(Game ds, bytes24 buildingInstance, bytes24 coreBuildingInstance) external;
+}

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.js
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.js
@@ -1,0 +1,163 @@
+import ds from "downstream";
+
+export default async function update(state) {
+    // uncomment this to browse the state object in browser console
+    // this will be logged when selecting a unit and then selecting an instance of this building
+    //logState(state);
+
+    const selectedTile = getSelectedTile(state);
+    const selectedBuilding =
+        selectedTile && getBuildingOnTile(state, selectedTile);
+
+    const reset = (values) => {
+        const mobileUnit = getMobileUnit(state);
+
+        if (!mobileUnit) {
+            console.log("no selected unit");
+            return;
+        }
+        const pswd = (values["input-password"] || "").toLowerCase();
+        console.log("Crafting with password:", pswd);
+        const payload = ds.encodeCall("function password(string pswd)", [pswd]);
+        console.log("Payload:", payload);
+
+        ds.dispatch({
+            name: "BUILDING_USE",
+            args: [selectedBuilding.id, mobileUnit.id, payload],
+        });
+
+        console.log("Reset dispatched");
+    };
+
+    const noop = () => {};
+
+    return {
+        version: 1,
+        components: [
+            {
+                id: "ResetTower",
+                type: "building",
+                content: [
+                    {
+                        id: "default",
+                        type: "inline",
+                        html:
+                            "<p>Labyrinth reset password:</p>" +
+                            '<p><input id="input-password" type="password" name="input-password"></input></p>',
+                        submit: (values) => {
+                            reset(values);
+                        },
+                        buttons: [
+                            {
+                                text: "Reset",
+                                type: "action",
+                                action: noop,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+function getMobileUnit(state) {
+    return state?.selected?.mobileUnit;
+}
+
+function getSelectedTile(state) {
+    const tiles = state?.selected?.tiles || {};
+    return tiles && tiles.length === 1 ? tiles[0] : undefined;
+}
+
+function getBuildingOnTile(state, tile) {
+    return (state?.world?.buildings || []).find(
+        (b) => tile && b.location?.tile?.id === tile.id,
+    );
+}
+
+// returns an array of items the building expects as input
+function getRequiredInputItems(building) {
+    return building?.kind?.inputs || [];
+}
+
+// search through all the bags in the world to find those belonging to this building
+function getBuildingBags(state, building) {
+    return building
+        ? (state?.world?.bags || []).filter(
+              (bag) => bag.equipee?.node.id === building.id,
+          )
+        : [];
+}
+
+// get building input slots
+function getInputSlots(state, building) {
+    // inputs are the bag with key 0 owned by the building
+    const buildingBags = getBuildingBags(state, building);
+    const inputBag = buildingBags.find((bag) => bag.equipee.key === 0);
+
+    // slots used for crafting have sequential keys startng with 0
+    return inputBag && inputBag.slots.sort((a, b) => a.key - b.key);
+}
+
+// are the required craft input items in the input slots?
+function inputsAreCorrect(state, building) {
+    const requiredInputItems = getRequiredInputItems(building);
+    const inputSlots = getInputSlots(state, building);
+
+    return (
+        inputSlots &&
+        inputSlots.length >= requiredInputItems.length &&
+        requiredInputItems.every(
+            (requiredItem) =>
+                inputSlots[requiredItem.key].item.id == requiredItem.item.id &&
+                inputSlots[requiredItem.key].balance == requiredItem.balance,
+        )
+    );
+}
+
+function logState(state) {
+    console.log("State sent to pluging:", state);
+}
+
+const friendlyPlayerAddresses = [
+    // 0x402462EefC217bf2cf4E6814395E1b61EA4c43F7
+];
+
+function unitIsFriendly(state, selectedBuilding) {
+    const mobileUnit = getMobileUnit(state);
+    return (
+        unitIsBuildingOwner(mobileUnit, selectedBuilding) ||
+        unitIsBuildingAuthor(mobileUnit, selectedBuilding) ||
+        friendlyPlayerAddresses.some((addr) =>
+            unitOwnerConnectedToWallet(state, mobileUnit, addr),
+        )
+    );
+}
+
+function unitIsBuildingOwner(mobileUnit, selectedBuilding) {
+    //console.log('unit owner id:',  mobileUnit?.owner?.id, 'building owner id:', selectedBuilding?.owner?.id);
+    return (
+        mobileUnit?.owner?.id &&
+        mobileUnit?.owner?.id === selectedBuilding?.owner?.id
+    );
+}
+
+function unitIsBuildingAuthor(mobileUnit, selectedBuilding) {
+    //console.log('unit owner id:',  mobileUnit?.owner?.id, 'building author id:', selectedBuilding?.kind?.owner?.id);
+    return (
+        mobileUnit?.owner?.id &&
+        mobileUnit?.owner?.id === selectedBuilding?.kind?.owner?.id
+    );
+}
+
+function unitOwnerConnectedToWallet(state, mobileUnit, walletAddress) {
+    //console.log('Checking player:',  state?.player, 'controls unit', mobileUnit, walletAddress);
+    return (
+        mobileUnit?.owner?.id == state?.player?.id &&
+        state?.player?.addr == walletAddress
+    );
+}
+
+// the source for this code is on github where you can find other example buildings:
+// https://github.com/playmint/ds/tree/main/contracts/src/example-plugins

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.js
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.js
@@ -1,10 +1,6 @@
 import ds from "downstream";
 
 export default async function update(state) {
-    // uncomment this to browse the state object in browser console
-    // this will be logged when selecting a unit and then selecting an instance of this building
-    //logState(state);
-
     const selectedTile = getSelectedTile(state);
     const selectedBuilding =
         selectedTile && getBuildingOnTile(state, selectedTile);
@@ -75,89 +71,3 @@ function getBuildingOnTile(state, tile) {
         (b) => tile && b.location?.tile?.id === tile.id,
     );
 }
-
-// returns an array of items the building expects as input
-function getRequiredInputItems(building) {
-    return building?.kind?.inputs || [];
-}
-
-// search through all the bags in the world to find those belonging to this building
-function getBuildingBags(state, building) {
-    return building
-        ? (state?.world?.bags || []).filter(
-              (bag) => bag.equipee?.node.id === building.id,
-          )
-        : [];
-}
-
-// get building input slots
-function getInputSlots(state, building) {
-    // inputs are the bag with key 0 owned by the building
-    const buildingBags = getBuildingBags(state, building);
-    const inputBag = buildingBags.find((bag) => bag.equipee.key === 0);
-
-    // slots used for crafting have sequential keys startng with 0
-    return inputBag && inputBag.slots.sort((a, b) => a.key - b.key);
-}
-
-// are the required craft input items in the input slots?
-function inputsAreCorrect(state, building) {
-    const requiredInputItems = getRequiredInputItems(building);
-    const inputSlots = getInputSlots(state, building);
-
-    return (
-        inputSlots &&
-        inputSlots.length >= requiredInputItems.length &&
-        requiredInputItems.every(
-            (requiredItem) =>
-                inputSlots[requiredItem.key].item.id == requiredItem.item.id &&
-                inputSlots[requiredItem.key].balance == requiredItem.balance,
-        )
-    );
-}
-
-function logState(state) {
-    console.log("State sent to pluging:", state);
-}
-
-const friendlyPlayerAddresses = [
-    // 0x402462EefC217bf2cf4E6814395E1b61EA4c43F7
-];
-
-function unitIsFriendly(state, selectedBuilding) {
-    const mobileUnit = getMobileUnit(state);
-    return (
-        unitIsBuildingOwner(mobileUnit, selectedBuilding) ||
-        unitIsBuildingAuthor(mobileUnit, selectedBuilding) ||
-        friendlyPlayerAddresses.some((addr) =>
-            unitOwnerConnectedToWallet(state, mobileUnit, addr),
-        )
-    );
-}
-
-function unitIsBuildingOwner(mobileUnit, selectedBuilding) {
-    //console.log('unit owner id:',  mobileUnit?.owner?.id, 'building owner id:', selectedBuilding?.owner?.id);
-    return (
-        mobileUnit?.owner?.id &&
-        mobileUnit?.owner?.id === selectedBuilding?.owner?.id
-    );
-}
-
-function unitIsBuildingAuthor(mobileUnit, selectedBuilding) {
-    //console.log('unit owner id:',  mobileUnit?.owner?.id, 'building author id:', selectedBuilding?.kind?.owner?.id);
-    return (
-        mobileUnit?.owner?.id &&
-        mobileUnit?.owner?.id === selectedBuilding?.kind?.owner?.id
-    );
-}
-
-function unitOwnerConnectedToWallet(state, mobileUnit, walletAddress) {
-    //console.log('Checking player:',  state?.player, 'controls unit', mobileUnit, walletAddress);
-    return (
-        mobileUnit?.owner?.id == state?.player?.id &&
-        state?.player?.addr == walletAddress
-    );
-}
-
-// the source for this code is on github where you can find other example buildings:
-// https://github.com/playmint/ds/tree/main/contracts/src/example-plugins

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.sol
@@ -44,7 +44,7 @@ contract ResetTower is BuildingKind {
 
         require(address(coreBuildingImpl) != address(0), "Core building not found");
 
-        coreBuildingImpl.reset(ds, buildingInstance, coreBuildingInstance);
+        coreBuildingImpl.reset(ds, coreBuildingInstance);
     }
 
     function INT16_ARRAY(bytes4 kindID, int16[4] memory keys) internal pure returns (bytes24) {

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.sol
@@ -27,10 +27,10 @@ contract ResetTower is BuildingKind {
         State state = ds.getState();
         bytes24 buildingTile = state.getFixedLocation(buildingInstance);
 
-        // Get location of origin (0, 0, 0) on non offset map
-        int16 coreQ = int16(int192(uint192(buildingTile) >> 32)) - 0;
-        int16 coreR = int16(int192(uint192(buildingTile) >> 16)) - -2;
-        int16 coreS = int16(int192(uint192(buildingTile))) - 2;
+        // Get location of origin (0, 0, 0) on non offset map by subtracting original reset tower coordinates [-2, 2, 0]
+        int16 coreQ = int16(int192(uint192(buildingTile) >> 32)) - -2;
+        int16 coreR = int16(int192(uint192(buildingTile) >> 16)) - 2;
+        int16 coreS = int16(int192(uint192(buildingTile))) - 0;
 
         // Get location of core tower
         coreQ += 6;

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Game} from "cog/IGame.sol";
+import {Dispatcher} from "cog/IDispatcher.sol";
+import {State} from "cog/IState.sol";
+import {Schema, Kind, Node} from "@ds/schema/Schema.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+import {BuildingKind} from "@ds/ext/BuildingKind.sol";
+import {ILabyrinthCore} from "./ILabyrinthCore.sol";
+
+using Schema for State;
+
+contract ResetTower is BuildingKind {
+    function getPasswordHash() internal pure returns (bytes32) {
+        return 0x1f1fc8e191099524ede873ed4b43087e02baaa5f39243fdd808f60582dc7702e;
+    }
+
+    function password(string calldata pswd) public {}
+
+    function use(Game ds, bytes24 buildingInstance, bytes24, /*actor*/ bytes calldata payload) public override {
+        // Check password
+        require((bytes4)(payload) == this.password.selector, "Invalid payload");
+        (string memory pswd) = abi.decode(payload[4:], (string));
+        require(keccak256(abi.encodePacked(pswd)) == getPasswordHash(), "Invalid password");
+
+        State state = ds.getState();
+        bytes24 buildingTile = state.getFixedLocation(buildingInstance);
+
+        // Get location of origin (0, 0, 0) on non offset map
+        int16 coreQ = int16(int192(uint192(buildingTile) >> 32)) - 0;
+        int16 coreR = int16(int192(uint192(buildingTile) >> 16)) - -2;
+        int16 coreS = int16(int192(uint192(buildingTile))) - 2;
+
+        // Get location of core tower
+        coreQ += 6;
+        coreR += -6;
+        coreS += 0;
+
+        // Get core building instance
+        bytes24 coreBuildingInstance = INT16_ARRAY(Kind.Building.selector, [int16(0), coreQ, coreR, coreS]);
+        bytes24 coreBuildingKind = state.getBuildingKind(coreBuildingInstance);
+        ILabyrinthCore coreBuildingImpl = ILabyrinthCore(state.getImplementation(coreBuildingKind));
+
+        require(address(coreBuildingImpl) != address(0), "Core building not found");
+
+        coreBuildingImpl.reset(ds, buildingInstance, coreBuildingInstance);
+    }
+
+    function INT16_ARRAY(bytes4 kindID, int16[4] memory keys) internal pure returns (bytes24) {
+        return bytes24(abi.encodePacked(kindID, uint96(0), keys[0], keys[1], keys[2], keys[3]));
+    }
+}

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.yaml
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.yaml
@@ -1,0 +1,25 @@
+---
+kind: BuildingKind
+spec:
+  category: custom
+  name: Reset Tower
+  description: This building is for Playmint use only and isn't part of the labyrinth puzzle.
+  model: 14-13
+  color: 1
+  contract:
+    file: ./ResetTower.sol
+  plugin:
+    file: ./ResetTower.js
+  materials:
+    - name: L33t Bricks
+      quantity: 100
+  inputs:
+    - name: Red Goo
+      quantity: 20
+    - name: Green Goo
+      quantity: 10
+    - name: Blue Goo
+      quantity: 2
+  outputs:
+    - name: Bronze Key
+      quantity: 1

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.yaml
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.yaml
@@ -5,7 +5,7 @@ spec:
   name: Reset Tower
   description: This building is for Playmint use only and isn't part of the labyrinth puzzle.
   model: 14-13
-  color: 1
+  color: 0
   contract:
     file: ./ResetTower.sol
   plugin:

--- a/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.yaml
+++ b/contracts/src/maps/labyrinth/kinds/buildings/LabyrinthCore/ResetTower.yaml
@@ -13,13 +13,3 @@ spec:
   materials:
     - name: L33t Bricks
       quantity: 100
-  inputs:
-    - name: Red Goo
-      quantity: 20
-    - name: Green Goo
-      quantity: 10
-    - name: Blue Goo
-      quantity: 2
-  outputs:
-    - name: Bronze Key
-      quantity: 1

--- a/contracts/src/maps/labyrinth/rooms/room_1.yaml
+++ b/contracts/src/maps/labyrinth/rooms/room_1.yaml
@@ -13,3 +13,8 @@ kind: Bag
 spec:
   location: [-2, 1, 1]
   items: []
+---
+kind: Building
+spec:
+  name: Reset Tower
+  location: [0, -2, 2]

--- a/contracts/src/maps/labyrinth/rooms/room_1.yaml
+++ b/contracts/src/maps/labyrinth/rooms/room_1.yaml
@@ -17,4 +17,4 @@ spec:
 kind: Building
 spec:
   name: Reset Tower
-  location: [0, -2, 2]
+  location: [-2, 2, 0]


### PR DESCRIPTION
# What

Added a reset tower which will call the `reset` function on the `LabyrinthCore` contract. 

![image](https://github.com/playmint/ds/assets/51167118/1382032e-2c8d-4109-9d40-49fecd49021e)

- This building is both present in the standalone and croissant maps
- A password must be supplied to reset
- The reset code has now been made a public function on the core building which can only be called by either the core building itself or the reset tower

# Why

Adds the ability to reset the Labyrinth without having to walk to the core building and supply 4 hearts

# Notes

If we want to change the password run a password (all lower case) through a keccak256 hash (can be done here: https://emn178.github.io/online-tools/keccak_256.html) and then update the `getPasswordHash` function in the `ResetTower` contract

```
    function getPasswordHash() internal pure returns (bytes32) {
        return 0x1f1fc8e191099524ede873ed4b43087e02baaa5f39243fdd808f60582dc7702e;
    }
```