### PR TITLE
allow xfer item from building-bag to wallet-bag

### DIFF
--- a/contracts/src/rules/InventoryRule.sol
+++ b/contracts/src/rules/InventoryRule.sol
@@ -59,8 +59,10 @@ contract InventoryRule is Rule {
         address toAddress,
         uint64 qty
     ) private {
-        // TODO: this check could be relaxed to match the TRANSFER_ITEM_MOBILE_UNIT "from" rules
-        require(state.getOwner(fromEquipee) == Node.Player(sender), "fromEquipee not owned by sender");
+        require(
+            state.getOwner(fromEquipee) == Node.Player(sender) || bytes4(fromEquipee) == Kind.Building.selector,
+            "fromEquipee not owned by sender"
+        );
 
         // get the item
         bytes24 fromBag = state.getEquipSlot(fromEquipee, fromEquipSlot);


### PR DESCRIPTION
lets you export items directly from building-attached bags like input/output slots to player wallet inventory.

we currently allow xfer from wallet inventory TO building-attached bags, so this makes it consistent.

HOWEVER; both of these things are probably not quite what we want as they do allow for teleporting items from long distance bags in some scenerios. We have an issue in the backlog about deciding if/how this kind of transfer should work. So at this time this is more about making it not appear broken than about deciding on how to enforce location-aware item transfers

fixes: #1091 