### PR TITLE
load the current tiles/kinds into tile-fab on load

### DIFF
--- a/cli/src/commands/apply.ts
+++ b/cli/src/commands/apply.ts
@@ -23,7 +23,7 @@ export const getManifestFilenames = (filename: string, isRecursive: boolean): st
             throw new Error(`${filename} is a directory. use --recursive to apply all manifests in a directory`);
         }
         // must be posix path, even on windows
-        const globPath = path.join(filename, '**/*.yaml').replace(/\\/g, '/');
+        const globPath = path.join(filename, '**/*.{yaml,yml}').replace(/\\/g, '/');
         return globSync(globPath, { follow: true });
     } else if (isRecursive) {
         throw new Error(`--filename must be a directory when used with --recursive`);

--- a/frontend/src/components/map/Buildings.tsx
+++ b/frontend/src/components/map/Buildings.tsx
@@ -58,8 +58,8 @@ export const Buildings = memo(
         tiles: WorldTileFragment[];
         buildings: WorldBuildingFragment[];
         selectedElementID?: string;
-        onClickBuilding: (id: string) => void;
-        pluginBuildingProperties: PluginMapProperty[];
+        onClickBuilding?: (id: string) => void;
+        pluginBuildingProperties?: PluginMapProperty[];
     }) => {
         const buildingComponents = useMemo(
             () =>
@@ -75,7 +75,7 @@ export const Buildings = memo(
                     const selected = selectedElementID === b.id ? 'outline' : 'none';
                     const rotation = b.facingDirection == FacingDirectionKind.RIGHT ? -30 : 30;
                     const tile = tiles.find(({ id }) => id === b.location?.tile.id);
-                    const overrideModel = pluginBuildingProperties
+                    const overrideModel = (pluginBuildingProperties || [])
                         .find((prop) => prop.id == b.id && prop.key == 'model')
                         ?.value.toString();
 
@@ -110,14 +110,14 @@ export const Buildings = memo(
                             />
                         );
                     } else if (getBuildingCategory(b.kind) == BuildingCategory.DISPLAY) {
-                        const labelText = pluginBuildingProperties
+                        const labelText = (pluginBuildingProperties || [])
                             .find((prop) => prop.id == b.id && prop.key == 'labelText')
                             ?.value.toString();
-                        const startTimeObject = pluginBuildingProperties.find(
+                        const startTimeObject = (pluginBuildingProperties || []).find(
                             (prop) => prop.id == b.id && prop.key == 'countdown-start'
                         )?.value as unknown as { start: number };
 
-                        const endTimeObject = pluginBuildingProperties.find(
+                        const endTimeObject = (pluginBuildingProperties || []).find(
                             (prop) => prop.id == b.id && prop.key == 'countdown-end'
                         )?.value as unknown as { end: number };
                         return (
@@ -138,7 +138,7 @@ export const Buildings = memo(
                             />
                         );
                     } else if (getBuildingCategory(b.kind) == BuildingCategory.BILLBOARD) {
-                        const image = pluginBuildingProperties
+                        const image = (pluginBuildingProperties || [])
                             .find((prop) => prop.id == b.id && prop.key == 'image')
                             ?.value.toString();
                         return (

--- a/frontend/src/components/map/Tile.tsx
+++ b/frontend/src/components/map/Tile.tsx
@@ -51,8 +51,8 @@ export const Tiles = memo(
     }: {
         tiles?: WorldTileFragment[];
         selectedTiles?: WorldTileFragment[];
-        onClickTile: (id: string) => void;
-        pluginTileProperties: PluginMapProperty[];
+        onClickTile?: (id: string) => void;
+        pluginTileProperties?: PluginMapProperty[];
     }) => {
         const [hovered, setHovered] = useState<string | undefined>();
         const hoveredTile = hovered && tiles ? tiles.find((t) => t.id === hovered) : undefined;
@@ -68,7 +68,7 @@ export const Tiles = memo(
         const tileComponents = useMemo(
             () =>
                 (tiles || []).map((t) => {
-                    const color = pluginTileProperties
+                    const color = (pluginTileProperties || [])
                         .find((prop) => prop.id == t.id && prop.key == 'color')
                         ?.value.toString();
                     const coords = getCoords(t);


### PR DESCRIPTION
### what

* When the tile-fabricator first loads it will now populate the grid with the Tiles, Buildings, and BuildingKinds from the game state.
* Reset will reload the page to reset back to the game state.
* Clear will wipe all the tiles, giving a blank canvas.
* Removed the diameter slider, it just gets in the way of loaded maps
* updated `ds apply -R` to find .yml files too (since tilefab exports as .yml in chrome) 

### why

Showing the current map is more intuitive, and makes it easier to deploy a BuildingKind with building-fab, then jump to tile-fab to place it.

resolves: #1163 

### notes

* state is only ever loaded on first load, it will not update based on live changes ... this avoids the situation where updates destroy or corrupt your creation while creating it.
* it's not really clear what should happen if you import on top of the state-loaded map ... currently it is addative, so you would need to press clear then import to get a clean import... this is so that you can still load additional things

### todo

* [x] fixup the nasty `any` types
* [x] fixup the broken preview tile not displaying
* [x] fixup the broken preview buildings not displaying
* [x] fixup the .yml extensions (or fix cli to accept them)