### PR TITLE
New Tutorial Folder to replace Cheat Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# Downstream
 
-Contracts, client libraries, and plugins for the on-chain Downstream game.
+<img src="tutorial/images/header.png">
 
-## How to play and build on top of Downstream
+___Downstream is a fully onchain game platform and creation tool.___
 
-See the [docs](./docs/index.md)
 
-## How to build this project
+# Build your own game with Downstream
+
+Follow the guide to [build your own game with Downstream](./tutorial/README.md).
+
+# Build and run a local platform instance
 
 <details>
 <summary>Clone Repository (with submodules and LFS)</summary>
 
-### Clone Repository
+## Clone Repository
 
 The repository needs cloning with LFS and recursive submodules.
 
@@ -26,7 +28,7 @@ The repository needs cloning with LFS and recursive submodules.
   git clone --recurse-submodules https://github.com/playmint/ds
   ```
 
-### **_⚠️ 🖥 Windows_** 
+## **_⚠️ 🖥 Windows_** 
 
 Windows users must ensure they have symlinks enabled.
 
@@ -43,7 +45,7 @@ Windows users must ensure they have symlinks enabled.
 <details>
 <summary>Running with Docker</summary>
 
-### Running with Docker
+## Running with Docker
 
 If you only need a local copy of the game built (without development helpers
 like hot reloading etc), then the easiest way is to provision using
@@ -65,9 +67,9 @@ See "Running Local with different Map Setups" section for deploying different ma
 <details>
 <summary>Docker Trouble shooting</summary>
 
-### Docker Trouble shooting
+## Docker Trouble shooting
 
-**1. Hardware Virtulisation**
+**1. Hardware Virtualisation**
 If when trying to run Docker you hit this error:
 ```
 hardware assisted virtualization and data execution protection must be enabled in the bios
@@ -79,22 +81,22 @@ You will need to enter your BIOS and activate Hardware Virtualisation. This is u
 <details>
 <summary>Building from Source</summary>
 
-### Building from Source
+## Building from Source
 
 For deploying locally with maximum flexibility and minimum rebuild times, you can install the whole tool chain and then create a local build with make.
 
-#### Install tools
+### Install tools
 
 Follow the [instructions for installing tools](./install-tools.md).
 
-#### Build & Run
+### Build & Run
 In the ds directory, run
 ```
 make dev
 ```
 In your browser, open `http://localhost:3000/`
 
-#### Rebuilding after core changes: 
+### Rebuilding after core changes: 
 If you have built the map during the `make dev` flow and since, there have been changes in the Unity scene
 you will need to rebuild the map. To do this, it is adviced to clean all build artifacts with
 
@@ -107,16 +109,17 @@ build the map by using the `make map` command.
 </details>
 
 <details>
-<summary>Running Local with different Map Setups</summary>
+<summary>Running locally with different maps</summary>
 
-## Running Local with different Map Setups
+# Running locally with different maps
 
 By Default, running `make dev` will spawn a one hex sized map and running with `docker` will spawn (the only  slightly larger) "tiny" map. 
 
-### 1. Using Playmint's Maps
+## 1. Using pre-built Maps
 
-Inside of the `ds/contracts/src/maps/` folder, you will find a few premade maps by Playmint. 
-In order to force one of these maps to be deployed with a local build of the game you need set the MAP env variable.
+The `ds/contracts/src/maps/` folder contains a few pre-made maps.
+
+In order to force one of these maps to be deployed with a local build of the game you need to set the MAP env variable.
 
 For `docker` builds this must be done by editing the `.env` file in the root
 of the repository. 
@@ -125,26 +128,26 @@ of the repository.
 MAP=quest-map
 ```
 
-For `make` builds the MAP variable can be set as part of the make command; e.g. 
+For `make` builds (and OSX docker builds) the MAP variable can be set as part of the make command; e.g. 
 
 ```
 MAP=quest-map make dev
 ```
 
-### 2. Apply a map after deploying
+## 2. Apply a map after deploying
 
-After doing a standard `docker` or `make` build, you can run the DS apply command and point it at one of the map folders. For example: `ds apply -R -f ./contracts/src/maps/quest-map/`
+After doing a standard `docker` or `make` build, you can run the DS apply command and point it at one of the map folders. For example: `ds apply -n local -R -f ./contracts/src/maps/quest-map/`
 
-### 3. Build your own map and deploy it
+## 3. Build your own map and deploy it
 
 Once the game is running locally, browsing to `http://localhost:3000/tile-fabricator` will show the Tile Fabricator.
 
 Once in the Tile Fabricator, you can design and export a map file. If you want to pre-populate your map wih buildings you will need to import .yaml files that define the buildingKinds.
 
 If you then rename the .yml file to a .yaml and move it to your desired location, you will be able to run the ds apply command, like so:
-`ds apply -R -f ./path/to/mymap.yaml`
+`ds apply -n local -f ./path/to/mymap.yaml`
 
-### 4 Generating the performance-test map
+## 4 Generating the performance-test map
 
 This is only possible with the `make` deploy flow and cannot be triggered for a `docker` build. To generate the performance-test map (used to push the limits of number of tiles and plugins) run:
 

--- a/frontend/public/images/docs/basic-factory-js.png
+++ b/frontend/public/images/docs/basic-factory-js.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e05ebfca31a196b64e7d55b29b41772ee0eaf2b19cd9ed28f99d5331428ed01
-size 491996

--- a/frontend/public/images/docs/basic-factory-sol.png
+++ b/frontend/public/images/docs/basic-factory-sol.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c5b32274362ba0050d4603725bfa6c2e8c46988f3cbf0e250bd1c210c1463d9c
-size 629738

--- a/frontend/public/images/docs/basic-factory-yaml.png
+++ b/frontend/public/images/docs/basic-factory-yaml.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d53828bb40aead399f54c8d0f848c7b9f9a5922fa955a21dce23abce579beeac
-size 316889

--- a/frontend/public/images/docs/building-fabricator.png
+++ b/frontend/public/images/docs/building-fabricator.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f65e3d07069e4bd0b70fb73a549186771f0ee8de7ffea088f066bb53ba0ce861
-size 662447

--- a/frontend/public/images/docs/vault-of-knowledge.png
+++ b/frontend/public/images/docs/vault-of-knowledge.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d83382ae55c6d3ec9110e950be353f777dcc309b1d52ee86fb457ef7efc2326
-size 1169309

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -159,9 +159,7 @@ Any other contract on the same chain can interact with the Downstream's read-onl
 
 # Video Guides
 
-| Video |   | Demonstrates |
-|-------|---|--------------|
-| [Tutorial 1](https://drive.google.com/file/d/1rvXt3Fs4M0-yn83Mc0iAG9HlhIJpSDRl/view?usp=drive_link) | <img src="images/dvb-thumb.png" width="200"> | Run default map and deploy DuckBurger example |
-2. [___Create new map with DuckBurger plus extractors.___](https://drive.google.com/file/d/1f6xYuzhBMBFMIYWe_Xb8Sr2vIhLukORY/view?usp=drive_link) 
-
-<img src="images/dvb2-thumb.png" width="200"> 
+| Video             | Demonstrates         |              |
+|-------------------|----------------------|--------------|
+| [Tutorial 1](https://drive.google.com/file/d/1rvXt3Fs4M0-yn83Mc0iAG9HlhIJpSDRl/view?usp=drive_link) | Build and run; Default Map; Deploy example buildings;| <img src="images/dvb-thumb.png" width="200"> |
+| [Tutorial 2](https://drive.google.com/file/d/1f6xYuzhBMBFMIYWe_Xb8Sr2vIhLukORY/view?usp=drive_link) | Tile Fabricator; Custom Map; |<img src="images/dvb2-thumb.png" width="200"> |

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -49,8 +49,11 @@ _Some common tasks:_
 | example | task |
 |---|---|
 | `ds apply -n local -f BasicFactory.yaml -k <private key>` | Apply manifest files (deploy buildings and maps) |
+| `ds apply help` | help on apply command |
 | `ds get -n local items` | Get ids for all items |
-| `ds get -n local items` | Get info for a ll buildingkinds |
+| `ds get -n local buildingkinds` | Get info for all buildingkinds |
+| `ds get -n local buildingkinds` | Get info for all buildingkinds |
+| `ds get help` | help on get command |
 | `ds help` | help on all commands |
 
 _options explained_

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -159,7 +159,7 @@ Any other contract on the same chain can interact with the Downstream's read-onl
 
 # Video Guides
 
-| Video             | Demonstrates         |              |
-|-------------------|----------------------|--------------|
-| [Tutorial 1](https://drive.google.com/file/d/1rvXt3Fs4M0-yn83Mc0iAG9HlhIJpSDRl/view?usp=drive_link) | Build and run; Default Map; Deploy example buildings;| <img src="images/dvb-thumb.png" width="200"> |
-| [Tutorial 2](https://drive.google.com/file/d/1f6xYuzhBMBFMIYWe_Xb8Sr2vIhLukORY/view?usp=drive_link) | Tile Fabricator; Custom Map; |<img src="images/dvb2-thumb.png" width="200"> |
+| Video             | Demonstrates         |
+|-------------------|----------------------|
+| <a href="https://drive.google.com/file/d/1rvXt3Fs4M0-yn83Mc0iAG9HlhIJpSDRl/view?usp=drive_link"><img src="images/dvb-thumb.png" width="200"></a>  | Build and run; Default Map; Deploy example buildings;|
+| <a href="https://drive.google.com/file/d/1f6xYuzhBMBFMIYWe_Xb8Sr2vIhLukORY/view?usp=drive_link"><img src="images/dvb2-thumb.png" width="200"></a> | Tile Fabricator; Custom Map; |

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -159,5 +159,5 @@ Any other contract on the same chain can interact with the Downstream's read-onl
 
 # Video Guides
 
-1. [___Run default map and deploy DuckBurger example.___](1rvXt3Fs4M0-yn83Mc0iAG9HlhIJpSDRl/view?usp=drive_link) <img src="images/dvb-thumb.png" width="200"> 
+1. [___Run default map and deploy DuckBurger example.___](https://drive.google.com/file/d/1rvXt3Fs4M0-yn83Mc0iAG9HlhIJpSDRl/view?usp=drive_link) <img src="images/dvb-thumb.png" width="200"> 
 2. [___Create new map with DuckBurger plus extractors.___](https://drive.google.com/file/d/1f6xYuzhBMBFMIYWe_Xb8Sr2vIhLukORY/view?usp=drive_link) <img src="images/dvb2-thumb.png" width="200"> 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -63,7 +63,8 @@ _options explained_
 
 ### Command line signing
 
-    ⚠️ Do not use a private key for any account you care about. You can use the Downstream connection dialogue box to copy the private key if connected with a burner. Or you can leave this option out and ds will give you a wallet connect QR code to sign.
+>[!CAUTION]
+>Do not use a private key for any account you care about. You can use the Downstream connection dialogue box to copy the private key if connected with a burner. Or you can leave this option out and ds will give you a wallet connect QR code to sign.
 
 ### Deploy a single building
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -86,7 +86,7 @@ _options explained_
 - Stop any local running build.
 - Copy your map manifest and building source to [contracts/src/maps](../contracts/src/maps)<map-folder>
 - Re-run with `MAP=<map-folder> docker compose up`
-    - Windows users may need to set the MAP variable in the root .env file because docker does 
+    - You can also set the MAP environment variable in the [.env file](../.env)
 
 # Adding Game Logic
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -159,5 +159,9 @@ Any other contract on the same chain can interact with the Downstream's read-onl
 
 # Video Guides
 
-1. [___Run default map and deploy DuckBurger example.___](https://drive.google.com/file/d/1rvXt3Fs4M0-yn83Mc0iAG9HlhIJpSDRl/view?usp=drive_link) <img src="images/dvb-thumb.png" width="200"> 
-2. [___Create new map with DuckBurger plus extractors.___](https://drive.google.com/file/d/1f6xYuzhBMBFMIYWe_Xb8Sr2vIhLukORY/view?usp=drive_link) <img src="images/dvb2-thumb.png" width="200"> 
+| Video |   | Demonstrates |
+|-------|---|--------------|
+| [Tutorial 1](https://drive.google.com/file/d/1rvXt3Fs4M0-yn83Mc0iAG9HlhIJpSDRl/view?usp=drive_link) | <img src="images/dvb-thumb.png" width="200"> | Run default map and deploy DuckBurger example |
+2. [___Create new map with DuckBurger plus extractors.___](https://drive.google.com/file/d/1f6xYuzhBMBFMIYWe_Xb8Sr2vIhLukORY/view?usp=drive_link) 
+
+<img src="images/dvb2-thumb.png" width="200"> 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,0 +1,71 @@
+# Building Games with Downstream
+
+## Build and run locally
+Follow the instructions in the [root README](../README.md)
+
+## Building Fabricator
+browse to [localhost:3000/building-fabricator](http://localhost:3000/building-fabricator)
+
+The Building Fabricator allows you to deploy buildings and items to Downstream without having to leave the game!
+
+<img src="images/building-fabricator.png" width="200">
+
+## Tile Fabricator
+browse to [localhost:3000/tile-fabricator](http://localhost:3000/tile-fabricator)
+
+The Tile Fabricator allows you to draw and remove tiles and buildings from a map definition and then export that as a configuration yaml file.
+
+![](images/tile-fabricator.png)
+
+## CLI
+Available as an npm package, `ds` is how buildings and maps are deployed to Downstream.
+
+Installation: `npm install -g @playmint/ds-cli`
+
+Help: `ds --help`
+
+### Deploying over current map
+
+Use the building-fabricator to export building sources and the tile-fabricator to export map files. Combine them all in a single folder and use `ds` to deploy them to a running Downstream:
+
+```ds apply -n local -k <private key> -R f <exported folder>```
+
+> note that `-k <private key>` can use the player private key if connected to Downstream with a Burner. Or you wil be presented with a WalletConnect QR code if you leave this option out.
+
+### Deploying fresh Downstream with your map
+
+- Stop any local running build.
+- Copy your map manifest and building source to [contracts/src/maps](../contracts/src/maps)<map-folder>
+- Re-run with `MAP=<map-folder> docker compose up`
+
+## Adding Game Logic
+
+## BuildingKind source overview
+The source code exported from the building-fabricator is split into 3 files:
+
+
+#### BasicFactory.yaml
+This contains the parameters set by you in the Building Fabricator and is the entry point when passed to `ds apply`.
+        
+#### BasicFactory.js - UI and action dispatch
+This is the javascript that controls UI behaviour and is deployed to chain as call data and linked to your building contract.
+
+It implements an `update` function, with access to state to make decisions about what to display.
+
+It also acts as a way to dispatch game actions to chain on behalf of the selected ***Unit***, e.g. BUILDING_USE. 
+
+The returns block of `update` configures the building UI for display and hooks up any buttons to functions declared in this file.
+
+The exported BasicFactory.js contains commented out code with examples of how to log the available state and how to restrict which Units can use the building.
+        
+#### BasicFactory.sol - onchain logic
+This defines the building contract deployed to chain and must implement `BuildingKind` interface. The entry point is the `BuildingKind.use` function, which can dispatch actions on behalf the ***Building***, e.g. CRAFT.
+
+The `use` function takes an optional payload param to be used for variable behaviour.
+
+The exported BasicFactory.sol contains commented out code of how to restrict which Units can use the building.
+
+## Examples
+> ⚠️ We are working on a tutorial to introduce all of Downstream's creation tools. 
+See some feature examples in [contracts/src/example-plugins](../contracts/src/example-plugins) and full maps in [contracts/src/maps](../contracts/src/maps)
+

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -98,7 +98,8 @@ The files exported from the Building Fabricator act as a starting point for impl
 | BasicFactory.js | UI and Action dispatching | Implements an `update` function that is called when an instance of the building is clicked on in game. Use the `state` parameter to make control what html and buttons are returned.Dispatch onchain actions on behalf of the selected ***Unit*** with `ds.dispatch` |
 | BasicFactory.sol | Onchain logic | A solidity contract implementing `BuildingKind` interface. The entry point is the `BuildingKind.use` function, which can dispatch actions on behalf the ***Building***. |
 
-    📣 We are working on a tutorial to introduce all of Downstream's creation tools and game logic api. Until then, the examples below and reaching out in Discord are the best way to discover what's possible with your Downstream game.
+> [!TIP]
+> We are working on a tutorial to introduce all of Downstream's creation tools and game logic api. Until then, the examples below and reaching out in Discord are the best way to discover what's possible with your Downstream game.
 
 # Examples    
 

--- a/tutorial/external-connections.md
+++ b/tutorial/external-connections.md
@@ -2,7 +2,8 @@
 
 External clients can connect to deployed Downstream instances and read game state in one of two ways.
 
-    The urls here assume running locally. Reach out to Playmint if you want to connect to a public instance.
+> [!IMPORTANT]  
+> The urls here assume running locally. Reach out to Playmint if you want to connect to a public instance.
 
 ## 1. GraphQL
 

--- a/tutorial/external-connections.md
+++ b/tutorial/external-connections.md
@@ -1,0 +1,28 @@
+# External Connections
+
+External clients can connect to deployed Downstream instances and read game state in one of two ways.
+
+    The urls here assume running locally. Reach out to Playmint if you want to connect to a public instance.
+
+## 1. GraphQL
+
+An instance of the Downstream platform includes an indexer with a GraphQL api.
+This is used by our web and command line clients for all action dispatches and state queries. 
+
+You could make use of this from your own clients:
+
+endpoint: [localhost:8080/query](https://localhost:8080/query)
+
+playground: [localhost:8080]( https://localhost:8080)
+
+examples can be found in our core client module, e.g:
+
+https://github.com/playmint/ds/blob/main/core/src/world.graphql
+
+## 2. Network RPC
+
+The JSON-RPC endpoint for the network can be used to query the chain directly outside of Downstream for more advanced use cases.
+
+When running locally there is an anvil chain available at  [localhost:8545]( https://localhost:8545)
+
+On a Playmint Devnet this is a private test network so if you wanted to deploy something outside of the context of Downstream you would need a wallet with our private fake ETH in it and so must use one of the test accounts so please get in touch.

--- a/tutorial/images/building-fabricator.png
+++ b/tutorial/images/building-fabricator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f65e3d07069e4bd0b70fb73a549186771f0ee8de7ffea088f066bb53ba0ce861
+size 662447

--- a/tutorial/images/building-fabricator.png
+++ b/tutorial/images/building-fabricator.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f65e3d07069e4bd0b70fb73a549186771f0ee8de7ffea088f066bb53ba0ce861
-size 662447
+oid sha256:19cba41709d6da804794b14c5b005106036d8f3013218d6adac5415bbaecad07
+size 1061747

--- a/tutorial/images/cli.png
+++ b/tutorial/images/cli.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:902bfcbfd37079fd6025e6ce96568b8d35cf618746223609bf4746767441ae91
+size 298924

--- a/tutorial/images/dvb-thumb.png
+++ b/tutorial/images/dvb-thumb.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25b341c344c34698fa7332033f4cbcf2a76a59883f8556afce699e60a0f558d2
+size 825768

--- a/tutorial/images/dvb2-thumb.png
+++ b/tutorial/images/dvb2-thumb.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfa9585059675cd4ed85c05bbd000dd790a79f761f91a9491a92dd47b6ed8651
+size 1012745

--- a/tutorial/images/fresh-local-downstream.png
+++ b/tutorial/images/fresh-local-downstream.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e26ac7f327661ca55dd797f56246722a3e3180138502cf5c48a5a7dcaeb4287
+size 1460906

--- a/tutorial/images/header.png
+++ b/tutorial/images/header.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d39d223c2bab609396dece13b3bcc51c83a37f15a6d29735d09ae8318ce72033
+size 452076

--- a/tutorial/images/map-croissant.png
+++ b/tutorial/images/map-croissant.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1796c473538a34dfd7df340aeebed5613c5b38de8198ce6555d1a6204391456e
+size 341749

--- a/tutorial/images/map-default-3d.png
+++ b/tutorial/images/map-default-3d.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7a7131d2831e8cd62bf8c4de3115f00d9b6b21ea11235f0aff30c70682dd6a6
+size 1130027

--- a/tutorial/images/map-default.png
+++ b/tutorial/images/map-default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dee8092f3052ad7df49732d9fced5d7fddfd719a52a3ea4e51a0ee90015392ab
+size 38850

--- a/tutorial/images/map-gate.png
+++ b/tutorial/images/map-gate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2add3d128e5acb7053163ed6d27f64719a95752ba392f0443f532f9ab0419ab
+size 126526

--- a/tutorial/images/map-hexcraft.png
+++ b/tutorial/images/map-hexcraft.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69624c7377e2f839e7580554c22a58ab75c2c2a8c3147f31a6fb20cadf692874
+size 350117

--- a/tutorial/images/map-labyrinth.png
+++ b/tutorial/images/map-labyrinth.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e83c6adca05847e522ffbddd4b22d176b7e1c3a4da8445bfd51b55f88113eb6
+size 245695

--- a/tutorial/images/map-quests.png
+++ b/tutorial/images/map-quests.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de16f47f90b6f7939b62c31e5f5b4b053dda712a10ea123b14950a979a34599b
+size 495748

--- a/tutorial/images/map-tiny.png
+++ b/tutorial/images/map-tiny.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24b8c73ec8316695b82ec9636381555ed57ac8a4c645898266dd851290acb43a
+size 66499

--- a/tutorial/images/map-tonk.png
+++ b/tutorial/images/map-tonk.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6255120a18995a3c831030f789065bbef78b39664f2f6d122b05979c1c98b570
+size 233848

--- a/tutorial/images/map-vanilla.png
+++ b/tutorial/images/map-vanilla.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:968d8b052e4e50a70e4490139540d32170491c6e07d440aa2f52c8b2229f0b2c
+size 363626

--- a/tutorial/images/private-key-1.png
+++ b/tutorial/images/private-key-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:728d19db518df844b18806f89f38b8dabf6ad1002dc16e970f3f3ac4c12213be
+size 182679

--- a/tutorial/images/private-key-2.png
+++ b/tutorial/images/private-key-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d8f8922ebfb7c882c07cee48da35f341ae0116d746d8eaf6a1fb4e02e64ee11
+size 713920

--- a/tutorial/images/tile-fabricator.png
+++ b/tutorial/images/tile-fabricator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab2fc879adb01952930aacf0c9e9460fff30d5fea57120153fc0d32b9d0d000e
+size 251961

--- a/tutorial/images/wallet.png
+++ b/tutorial/images/wallet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be15c9e56e89f58bdbdc3473c19810bfaee5e597d2fcbe1037b92835bda01970
+size 1116600


### PR DESCRIPTION
### What

New "tutorial" folder for docs to help with building games with downstream.

So far this covers the high level local build process (deferring to main Readme), introduction to core tools and summary of the existing example maps.

Also linked from top of root Reame

Resolves #1168 

### Why

This becomes an in-repo place to point potential builders to get started. 

Its linked from the root readme as well, so anyone browsing the project has easy access ot this guide.

### Next

The upcoming tutorial work should be documented in this folder.

We need a "how to play" guide. Possibly a link to an existing video.

The old docs folder can be removed.