### PR TITLE
option to deploy to redstone

### DIFF
--- a/.github/workflows/build-hexwood.yml
+++ b/.github/workflows/build-hexwood.yml
@@ -38,6 +38,13 @@ on:
           - croissant
           - example-gate
           - labyrinth
+      SELECTED_CHAIN:
+        type: choice
+        description: Chain
+        required: true
+        options:
+          - anvil
+          - redstone-holesky
 
 jobs:
   build:
@@ -49,6 +56,7 @@ jobs:
       DEPLOYMENT_PRIORITY: default
       PLATFORMS: linux/amd64
       DEPLOYMENT_MAP: ${{ inputs.SELECTED_MAP }}
+      DEPLOYMENT_CHAIN: ${{ inputs.SELECTED_CHAIN }}
     secrets:
       AZURE_REGISTRY_URL: ${{ secrets.AZURE_REGISTRY_URL }}
       AZURE_REGISTRY_USERNAME: ${{ secrets.AZURE_REGISTRY_USERNAME }}
@@ -59,3 +67,5 @@ jobs:
       UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
       UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
       UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+      DEPLOYER_PRIVATE_KEY: ${{ secrets.REDSTONE_HOLESKY_DEPLOYER_KEY }}
+      SEQUENCER_PRIVATE_KEY: ${{ secrets.REDSTONE_HOLESKY_SEQUENCER_KEY }}

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -15,6 +15,7 @@ jobs:
       DEPLOYMENT_MAP: quest-map
       DEPLOYMENT_ENVIRONMENT: hexwood0
       DEPLOYMENT_PRIORITY: default
+      DEPLOYMENT_CHAIN: anvil
       PLATFORMS: linux/arm64/v8,linux/amd64
     secrets:
       AZURE_REGISTRY_URL: ${{ secrets.AZURE_REGISTRY_URL }}
@@ -26,3 +27,5 @@ jobs:
       UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
       UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
       UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+      DEPLOYER_PRIVATE_KEY: ${{ secrets.REDSTONE_HOLESKY_DEPLOYER_KEY }}
+      SEQUENCER_PRIVATE_KEY: ${{ secrets.REDSTONE_HOLESKY_SEQUENCER_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,10 @@
 on:
   workflow_call:
     inputs:
+      DEPLOYMENT_CHAIN:
+        type: string
+        description: anvil,redstone etc
+        default: anvil
       DEPLOYMENT_ENVIRONMENT:
         description: Name of environment main/prod/test to deploy to
         required: true
@@ -49,6 +53,12 @@ on:
         required: true
       AZURE_CLUSTER_RESOURCE_GROUP:
         description: Name of the resource group where the cluster lives
+        required: true
+      DEPLOYER_PRIVATE_KEY:
+        description: key for (non-anvil) deployments
+        required: true
+      SEQUENCER_PRIVATE_KEY:
+        description: key for (non-anvil) sequencer
         required: true
       UNITY_SERIAL:
         description: Unity licence serial
@@ -223,6 +233,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
+    - name: Use Node.js 18.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18.x'
     - name: Update deployment status
       uses: bobheadxi/deployments@v0.6.2
       id: deployment
@@ -241,11 +261,42 @@ jobs:
       uses: azure/setup-helm@v3
       with:
         version: '3.7.2'
+    - name: Deploy Contracts
+      env:
+        OVERRIDE_VALUES: overrides.yaml
+        DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+        SEQUENCER_PRIVATE_KEY: ${{ secrets.SEQUENCER_PRIVATE_KEY }}
+      run: |
+        touch $OVERRIDE_VALUES
+        if [[ "${{ inputs.DEPLOYMENT_CHAIN }}" == "redstone-holesky" ]]; then
+          (cd contracts && forge script script/Deploy.sol:GameDeployer \
+            --broadcast \
+            --rpc-url "https://rpc.holesky.redstone.xyz" \
+            --slow
+          )
+          cat contracts/out/latest.json
+          echo "chainId: 17001" >> $OVERRIDE_VALUES
+          echo "indexer:" >> $OVERRIDE_VALUES
+          echo "  gameAddress: $(jq -r .game contracts/out/latest.json)" >> $OVERRIDE_VALUES
+          echo "  stateAddress: $(jq -r .state contracts/out/latest.json)" >> $OVERRIDE_VALUES
+          echo "  routerAddress: $(jq -r .router contracts/out/latest.json)" >> $OVERRIDE_VALUES
+          echo "  providerUrlHttp: https://rpc.holesky.redstone.xyz" >> $OVERRIDE_VALUES
+          echo "  providerUrlWs: wss://rpc.holesky.redstone.xyz/ws" >> $OVERRIDE_VALUES
+          echo "frontend:" >> $OVERRIDE_VALUES
+          echo "  gameAddress: $(jq -r .game contracts/out/latest.json)" >> $OVERRIDE_VALUES
+          echo "sequencer:" >> $OVERRIDE_VALUES
+          echo "  privateKey: ${SEQUENCER_PRIVATE_KEY}" >> $OVERRIDE_VALUES
+          echo "  providerUrlHttp: https://rpc.holesky.redstone.xyz" >> $OVERRIDE_VALUES
+          echo "  providerUrlWs: wss://rpc.holesky.redstone.xyz/ws" >> $OVERRIDE_VALUES
+          echo "  mineEmpty: false" >> $OVERRIDE_VALUES
+        fi
     - name: Deploy to Azure
       env:
+        OVERRIDE_VALUES: overrides.yaml
         CHART_VERSION: ${{ github.sha }}
         CHART_NAMESPACE: ${{ inputs.DEPLOYMENT_ENVIRONMENT }}
         CHART_VALUES: |-
+          chain: ${{ inputs.DEPLOYMENT_CHAIN }}
           cluster:
             domain: ${{ inputs.DEPLOYMENT_DOMAIN }}
           version: ${{ github.sha }}
@@ -258,8 +309,26 @@ jobs:
           --history-max 5 \
           ds ./chart \
             --values /tmp/values.yaml \
+            --values $OVERRIDE_VALUES \
             --create-namespace \
             -n "${CHART_NAMESPACE}"
+    - name: Wait for services
+      uses: iFaxity/wait-on-action@v1.1.0
+      with:
+        resource: https://services-${{ inputs.DEPLOYMENT_ENVIRONMENT }}.${{ inputs.DEPLOYMENT_DOMAIN }}/
+        interval: 1000
+        simultaneous: 1
+        timeout: 600000
+    - name: Apply Map
+      env:
+        DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+        MAP_NAME: ${{ inputs.DEPLOYMENT_MAP }}
+        NETWORK_NAME: ${{ inputs.DEPLOYMENT_ENVIRONMENT }}
+      run: |
+        if [[ "${{ inputs.DEPLOYMENT_CHAIN }}" == "redstone-holesky" ]]; then
+          (cd /tmp && (npm install -g @playmint/ds-cli || true))
+          ds -k "${DEPLOYER_PRIVATE_KEY}" -n "${NETWORK_NAME}" apply -R -f "contracts/src/maps/${MAP_NAME}" --max-connections 50
+        fi
     - name: Update deployment status
       uses: bobheadxi/deployments@v0.6.2
       if: always()

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -3,9 +3,15 @@ gameID: {{ $.Values.frontend.gameAddress | quote}}
 build: {{ $.Values.version | quote }}
 wsEndpoint: "wss://services-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}/query"
 httpEndpoint: "https://services-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}/query"
+{{ if eq $.Values.chain "anvil" }}
 networkEndpoint: "https://network-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
 networkName: "{{ $.Release.Namespace }}"
 networkID: "{{ $.Release.Namespace | mustRegexFind "[0-9]+$" | printf "223%02s" }}"
+{{ else if eq $.Values.chain "redstone-holesky" }}
+networkEndpoint: "https://rpc.holesky.redstone.xyz"
+networkName: "Redstone Holesky"
+networkID: "17001"
+{{ end }}
 tonkEndpoint: "https://tonk-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
 {{ end }}
 
@@ -35,22 +41,27 @@ spec:
           env:
             - name: PORT
               value: "8080"
-            - name: CHAIN_ID
-              value: "{{ $.Release.Namespace | mustRegexFind "[0-9]+$" | printf "223%02s" }}"
             - name: SEQUENCER_PRIVATE_KEY
               value: {{ $.Values.sequencer.privateKey | quote }}
+            {{ if eq $.Values.chain "redstone-holesky" }}
+            - name: CHAIN_ID
+              value: "17001"
+            {{ else }}
+            - name: CHAIN_ID
+              value: "{{ $.Release.Namespace | mustRegexFind "[0-9]+$" | printf "223%02s" }}"
+            {{ end }}
+            - name: SEQUENCER_MINE_EMPTY
+              value: {{ $.Values.sequencer.mineEmpty | quote }}
             - name: SEQUENCER_PROVIDER_URL_HTTP
               value: {{ $.Values.sequencer.providerUrlHttp | quote }}
             - name: SEQUENCER_PROVIDER_URL_WS
               value: {{ $.Values.sequencer.providerUrlWs | quote }}
-            - name: SEQUENCER_MINE_EMPTY
-              value: {{ $.Values.sequencer.mineEmpty | quote }}
-            - name: INDEXER_WATCH_PENDING
-              value: {{ $.Values.indexer.watchPending | quote }}
             - name: INDEXER_PROVIDER_URL_HTTP
               value: {{ $.Values.indexer.providerUrlHttp | quote }}
             - name: INDEXER_PROVIDER_URL_WS
               value: {{ $.Values.indexer.providerUrlWs | quote }}
+            - name: INDEXER_WATCH_PENDING
+              value: {{ $.Values.indexer.watchPending | quote }}
             - name: INDEXER_GAME_ADDRESS
               value: {{ $.Values.indexer.gameAddress | quote }}
             - name: INDEXER_STATE_ADDRESS
@@ -64,7 +75,7 @@ spec:
           - -eu
           - -c
           - |
-            {{ if $.Values.anvil.enabled -}}
+            {{ if eq $.Values.chain "anvil" -}}
             echo "waiting"
             /wait-for -it localhost:8545 -t 300
             {{ end -}}
@@ -80,7 +91,7 @@ spec:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 5
-        {{ if $.Values.anvil.enabled -}}
+        {{ if eq $.Values.chain "anvil" -}}
         - name: contracts
           image: {{ printf "ghcr.io/playmint/ds-contracts:%s" $.Values.version }}
           imagePullPolicy: Always
@@ -107,7 +118,7 @@ spec:
           - mountPath: "/root/.foundry/anvil/tmp"
             name: contracts-scratch
         {{ end -}}
-      {{ if $.Values.anvil.enabled }}
+      {{ if eq $.Values.chain "anvil" }}
       volumes:
       - name: contracts-scratch
         ephemeral:
@@ -184,7 +195,7 @@ spec:
   selector:
     app: {{ $.Release.Name }}-services
 
-{{ if $.Values.anvil.enabled }}
+{{ if eq $.Values.chain "chain" }}
 ---
 apiVersion: v1
 kind: Service
@@ -251,7 +262,7 @@ spec:
       name: "downstream-domain-certificate"
       namespace: "ingress-system"
 
-{{ if $.Values.anvil.enabled }}
+{{ if eq $.Values.chain "anvil" }}
 ---
 apiVersion: "gateway.solo.io/v1"
 kind: VirtualService

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,8 +4,7 @@ cluster:
   domain: downstream.game
 chainId: 1337
 map: "default"
-anvil:
-  enabled: true
+chain: anvil
 sequencer:
   privateKey: "095a37ef5b5d87db7fe50551725cb64804c8c554868d3d729c0dd17f0e664c87"
   providerUrlHttp: "http://localhost:8545"


### PR DESCRIPTION
### what

adds option to the Github Action deployment workflow to deploy to Redstone Holesky

![Screenshot 2024-03-19 at 17 56 26](https://github.com/playmint/ds/assets/45921/870c1c8d-b439-437e-9e72-643f99f72564)


### why

we think it's a good location for some hackathon antics

resolves: #1166 

### notes

the "reset" action will not work for redstone deployments, since the reset action works by destroying the chain, but that is not an option here

### todo

* [x] check the old anvil deployment still works
* [x] it's not currently doing the ds apply for map