### PR TITLE
No panel when selecting billboards

### DIFF
--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -202,6 +202,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
             case 'FactoryBuildingData':
             case 'BlockerBuildingData':
             case 'DisplayBuildingData':
+            case 'BillboardData':
             case 'ExtractorBuildingData':
                 {
                     const t = tiles.find(


### PR DESCRIPTION
This PR fixes an issue where clicking a billboard would not show the billboard's information panel. This was happening because the tile beneath the billboard wasn't being auto-selected when the billboard was clicked.
I have added the billboardData to the auto-select-tile check, so that the tile is now selected with the billboard and so the panel now shows up again.