### PR TITLE
use default map as default MAP env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-MAP=tiny
+MAP=default


### PR DESCRIPTION
# What
default docker work flow now deploys the single tile map

# Why
so customer default workflow allows for deploying maps from scratch , which is how we're running the tutorials

# How
.env file now sets MAP var to default rather than tiny

![image](https://github.com/playmint/ds/assets/90266137/256a5902-85b5-46fb-a694-3ccb3f0eaabb)

resolves #1190 
