### PR TITLE
fix inconsistent tutorial title

### DIFF
--- a/contracts/src/maps/tutorial-room-3/Readme.md
+++ b/contracts/src/maps/tutorial-room-3/Readme.md
@@ -1,5 +1,6 @@
 # Downstream Game Creation Tutorial 3
-## Quests
+
+## Aim
 
 We will follow the steps below to create a series of quests which you will use to guide the player to complete various tasks.
 


### PR DESCRIPTION
all other tutorials start with "aim" this one should too