### PR TITLE
State lockdown

### DIFF
--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -44,12 +44,14 @@ contract GameDeployer is Script {
         Dispatcher dispatcher = ds.getDispatcher();
 
         InventoryRule inventoryRule = new InventoryRule(ds);
+        address tokenAddress = inventoryRule.getTokensAddress();
+        ds.autorizeStateMutation(tokenAddress);
 
         string memory o = "key";
         vm.serializeAddress(o, "game", address(ds));
         vm.serializeAddress(o, "state", address(ds.getState()));
         vm.serializeAddress(o, "router", address(ds.getRouter()));
-        vm.serializeAddress(o, "tokens", address(inventoryRule.getTokensAddress()));
+        vm.serializeAddress(o, "tokens", address(tokenAddress));
         string memory latestJson = vm.serializeAddress(o, "dispatcher", address(dispatcher));
         vm.writeJson(latestJson, "./out/latest.json");
 

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -56,7 +56,6 @@ contract DownstreamGame is BaseGame {
 
     constructor(address _owner) BaseGame("DOWNSTREAM", "http://downstream.game/") {
         owner = _owner;
-        console.log("Registering owner: ", owner);
         // create a state
         BaseState state = new BaseState(address(this));
 
@@ -118,8 +117,12 @@ contract DownstreamGame is BaseGame {
         _registerDispatcher(dispatcher);
     }
 
-    function registerRule(Rule rule) public ownerOnly returns (address) {
+    function registerRule(Rule rule) public ownerOnly {
         state.authorizeContract(address(rule));
         BaseDispatcher(address(dispatcher)).registerRule(rule);
+    }
+
+    function autorizeStateMutation(address addr) public ownerOnly {
+        state.authorizeContract(addr);
     }
 }

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -47,9 +47,18 @@ contract DownstreamRouter is BaseRouter {
 }
 
 contract DownstreamGame is BaseGame {
-    constructor() BaseGame("DOWNSTREAM", "http://downstream.game/") {
+    address public owner;
+
+    modifier ownerOnly() {
+        require(msg.sender == owner, "DownstreamGame: Sender is not the owner");
+        _;
+    }
+
+    constructor(address _owner) BaseGame("DOWNSTREAM", "http://downstream.game/") {
+        owner = _owner;
+        console.log("Registering owner: ", owner);
         // create a state
-        BaseState state = new BaseState();
+        BaseState state = new BaseState(address(this));
 
         // register the kind ids we are using
         state.registerNodeType(Kind.Player.selector, "Player", CompoundKeyKind.ADDRESS);
@@ -97,7 +106,9 @@ contract DownstreamGame is BaseGame {
         BaseRouter router = new DownstreamRouter();
 
         // configure our dispatcher with state
-        BaseDispatcher dispatcher = new BaseDispatcher();
+        BaseDispatcher dispatcher = new BaseDispatcher(address(this));
+        state.authorizeContract(address(dispatcher));
+
         dispatcher.registerState(state);
         dispatcher.registerRouter(router);
 
@@ -105,5 +116,10 @@ contract DownstreamGame is BaseGame {
         _registerState(state);
         _registerRouter(router);
         _registerDispatcher(dispatcher);
+    }
+
+    function registerRule(Rule rule) public ownerOnly returns (address) {
+        state.authorizeContract(address(rule));
+        BaseDispatcher(address(dispatcher)).registerRule(rule);
     }
 }

--- a/contracts/test/helpers/GameTest.sol
+++ b/contracts/test/helpers/GameTest.sol
@@ -79,7 +79,7 @@ struct PlayerAccount {
 }
 
 abstract contract GameTest {
-    Game internal game;
+    DownstreamGame internal game;
     BaseDispatcher internal dispatcher;
     State internal state;
     Dev internal dev;
@@ -92,7 +92,7 @@ abstract contract GameTest {
     constructor() {
         // setup the dev contract for calling cheats
         dev = new Dev();
-        game = new DownstreamGame();
+        game = new DownstreamGame(address(this));
 
         // init players
         players[0] = PlayerAccount({key: 0xa1, addr: __vm.addr(0xa1)});
@@ -112,25 +112,25 @@ abstract contract GameTest {
         tokens = Items1155(inventoryRule.getTokensAddress());
 
         // setup game
-        dispatcher = BaseDispatcher(address(game.getDispatcher()));
-        dispatcher.registerRule(new CheatsRule(address(dev)));
-        dispatcher.registerRule(new MovementRule(game));
-        dispatcher.registerRule(new ScoutRule());
-        dispatcher.registerRule(inventoryRule);
-        dispatcher.registerRule(new BuildingRule(game));
-        dispatcher.registerRule(new CraftingRule(game));
-        dispatcher.registerRule(new PluginRule());
-        dispatcher.registerRule(new NewPlayerRule(allowlist));
-        dispatcher.registerRule(new CombatRule());
-        dispatcher.registerRule(new NamingRule());
-        dispatcher.registerRule(new BagRule());
-        dispatcher.registerRule(new ExtractionRule(game));
+        game.registerRule(new CheatsRule(address(dev)));
+        game.registerRule(new MovementRule(game));
+        game.registerRule(new ScoutRule());
+        game.registerRule(inventoryRule);
+        game.registerRule(new BuildingRule(game));
+        game.registerRule(new CraftingRule(game));
+        game.registerRule(new PluginRule());
+        game.registerRule(new NewPlayerRule(allowlist));
+        game.registerRule(new CombatRule());
+        game.registerRule(new NamingRule());
+        game.registerRule(new BagRule());
+        game.registerRule(new ExtractionRule(game));
         dev.setGame(game);
 
         // fetch the State
         state = game.getState();
 
         // register base goos
+        dispatcher = BaseDispatcher(address(game.getDispatcher()));
         dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.GreenGoo(), "Green Goo", "15-185")));
         dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.BlueGoo(), "Blue Goo", "32-96")));
         dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (ItemUtils.RedGoo(), "Red Goo", "22-256")));

--- a/contracts/test/helpers/GameTest.sol
+++ b/contracts/test/helpers/GameTest.sol
@@ -94,6 +94,9 @@ abstract contract GameTest {
         dev = new Dev();
         game = new DownstreamGame(address(this));
 
+        // tests are allowed to directly maniuplate the state
+        game.autorizeStateMutation(address(this));
+
         // init players
         players[0] = PlayerAccount({key: 0xa1, addr: __vm.addr(0xa1)});
         players[1] = PlayerAccount({key: 0xb2, addr: __vm.addr(0xb2)});
@@ -107,9 +110,18 @@ abstract contract GameTest {
         allowlist[2] = players[2].addr;
         allowlist[3] = players[3].addr;
 
+        // TODO: All players are able to directly manipulate the state. This wouldn't be true in a real game.
+        // however we would have to make all tests utilize the Rule contracts.
+        for (uint256 i = 0; i < allowlist.length; i++) {
+            game.autorizeStateMutation(players[i].addr);
+        }
+
         // items
         InventoryRule inventoryRule = new InventoryRule(game);
         tokens = Items1155(inventoryRule.getTokensAddress());
+
+        // The tokens contract directly mutates state. This is how it works within the real game.
+        game.autorizeStateMutation(address(tokens));
 
         // setup game
         game.registerRule(new CheatsRule(address(dev)));


### PR DESCRIPTION
# What

State mutation can only be done by the owner of the State contract which is the `DownstreamGame` contract, and any autorised contracts which are each of the rule contracts and the 1155 token contract.

Each of the unit tests needed updating as rules needed to be authorised as well as each of the test accounts as we directly manipulate state outside rules during pranks.

## WIP

I'm classing this as WIP as I haven't thoroughly tested our tutorial maps or how easy/possible it is to circumvent my attempt at locking down state.

So far I have tested:
- Deploying tiny map
- spawning a unit
- Moving a unit
- Transferring an 1155 token from inventory, to wallet and back again
- Using building fabricator to deploy a building
- Contructing a building
- Crafting an item and moving it to my inventory

## How

For this to be possible changes have been made to COG to add the concept of `owner` / `allowList` to the `BaseDispatcher` and `BaseGame` contracts therefore the COG PR needs to be merged before this PR is merged.

## Notes

- The deployer account owns the `DownstreamGame` contract
- `DownstreamGame` owns the `BaseState`
- Rules are now registered through the `DownstreamGame` contract which does the job of registering them with the `dispatcher` along with authorising them to make state mutations via the `BaseState` contract.
- The 1155 token is autorised to make direct state modifications by the deploy script calling the `ownerOnly` `autorizeStateMutation` function on the `DownstreamGame` contract.

fixes #1196
