### PR TITLE
Dev Destroy Actions (WIP)

### DIFF
--- a/cli/src/commands/destroy.ts
+++ b/cli/src/commands/destroy.ts
@@ -1,0 +1,183 @@
+import fs from 'fs';
+import { globSync } from 'glob';
+import path from 'path';
+import { Op, getOpsForManifests } from '../utils/destroyer';
+import { readManifestsDocumentsSync } from '../utils/manifest';
+import { getAvailableBuildingKinds } from './get';
+
+type OpResult = {
+    ok: boolean;
+    err?: unknown;
+    op: Op;
+};
+
+export const getManifestFilenames = (filename: string, isRecursive: boolean): string[] => {
+    if (filename === '-') {
+        return [filename];
+    }
+    const isDirectory = fs.lstatSync(filename).isDirectory();
+    if (isDirectory) {
+        if (!isRecursive) {
+            throw new Error(`${filename} is a directory. use --recursive to destroy all manifests in a directory`);
+        }
+        // must be posix path, even on windows
+        const globPath = path.join(filename, '**/*.{yaml,yml}').replace(/\\/g, '/');
+        return globSync(globPath, { follow: true });
+    } else if (isRecursive) {
+        throw new Error(`--filename must be a directory when used with --recursive`);
+    } else {
+        return [filename];
+    }
+};
+
+const destroy = {
+    command: 'destroy',
+    describe: 'destroy an extension configuration from the game',
+    builder: (yargs) =>
+        yargs
+            .option('filename', {
+                alias: 'f',
+                describe: 'path to manifest that contain the configurations to destroy, use "-" to read from stdin',
+                type: 'string',
+            })
+            .option('recursive', {
+                alias: 'R',
+                describe:
+                    'process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory',
+                type: '',
+            })
+            .option('dry-run', {
+                describe: 'show changes that would be destroyed',
+                type: 'boolean',
+            })
+            .option('max-connections', {
+                describe: 'max number of connections to use for submitting parallel tx',
+                type: 'number',
+                default: 250,
+            })
+            .check((ctx) => {
+                if (ctx.filename === '-') {
+                    return true;
+                }
+                if (!fs.existsSync(ctx.filename)) {
+                    throw new Error(`file not found: ${ctx.filename}`);
+                }
+                return true;
+            })
+            .demand(['filename'])
+            .example([
+                ['$0 destroy -f ./manifest.yaml', 'Destroy a single manifest'],
+                ['$0 destroy -R -f .', 'Destroy ALL manifests in directory'],
+            ]),
+    handler: async (ctx) => {
+        const manifestFilenames = getManifestFilenames(ctx.filename, ctx.recursive);
+        const docs = (await Promise.all(manifestFilenames.map(readManifestsDocumentsSync))).flatMap((docs) => docs);
+        const existingBuildingKinds = await getAvailableBuildingKinds(ctx);
+
+        const opsets = await getOpsForManifests(docs, existingBuildingKinds);
+
+        // abort here if dry-run
+        if (ctx.dryRun) {
+            console.error('The following actions will be performed:');
+            console.error(
+                opsets
+                    .flatMap((op) =>
+                        op.flatMap(({ actions }) =>
+                            actions.map(
+                                (op) => `    ${op.name}(${op.args.map((arg) => JSON.stringify(arg)).join(', ')})`
+                            )
+                        )
+                    )
+                    .join('\n')
+            );
+            console.error('');
+            process.exit(0);
+        }
+
+        // authenticate player
+        const player = await ctx.player();
+
+        // destroy the ops
+        let results: OpResult[] = [];
+        for (let i = 0; i < opsets.length; i++) {
+            // batch up the op in the opset to avoid opening too many
+            // connections at once
+            const batches = batched(opsets[i], ctx.maxConnections);
+            for (let j = 0; j < batches.length; j++) {
+                const pending = batches[j].map(async (op) => {
+                    if (op.inBounds === false) {
+                        console.log(`❌ ${op.note} - out of bounds\n`);
+                                return {
+                                    ok: false,
+                                    err: 'coords were out of bounds',
+                                    op,
+                                };
+                    }
+                    let retries = 0;
+                    while (retries < 5) {
+                        try {
+                            await player.dispatchAndWait(...op.actions);
+                            console.log(`✅ ${op.note}\n`);
+                            return {
+                                ok: true,
+                                op,
+                            };
+                        } catch (err) {
+                            if (retries === 4) {
+                                console.log(`❌ ${op.note}\n`);
+                                return {
+                                    ok: false,
+                                    err,
+                                    op,
+                                };
+                            } else {
+                                console.log(`🕒 retrying: ${op.note}\n`);
+                            }
+                        }
+                        retries++;
+                    }
+                    return {
+                        ok: false,
+                        err: `retries exceeded`,
+                        op,
+                    };
+                });
+                const res = await Promise.all(pending);
+                results = [...results, ...res];
+            }
+        }
+
+        // report any failures
+        const errs = results
+            .filter((res) => !res.ok)
+            .map(
+                (res) =>
+                    `file: ${res.op.doc.filename}\nerror:${res.err || 'unknown'}\nactions:${JSON.stringify(
+                        res.op.actions
+                    )}`
+            );
+        if (errs.length > 0) {
+            console.error(`\n${errs.length} manifests failed to destroy:\n\n${errs.join('\n\n')}`);
+            process.exit(1);
+        }
+
+        // done!
+        process.exit(0);
+    },
+};
+
+export default destroy;
+
+function batched<T>(input: T[], perChunk: number): T[][] {
+    return input.reduce((output, item, index) => {
+        const chunkIndex = Math.floor(index / perChunk);
+
+        if (!output[chunkIndex]) {
+            output[chunkIndex] = []; // start a new chunk
+        }
+
+        output[chunkIndex].push(item);
+
+        return output;
+    }, [] as T[][]);
+}

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -11,6 +11,7 @@ import { actions, dispatch } from './commands/actions';
 import config from './commands/config';
 import getter from './commands/get';
 import apply from './commands/apply';
+import destroy from './commands/destroy';
 import { test } from './commands/test';
 import chalk from 'chalk';
 import { offset } from './commands/offset';
@@ -80,6 +81,7 @@ yargs
     .command(config)
     .command(getter)
     .command(apply)
+    .command(destroy)
     .command(test)
     .command(offset)
     .command({

--- a/cli/src/utils/destroyer.ts
+++ b/cli/src/utils/destroyer.ts
@@ -1,0 +1,166 @@
+import { CogAction, NodeSelectors } from '@downstream/core';
+import { BuildingKindFragment } from '@downstream/core/src/gql/graphql';
+import { id as keccak256UTF8, solidityPacked } from 'ethers';
+import { z } from 'zod';
+import {
+    BuildingCategoryEnum,
+    BuildingCategoryEnumVals,
+    ManifestDocument,
+} from '../utils/manifest';
+import { isInBounds } from '../utils/bounds';
+
+export const encodeTileID = ({ q, r, s }: { q: number; r: number; s: number }) => {
+    return solidityPacked(
+        ['bytes4', 'uint96', 'int16', 'int16', 'int16', 'int16'],
+        [NodeSelectors.Tile, 0, 0, q, r, s]
+    );
+};
+
+export const encodeBagID = ({ q, r, s }: { q: number; r: number; s: number }) => {
+    return solidityPacked(['bytes4', 'uint96', 'int16', 'int16', 'int16', 'int16'], [NodeSelectors.Bag, 0, 0, q, r, s]);
+};
+
+const encodeBuildingKindID = ({ name, category }) => {
+    const id = Number(BigInt.asUintN(32, BigInt(keccak256UTF8(`building/${name}`))));
+    const categoryEnum = getBuildingCategoryEnum(category);
+    return solidityPacked(['bytes4', 'uint32', 'uint64', 'uint64'], [NodeSelectors.BuildingKind, 0, id, categoryEnum]);
+};
+
+const getBuildingCategoryEnum = (category: BuildingCategoryEnum): number => {
+    return BuildingCategoryEnumVals.indexOf(category);
+};
+
+const getBuildingKindIDByName = (existingBuildingKinds, pendingBuildingKinds, name: string) => {
+    const foundBuildingKinds = existingBuildingKinds.filter((buildingKind) => buildingKind.name?.value === name);
+    if (foundBuildingKinds.length === 1) {
+        const buildingKind = foundBuildingKinds[0];
+        if (!buildingKind.id) {
+            throw new Error(`missing status.id field for BuildingKind ${name}`);
+        }
+        return buildingKind.id;
+    } else if (foundBuildingKinds.length > 1) {
+        throw new Error(
+            `BuildingKind ${name} is ambiguous, found ${foundBuildingKinds.length} existing BuildingKinds with that name`
+        );
+    }
+    // find ID based on pending specs
+    const manifests = pendingBuildingKinds.filter((m) => m.spec.name == name);
+    if (manifests.length === 0) {
+        throw new Error(
+            `unable to find BuildingKind id for reference: ${name}, are you missing an BuildingKind manifest?`
+        );
+    }
+    if (manifests.length > 1) {
+        throw new Error(
+            `BuildingKind ${name} is ambiguous, found ${manifests.length} different manifests that declare BuildingKinds with that name`
+        );
+    }
+    const manifest = manifests[0];
+    if (manifest.kind !== 'BuildingKind') {
+        throw new Error(`unexpected kind: wanted BuildingKind got ${manifest.kind}`);
+    }
+    return encodeBuildingKindID(manifest.spec);
+};
+
+export const getOpsForManifests = async (
+    docs,
+    existingBuildingKinds: BuildingKindFragment[],
+): Promise<OpSet[]> => {
+    const pendingBuildingKinds = docs.map((doc) => doc.manifest).filter(({ kind }) => kind === 'BuildingKind');
+
+    // build list of operations
+    const opsets: OpSet[] = [];
+    let opn = -1;
+
+    // destroy building instances
+    opn++;
+    opsets[opn] = [];
+    for (const doc of docs) {
+        if (doc.manifest.kind != 'Building') {
+            continue;
+        }
+        const spec = doc.manifest.spec;
+        const [q, r, s] = spec.location;
+        const inBounds = isInBounds(q, r, s);
+        
+        opsets[opn].push({
+            doc,
+            actions: [
+                {
+                    name: 'DEV_DESTROY_BUILDING',
+                    args: [
+                        getBuildingKindIDByName(existingBuildingKinds, pendingBuildingKinds, spec.name),
+                        ...spec.location,
+                    ],
+                },
+            ],
+            note: `destroyed building instance of ${spec.name} at ${spec.location.join(',')}`,
+            inBounds: inBounds,
+        });
+    }
+
+    // destroy tile manifests (this is only valid while cheats are enabled)
+    opn++;
+    opsets[opn] = [];
+    for (const doc of docs) {
+        if (doc.manifest.kind != 'Tile') {
+            continue;
+        }
+        const spec = doc.manifest.spec;
+        const [q, r, s] = spec.location;
+        const inBounds = isInBounds(q, r, s);
+
+        opsets[opn].push({
+            doc,
+            actions: [
+                {
+                    name: 'DEV_DESTROY_TILE',
+                    args: spec.location,
+                },
+            ],
+            note: `destroyed tile ${spec.location.join(',')}`,
+            inBounds: inBounds,
+        });
+    }
+
+    // destory bag manifests (this is only valid while cheats are enabled)
+    opn++;
+    opsets[opn] = [];
+    for (const doc of docs) {
+        if (doc.manifest.kind != 'Bag') {
+            continue;
+        }
+
+        const spec = doc.manifest.spec;
+        const [q, r, s] = spec.location;
+        const inBounds = isInBounds(q, r, s);
+
+        const bagID = encodeBagID({ q, r, s });
+        const ownerAddress = solidityPacked(['uint160'], [0]); // public
+        const equipee = encodeTileID({ q, r, s });
+        const equipSlot = 0;
+
+        opsets[opn].push({
+            doc,
+            actions: [
+                {
+                    name: 'DEV_DESTROY_BAG',
+                    args: [bagID, ownerAddress, equipee, equipSlot],
+                },
+            ],
+            note: `destroyed bag ${spec.location.join(',')}`,
+            inBounds: inBounds,
+        });
+    }
+
+    return opsets;
+};
+
+export type Op = {
+    doc: z.infer<typeof ManifestDocument>;
+    actions: CogAction[];
+    note: string;
+    inBounds?: boolean;
+};
+
+export type OpSet = Op[];

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -183,6 +183,21 @@ interface Actions {
         uint64[] calldata slotBalances
     ) external;
 
+    // destroy a tile at any location
+    function DEV_DESTROY_TILE(int16 q, int16 r, int16 s) external;
+
+    // destroy a building at any location
+    function DEV_DESTROY_BUILDING(bytes24 buildingKind, int16 q, int16 r, int16 s)
+        external;
+
+    // spawn a bag with resources equip somewhere
+    function DEV_DESTROY_BAG(
+        bytes24 bagID,
+        address owner,
+        bytes24 equipee,
+        uint8 equipSlot
+    ) external;
+
     // calling DEV_DISABLE_CHEATS will disable cheats this action cannot
     // be undone, DEV_ cheat actions will be disabled and ignored forever
     function DEV_DISABLE_CHEATS() external;

--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -72,6 +72,18 @@ contract CheatsRule is Rule {
             require(Bounds.isInBounds(q, r, s), "DEV_SPAWN_BUILDING coords out of bounds");
 
             _construct(state, ctx, buildingKind, q, r, s, facingDirection);
+        } else if (bytes4(action) == Actions.DEV_DESTROY_TILE.selector) {
+            require(isCheatAllowed(ctx.sender), "DEV_DESTROY_TILE not allowed");
+            (int16 q, int16 r, int16 s) = abi.decode(action[4:], (int16, int16, int16));
+            require(Bounds.isInBounds(q, r, s), "DEV_DESTROY_TILE coords out of bounds");
+             _destroyTile(state, q, r, s);
+
+        } else if (bytes4(action) == Actions.DEV_DESTROY_BUILDING.selector) {
+            require(isCheatAllowed(ctx.sender), "DEV_DESTROY_BUILDING not allowed");
+
+        } else if (bytes4(action) == Actions.DEV_DESTROY_BAG.selector) {
+            require(isCheatAllowed(ctx.sender), "DEV_DESTROY_BAG not allowed");
+
         } else if (bytes4(action) == Actions.DEV_DISABLE_CHEATS.selector) {
             require(isCheatAllowed(ctx.sender), "DEV_DISABLE_CHEATS not allowed");
 
@@ -101,6 +113,11 @@ contract CheatsRule is Rule {
 
     function _spawnTile(State state, int16 q, int16 r, int16 s) private {
         state.setBiome(Node.Tile(DEFAULT_ZONE, q, r, s), BiomeKind.DISCOVERED);
+    }
+
+    function _destroyTile(State state, int16 q, int16 r, int16 s) private {
+        //state.setBiome(Node.Tile(DEFAULT_ZONE, q, r, s), BiomeKind.UNDISCOVERED);
+        state.destroyTile(Node.Tile(DEFAULT_ZONE, q, r, s));
     }
 
     // allow constructing a building without any materials

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -288,6 +288,11 @@ library Schema {
         return state.set(Rel.Biome.selector, 0x0, node, 0x0, uint64(biome));
     }
 
+    function destroyTile(State state, bytes24 node) internal {
+        // return state.set(Rel.Biome.selector, 0x0, node, 0x0, uint64(biome));
+        return state.remove(Rel.Biome.selector, 0x0, node);
+    }
+
     function getBiome(State state, bytes24 node) internal view returns (BiomeKind) {
         (, uint160 biome) = state.get(Rel.Biome.selector, 0x0, node);
         return BiomeKind(uint8(biome));


### PR DESCRIPTION
## What
implements `ds destroy`. Behaves similar to ds apply, but instead, it results in removing the node from state.
- DEV_DESTROY_TILE
- DEV_DESTROY_BUILDING
- DEV_DESTROY_BAG

## Notes
- Changes have also been made to `ds\core\src\abi\Actions.ts`, which haven't been pushed to the PR

### Current problem
_(Currently testing destroying tiles)_
When I run:
```solidity
state.remove(Rel.Biome.selector, 0x0, node);
```
It seems to change the tile to `UNDISCOVERED`, but it's still rendered and doesn't remove it from the world. (I get this error when I try to move to the removed tile: "dispatch fail: failed to call: execution reverted: NoMoveToUndiscovered")

Still looking into this ^ WIP...

Resolves #1214 