### PR TITLE
removes "not valid cos..." console log message

### DIFF
--- a/frontend/src/plugins/action-context-panel/index.tsx
+++ b/frontend/src/plugins/action-context-panel/index.tsx
@@ -770,10 +770,6 @@ const Combat: FunctionComponent<CombatProps> = ({
     const attackTile = path.slice(-1).find(() => true);
 
     const canAttack = mobileUnit && player && valid && attackTile;
-    if (!valid) {
-        console.log('not valid cos', reason);
-    }
-
     const mobileUnitKey = mobileUnit?.key;
     const mobileUnitId = mobileUnit?.id;
     const mobileUnitLocation = mobileUnit?.nextLocation;


### PR DESCRIPTION
## What
Remove the "not valid cos" `console.log` message
![image](https://github.com/playmint/ds/assets/27741109/50a56d79-1c82-4b29-bb53-39dee7847632)

## Why
It often spams the console and gets in the way when trying to debug things

## Notes
Or we could store the last `reason` to make sure the same message doesn't appear twice in a row?
eg:
```tsx
let lastReason;
...
if (!valid) {
    if (reason != lastReason){
        console.log('not valid cos', reason);
        lastReason = reason;
    }       
}

```