### PR TITLE
Fixed item check examples

### DIFF
--- a/contracts/src/maps/basic-factory/BasicFactory.sol
+++ b/contracts/src/maps/basic-factory/BasicFactory.sol
@@ -86,8 +86,8 @@ contract BasicFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance ) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/basic-factory/BasicFactory.sol
+++ b/contracts/src/maps/basic-factory/BasicFactory.sol
@@ -86,7 +86,7 @@ contract BasicFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, uint64 balance ) = state.getItemSlot(bag, slot);
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
                     if (resource == item && balance > 0) {
                         return true;
                     }

--- a/contracts/src/maps/croissant/kinds/duck-burger/BasicFactory.sol
+++ b/contracts/src/maps/croissant/kinds/duck-burger/BasicFactory.sol
@@ -86,8 +86,8 @@ contract BasicFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance ) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/croissant/kinds/duck-burger/BasicFactory.sol
+++ b/contracts/src/maps/croissant/kinds/duck-burger/BasicFactory.sol
@@ -86,7 +86,7 @@ contract BasicFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, uint64 balance ) = state.getItemSlot(bag, slot);
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
                     if (resource == item && balance > 0) {
                         return true;
                     }

--- a/contracts/src/maps/croissant/kinds/hc-kinds/engineers/hc-en-config/contracts/Utils.sol
+++ b/contracts/src/maps/croissant/kinds/hc-kinds/engineers/hc-en-config/contracts/Utils.sol
@@ -16,7 +16,7 @@ function getItemSlot(State state, bytes24 actor, bytes24 item) view returns (byt
         if (bag != 0) {
             for (uint8 slot = 0; slot < 4; slot++) {
                 (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
-                if (resource == item) {
+                if (resource == item && balance > 0) {
                     return (bag, slot, balance);
                 }
             }

--- a/contracts/src/maps/croissant/kinds/labyrinth-kinds/buildings/BaseFactory.sol
+++ b/contracts/src/maps/croissant/kinds/labyrinth-kinds/buildings/BaseFactory.sol
@@ -86,8 +86,8 @@ contract BaseFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/croissant/kinds/labyrinth-kinds/buildings/Gates/PrepGate.sol
+++ b/contracts/src/maps/croissant/kinds/labyrinth-kinds/buildings/Gates/PrepGate.sol
@@ -50,16 +50,16 @@ contract PrepGate is BuildingKind {
                 uint64 balance;
                 (bagItemId, balance) = state.getItemSlot(bagId, itemSlot);
                 //TODO: this is shameful
-                if (bagItemId == sword) {
+                if (bagItemId == sword && balance > 0) {
                     hasSword = true;
                 }
-                if (bagItemId == shield) {
+                if (bagItemId == shield && balance > 0) {
                     hasShield = true;
                 }
-                if (bagItemId == armor) {
+                if (bagItemId == armor && balance > 0) {
                     hasArmor = true;
                 }
-                if (bagItemId == _UNIVERSAL_KEY) {
+                if (bagItemId == _UNIVERSAL_KEY && balance > 0) {
                     hasUniversalKey = true;
                 }
                 numItems += balance;

--- a/contracts/src/maps/croissant/kinds/labyrinth-kinds/buildings/PasswordFactory/PasswordFactory.sol
+++ b/contracts/src/maps/croissant/kinds/labyrinth-kinds/buildings/PasswordFactory/PasswordFactory.sol
@@ -93,8 +93,8 @@ abstract contract PasswordFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/croissant/kinds/pointless-building/Cuspis.sol
+++ b/contracts/src/maps/croissant/kinds/pointless-building/Cuspis.sol
@@ -86,8 +86,8 @@ contract Cuspis is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/duck-burger/BasicFactory.sol
+++ b/contracts/src/maps/duck-burger/BasicFactory.sol
@@ -86,8 +86,8 @@ contract BasicFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/gate/Gate.sol
+++ b/contracts/src/maps/gate/Gate.sol
@@ -49,7 +49,7 @@ contract ExampleGate is BuildingKind {
             for (itemSlot = 0; itemSlot < 4; itemSlot++) {
                 bytes24 bagItemId;
                 (bagItemId, balance) = state.getItemSlot(bagId, itemSlot);
-                if (bagItemId == itemId) {
+                if (bagItemId == itemId && balance > 0) {
                     // Found item
                     return (bagSlot, itemSlot, balance);
                 }

--- a/contracts/src/maps/hexcraft/hc-kinds/engineers/hc-en-config/contracts/Utils.sol
+++ b/contracts/src/maps/hexcraft/hc-kinds/engineers/hc-en-config/contracts/Utils.sol
@@ -16,7 +16,7 @@ function getItemSlot(State state, bytes24 actor, bytes24 item) view returns (byt
         if (bag != 0) {
             for (uint8 slot = 0; slot < 4; slot++) {
                 (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
-                if (resource == item) {
+                if (resource == item && balance > 0) {
                     return (bag, slot, balance);
                 }
             }

--- a/contracts/src/maps/labyrinth/kinds/buildings/BaseFactory.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/BaseFactory.sol
@@ -86,8 +86,8 @@ contract BaseFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/labyrinth/kinds/buildings/Gates/PrepGate.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/Gates/PrepGate.sol
@@ -50,16 +50,16 @@ contract PrepGate is BuildingKind {
                 uint64 balance;
                 (bagItemId, balance) = state.getItemSlot(bagId, itemSlot);
                 //TODO: this is shameful
-                if (bagItemId == sword) {
+                if (bagItemId == sword && balance > 0) {
                     hasSword = true;
                 }
-                if (bagItemId == shield) {
+                if (bagItemId == shield && balance > 0) {
                     hasShield = true;
                 }
-                if (bagItemId == armor) {
+                if (bagItemId == armor && balance > 0) {
                     hasArmor = true;
                 }
-                if (bagItemId == _UNIVERSAL_KEY) {
+                if (bagItemId == _UNIVERSAL_KEY && balance > 0) {
                     hasUniversalKey = true;
                 }
                 numItems += balance;

--- a/contracts/src/maps/labyrinth/kinds/buildings/PasswordFactory/PasswordFactory.sol
+++ b/contracts/src/maps/labyrinth/kinds/buildings/PasswordFactory/PasswordFactory.sol
@@ -93,8 +93,8 @@ abstract contract PasswordFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/state-storage/StateStorage.sol
+++ b/contracts/src/maps/state-storage/StateStorage.sol
@@ -83,8 +83,8 @@ contract BasicFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/contracts/src/maps/tutorial-room-1/BasicFactory.sol
+++ b/contracts/src/maps/tutorial-room-1/BasicFactory.sol
@@ -86,8 +86,8 @@ contract BasicFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }

--- a/frontend/src/pages/building-fabricator.tsx
+++ b/frontend/src/pages/building-fabricator.tsx
@@ -324,8 +324,8 @@ contract BasicFactory is BuildingKind {
             bytes24 bag = state.getEquipSlot(actor, bagIndex);
             if (bag != 0) {
                 for (uint8 slot = 0; slot < 4; slot++) {
-                    (bytes24 resource, /*uint64 balance*/ ) = state.getItemSlot(bag, slot);
-                    if (resource == item) {
+                    (bytes24 resource, uint64 balance) = state.getItemSlot(bag, slot);
+                    if (resource == item && balance > 0) {
                         return true;
                     }
                 }


### PR DESCRIPTION
### What
Fixed some example code to handle slot item bug.

A bug means Slots can have an item with zero balance so finding the item is not enough. Example code should avoid this bug.

resolves #1149 

Everything should behave exactly the same but maps affected are:
- BasicFactory (Fabricator code updated too). This is in an unused example function.
- Anything that has used BasicFactory and not removed the unused functions (DuckBurger + State Storage).
- Gate example
- Hexcraft
- Labyrinth 
- Croisaant (because it uses all of the above)