### PR TITLE
Adding wallet config to our config template for holesky

### DIFF
--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -11,6 +11,10 @@ networkID: "{{ $.Release.Namespace | mustRegexFind "[0-9]+$" | printf "223%02s" 
 networkEndpoint: "https://rpc.holesky.redstone.xyz"
 networkName: "Redstone Holesky"
 networkID: "17001"
+wallets:
+  metamask: true
+  walletconnect: true
+  burner: false
 {{ end }}
 tonkEndpoint: "https://tonk-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
 {{ end }}


### PR DESCRIPTION
# What

Disabled burner wallet for Redstone Holesky by adding wallet config to the config template

# Why

We want to disable the burner wallet for mainnet. As there isn't a mainnet config as of yet I've added the wallet config for Redstone Holesky in preparation for when we do add the mainnet config.

# Notes

Mostly this was an exercise to see if the wallet config was being pull through as expected. I tested this by adding the wallet config under the anvil section and disabling burner, deploying and checking if the burner option was available which it wasn't.

For the burner to be disabled the burner option has to be explicitly set to `false`. If no wallet config is specified all options default to true.