### PR TITLE
Limit NAME/DESCRIBE owned entity max characters & annotate -> setData

### DIFF
--- a/contracts/src/rules/NamingRule.sol
+++ b/contracts/src/rules/NamingRule.sol
@@ -29,18 +29,22 @@ contract NamingRule is Rule {
     }
 
     function _changeEntityName(State state, bytes24 player, bytes24 entity, string memory name) private {
+        require(bytes(name).length <= 32, "Name exceeds 32 characters");
+
         bytes24 existingOwner = state.getOwner(entity);
         if (existingOwner != 0x0 && existingOwner != player) {
             revert("EntityNotOwnedByPlayer");
         }
-        state.annotate(entity, "name", name);
+        state.setData(entity, "name", bytes32(bytes(name)));
     }
 
     function _changeEntityDescription(State state, bytes24 player, bytes24 entity, string memory desc) private {
+        require(bytes(desc).length <= 140, "Description exceeds 140 characters");
+
         bytes24 existingOwner = state.getOwner(entity);
         if (existingOwner != 0x0 && existingOwner != player) {
             revert("EntityNotOwnedByPlayer");
         }
-        state.annotate(entity, "description", desc);
+        state.setData(entity, "description", bytes32(bytes(desc)));
     }
 }

--- a/contracts/src/rules/NamingRule.sol
+++ b/contracts/src/rules/NamingRule.sol
@@ -39,7 +39,7 @@ contract NamingRule is Rule {
     }
 
     function _changeEntityDescription(State state, bytes24 player, bytes24 entity, string memory desc) private {
-        require(bytes(desc).length <= 140, "Description exceeds 140 characters");
+        require(bytes(desc).length <= 32, "Description exceeds 32 characters");
 
         bytes24 existingOwner = state.getOwner(entity);
         if (existingOwner != 0x0 && existingOwner != player) {

--- a/contracts/test/rules/NamingRule.t.sol
+++ b/contracts/test/rules/NamingRule.t.sol
@@ -22,7 +22,7 @@ contract NamingRuleTest is Test, GameTest {
         setName(entity, name);
 
         BaseState base = BaseState(address(game.getState()));
-        assertEq(base.getAnnotationRef(entity, "name"), keccak256(bytes(name)));
+        assertEq(base.getData(entity, "name"), bytes32(bytes(name)));
         vm.stopPrank();
     }
 

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -75,7 +75,7 @@ fragment WorldMobileUnit on Node {
         id
     }
     # owner assigned name
-    name: annotation(name: "name") {
+    name: data(name: "name") {
         value
     }
 }
@@ -163,10 +163,6 @@ fragment WorldTile on Node {
 fragment WorldPlayer on Node {
     id
     addr: key
-    # player name
-    name: annotation(name: "name") {
-        value
-    }
 }
 
 fragment WorldState on State {

--- a/frontend/src/components/panels/mobile-unit-panel.tsx
+++ b/frontend/src/components/panels/mobile-unit-panel.tsx
@@ -202,7 +202,7 @@ export const MobileUnitPanel = () => {
                 .dispatch({ name: 'NAME_OWNED_ENTITY', args: [entityId, name] })
                 .catch((err) => console.error('naming failed', err));
         },
-        [player]
+        [player, selectedMobileUnit]
     );
 
     const mobileUnitBags = selectedMobileUnit ? getBagsAtEquipee(world?.bags || [], selectedMobileUnit) : [];

--- a/frontend/src/components/panels/mobile-unit-panel.tsx
+++ b/frontend/src/components/panels/mobile-unit-panel.tsx
@@ -188,8 +188,10 @@ export const MobileUnitPanel = () => {
             if (!player) {
                 return;
             }
-            const name = prompt('Enter a name:');
+            const defaultName = formatNameOrId(selectedMobileUnit, 'unit');
+            const name = prompt('Enter a name:', defaultName);
             if (!name || name.length < 3) {
+                alert('rejected: min 3 characters');
                 return;
             }
             if (name.length > 20) {

--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -227,11 +227,11 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, kinds, w
                 )}
                 {selectedTile && <TileInventory tile={selectedTile} bags={world?.bags || []} />}
                 <span className="label" style={{ marginTop: '2rem' }}>
-                    <strong>AUTHOR:</strong> {author.name?.value ? author.name?.value : author.addr}
+                    <strong>AUTHOR:</strong> {author.addr}
                 </span>
                 {owner && (
                     <span className="label">
-                        <strong>OWNER:</strong> {owner.name?.value ? owner.name?.value : owner.addr}
+                        <strong>OWNER:</strong> {owner.addr}
                     </span>
                 )}
                 <span className="label" style={{ width: '30%' }}>

--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -160,7 +160,6 @@ const TileBuilding: FunctionComponent<TileBuildingProps> = ({ building, kinds, w
 
     const author = world?.players.find((p) => p.id === building?.kind?.owner?.id) ?? {
         addr: 'unknown',
-        name: { value: 'unknown' },
     };
     const owner = world?.players.find((p) => p.id === building?.owner?.id);
 

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -1,6 +1,6 @@
 /** @format */
 
-import {ethers} from 'ethers';
+import { ethers } from 'ethers';
 
 interface MaybeNamed {
     id: string;

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -1,5 +1,7 @@
 /** @format */
 
+const decoder = new TextDecoder();
+
 interface MaybeNamed {
     id: string;
     name?: {
@@ -15,7 +17,22 @@ export const formatNameOrId = (node?: MaybeNamed, idPrefix: string = ''): string
     if (!node) {
         return '';
     }
-    return node.name?.value ? node.name.value : `${idPrefix}${formatShortId(node.id)}`;
+    if (node.name?.value) {
+        const length = node.name.value.length / 2;
+
+        // convert the bytes32 (data) value to a Uint8Array
+        const bytes = new Uint8Array(length);
+        for (let i = 0; i < length; i++) {
+            bytes[i] = parseInt(node.name.value.slice(i * 2, i * 2 + 2), 16);
+        }
+
+        // decode the Uint8Array as a string and trim trailing null characters
+        const name = decoder.decode(bytes);
+        const trimmedName = name.replace(/\0/g, '');
+        return trimmedName;
+    } else {
+        return `${idPrefix}${formatShortId(node.id)}`;
+    }
 };
 
 export const getItemStructure = (itemId: string) => {

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -1,6 +1,6 @@
 /** @format */
 
-const decoder = new TextDecoder();
+import {ethers} from 'ethers';
 
 interface MaybeNamed {
     id: string;
@@ -18,18 +18,7 @@ export const formatNameOrId = (node?: MaybeNamed, idPrefix: string = ''): string
         return '';
     }
     if (node.name?.value) {
-        const length = node.name.value.length / 2;
-
-        // convert the bytes32 (data) value to a Uint8Array
-        const bytes = new Uint8Array(length);
-        for (let i = 0; i < length; i++) {
-            bytes[i] = parseInt(node.name.value.slice(i * 2, i * 2 + 2), 16);
-        }
-
-        // decode the Uint8Array as a string and trim trailing null characters
-        const name = decoder.decode(bytes);
-        const trimmedName = name.replace(/\0/g, '');
-        return trimmedName;
+        return ethers.decodeBytes32String(node.name.value);
     } else {
         return `${idPrefix}${formatShortId(node.id)}`;
     }


### PR DESCRIPTION
## What
1. Limited max characters in a name to 32 & description to 140
2. Changed from setting `annotate` to `setData` in `NamingRule.sol`
3. Adjusted code that shows unit name

## Why
1. So that someone can't use their world names and descriptions as a public database!
2. Because farms needs to be able to read name and description data on-chain which `annotate` doesn't currently allow
3. Because `data` is stored as `bytes32` instead of a `string`

## Extra
- Since we removed player naming a while ago, I've removed it from the graphql and implementations of player name in the frontend
- Added alert when mobile unit name is too short (to keep it consistent with behavior when name is too long)
- Mobile unit name prompt now defaults to the current mobile unit name

Resolves #1252 