### PR TITLE
Token contract address set in config

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -284,6 +284,7 @@ jobs:
           echo "  providerUrlWs: wss://rpc.holesky.redstone.xyz/ws" >> $OVERRIDE_VALUES
           echo "frontend:" >> $OVERRIDE_VALUES
           echo "  gameAddress: $(jq -r .game contracts/out/latest.json)" >> $OVERRIDE_VALUES
+          echo "  tokenAddress: $(jq -r .tokens contracts/out/latest.json)" >> $OVERRIDE_VALUES
           echo "sequencer:" >> $OVERRIDE_VALUES
           echo "  privateKey: ${SEQUENCER_PRIVATE_KEY}" >> $OVERRIDE_VALUES
           echo "  providerUrlHttp: https://rpc.holesky.redstone.xyz" >> $OVERRIDE_VALUES

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -200,7 +200,7 @@ spec:
   selector:
     app: {{ $.Release.Name }}-services
 
-{{ if eq $.Values.chain "chain" }}
+{{ if eq $.Values.chain "anvil" }}
 ---
 apiVersion: v1
 kind: Service

--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -16,6 +16,7 @@ wallets:
   walletconnect: true
   burner: false
 {{ end }}
+tokenAddress: {{ $.Values.frontend.tokenAddress | quote }}
 tonkEndpoint: "https://tonk-{{ $.Release.Namespace }}.{{ $.Values.cluster.domain }}"
 {{ end }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -20,4 +20,4 @@ indexer:
   routerAddress: ""
 frontend:
   gameAddress: "DOWNSTREAM" # default to latest address
-
+  tokenAddress: "0x0a668c3342e68b5F9054403e2080fA77259e8DbA"

--- a/core/src/cog.ts
+++ b/core/src/cog.ts
@@ -61,6 +61,7 @@ const cogDefaultConfig = {
     networkEndpoint: 'http://localhost:8545',
     networkID: '22300',
     networkName: 'hexwoodlocal',
+    tokenAddress: '0x0a668c3342e68b5F9054403e2080fA77259e8DbA',
 } satisfies GameConfig;
 
 /**
@@ -94,6 +95,7 @@ export function configureClient({
     actions: iactions,
     authMessage,
     gameID,
+    tokenAddress,
 }: GameConfig) {
     const wsClient = createWSClient({
         url: wsEndpoint,
@@ -289,7 +291,7 @@ export function configureClient({
             ),
         );
 
-    return { gameID, signin, signout, query, subscription, dispatch, block };
+    return { gameID, tokenAddress, signin, signout, query, subscription, dispatch, block };
 }
 
 /**

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -92,6 +92,7 @@ export interface GameConfig {
     networkEndpoint: string;
     networkID: string;
     networkName: string;
+    tokenAddress: string;
 }
 
 export type ActionName = Parameters<ActionsInterface['getFunction']>[0];

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -7,6 +7,7 @@
     "networkEndpoint": "http://localhost:8545",
     "networkID": "22300",
     "networkName": "hexwoodlocal",
+    "tokenAddress": "0x0a668c3342e68b5F9054403e2080fA77259e8DbA",
     "wallets": {
         "metamask": true,
         "walletconnect": true,

--- a/frontend/src/components/panels/wallet-items-panel.tsx
+++ b/frontend/src/components/panels/wallet-items-panel.tsx
@@ -98,7 +98,8 @@ const StyledWalletItemsItem = styled.div`
 export const WalletItemsItem: FunctionComponent<{
     blockNumber: number;
     player: ConnectedPlayer;
-}> = ({ player, blockNumber }) => {
+    tokenAddress: string;
+}> = ({ player, blockNumber, tokenAddress }) => {
     const { provider } = useWalletProvider();
     const tokens = useMemo(
         () =>
@@ -185,8 +186,7 @@ export const WalletItemsItem: FunctionComponent<{
                 params: {
                     type: 'ERC1155',
                     options: {
-                        // FIXME: get this from config.json or graphql somehow
-                        address: '0x0a668c3342e68b5F9054403e2080fA77259e8DbA',
+                        address: tokenAddress,
                         tokenId: BigInt(token.info.item.id).toString(),
                     },
                 },
@@ -202,7 +202,7 @@ export const WalletItemsItem: FunctionComponent<{
         } else {
             console.warn('provider does not support sendAsync or sendCustomRequest');
         }
-    }, [player, provider]);
+    }, [player, provider, tokenAddress]);
 
     return (
         <StyledWalletItemsItem>
@@ -232,17 +232,18 @@ export const WalletItemsItem: FunctionComponent<{
 
 export interface WalletItemsPanelProps {
     player: ConnectedPlayer;
+    tokenAddress: string;
     blockNumber: number;
 }
 
 export const WalletItemsPanel: FunctionComponent<WalletItemsPanelProps> = ({
     player,
     blockNumber,
-}: // acceptedWalletItemss,
-WalletItemsPanelProps) => {
+    tokenAddress,
+}: WalletItemsPanelProps) => {
     return (
         <StyledWalletItemsPanel className="no-scrollbars">
-            <WalletItemsItem player={player} blockNumber={blockNumber} />
+            <WalletItemsItem player={player} blockNumber={blockNumber} tokenAddress={tokenAddress} />
         </StyledWalletItemsPanel>
     );
 };

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -1,4 +1,4 @@
-import { BagFragment, CogAction, QUEST_STATUS_ACCEPTED, WorldTileFragment } from '@app/../../core/src';
+import { BagFragment, CogAction, GameConfig, QUEST_STATUS_ACCEPTED, WorldTileFragment } from '@app/../../core/src';
 import { Bags } from '@app/components/map/Bag';
 import { Buildings } from '@app/components/map/Buildings';
 import { CombatSessions } from '@app/components/map/CombatSession';
@@ -37,7 +37,9 @@ import { getBagsAtEquipee, getBuildingAtTile, getSessionsAtTile } from '@downstr
 import { StyledBasePanel, StyledHeaderPanel } from '@app/styles/base-panel.styles';
 import { WalletItemsPanel } from '@app/components/panels/wallet-items-panel';
 
-export interface ShellProps extends ComponentProps {}
+export interface ShellProps extends ComponentProps {
+    config?: Partial<GameConfig>;
+}
 
 const StyledShell = styled('div')`
     ${styles}
@@ -53,7 +55,7 @@ export type SelectedBag = {
     isCombatReward?: boolean;
 };
 
-export const Shell: FunctionComponent<ShellProps> = () => {
+export const Shell: FunctionComponent<ShellProps> = ({ config }) => {
     const { ready: mapReady, setContainerStyle } = useUnityMap();
     const { world, selected, tiles, selectTiles, selectMobileUnit, selectMapElement, selectIntent } = useGameState();
     const { loadingSession } = useSession();
@@ -427,7 +429,11 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                             />
                         )}
                         {world && player && walletItemsActive && (
-                            <WalletItemsPanel player={player} blockNumber={blockNumber} />
+                            <WalletItemsPanel
+                                player={player}
+                                blockNumber={blockNumber}
+                                tokenAddress={config?.tokenAddress || ''}
+                            />
                         )}
                     </div>
                     <ItemPluginPanel ui={ui || []} />

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -16,7 +16,7 @@ export default function ShellPage() {
                 <GameStateProvider config={config}>
                     <SessionProvider>
                         <InventoryProvider>
-                            <Shell />
+                            <Shell config={config} />
                             {config && <div className="build-version">build v0.1-{config.commit}</div>}
                         </InventoryProvider>
                     </SessionProvider>


### PR DESCRIPTION
# What

On Redsky deployments, tokens can now be added to metamask. This was failing before because we were using the hardcoded token address that makes sense for Anvil deployments (for now anyway). 

Also fixed a typo in `app.yaml` so the avil service is exposed as we weren't able to connect to the anvil endpoint via metamask.

# How

Switched the hardcoded token address in the frontend for an address specified in the config. For Redsky this address is pulled from the `latest.json` file which is output by `Deploy.sol`. For anvil deployments the hardcoded address is still being used however it is now specified in `values.yaml` instead of in the frontend. 

I didn't want to make too many changes to the deployment script but I suppose it would make sense that both types of deployments read the address from `latest.json` however at the moment the overrides are only in place for Redstone

Issue: https://github.com/playmint/ds/issues/1114