### PR TITLE
Modify rules/actions to properly handle zone parameter

### DIFF
--- a/contracts/src/utils/TileUtils.sol
+++ b/contracts/src/utils/TileUtils.sol
@@ -2,11 +2,13 @@
 pragma solidity ^0.8.13;
 
 import {State, CompoundKeyEncoder, CompoundKeyDecoder} from "cog/IState.sol";
-import {Schema, Node, Kind, Q, R, S} from "@ds/schema/Schema.sol";
+import {Schema, Node, Kind, Z, Q, R, S} from "@ds/schema/Schema.sol";
 
 using Schema for State;
 
 library TileUtils {
+    uint256 constant $MAX_INT = 2**256 - 1;
+
     function coords(bytes24 tile) internal pure returns (int16[4] memory keys) {
         keys = CompoundKeyDecoder.INT16_ARRAY(tile);
     }
@@ -14,6 +16,10 @@ library TileUtils {
     function distance(bytes24 tileA, bytes24 tileB) internal pure returns (uint256) {
         int16[4] memory a = CompoundKeyDecoder.INT16_ARRAY(tileA);
         int16[4] memory b = CompoundKeyDecoder.INT16_ARRAY(tileB);
+        if(a[Z] != b[Z]) // If the two tiles are in different zones, return the maximum distance
+        {
+            return $MAX_INT;
+        }
         return uint256(
             (abs(int256(a[Q]) - int256(b[Q])) + abs(int256(a[R]) - int256(b[R])) + abs(int256(a[S]) - int256(b[S]))) / 2
         );


### PR DESCRIPTION
This PR seems like a bit of an anti-climax, but after looking through I think this is all that needs changing.
I've added a zone parameter check to the distance and isDirect functions in TileUtils.
Everything else seems to parent off from these functions so it should do the trick.

I return a big ol' distance in the distance function if the zones are different. I suppose this could just return an error, but the big distance should serve the purpose just as well without extra error handling.

and IsDirect returns false if the zones are different.