### PR TITLE
Zone unit limit and unit active timeout

### DIFF
--- a/contracts/script/Deploy.sol
+++ b/contracts/script/Deploy.sol
@@ -41,7 +41,7 @@ contract GameDeployer is Script {
         Zones721 zoneOwnership = new Zones721(deployerAddr);
 
         // owner is set to deploy account not this contract's address as calls from this script have a msg.sender of the deployer
-        DownstreamGame ds = new DownstreamGame(address(msg.sender), address(zoneOwnership));
+        DownstreamGame ds = new DownstreamGame(address(msg.sender), zoneOwnership);
         Dispatcher dispatcher = ds.getDispatcher();
 
         // tell the zoneOwnership contract to manage the state

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -155,11 +155,11 @@ contract DownstreamGame is BaseGame {
         return unitTimeoutBlocks;
     }
 
-    function setUnitTimeoutBlocks(uint256 blocks) public ownerOnly {
+    function setUnitTimeoutBlocks(uint64 blocks) public ownerOnly {
         _setUnitTimeoutBlocks(blocks);
     }
 
-    function _setUnitTimeoutBlocks(uint256 blocks) internal {
+    function _setUnitTimeoutBlocks(uint64 blocks) internal {
         state.set(Rel.UnitTimeoutBlocks.selector, 0, Node.GameSettings(), Node.GameSettings(), uint64(blocks));
     }
 
@@ -168,11 +168,11 @@ contract DownstreamGame is BaseGame {
         return zoneUnitLimit;
     }
 
-    function setZoneUnitLimit(uint256 limit) public ownerOnly {
+    function setZoneUnitLimit(uint64 limit) public ownerOnly {
         _setZoneUnitLimit(limit);
     }
 
-    function _setZoneUnitLimit(uint256 limit) internal {
+    function _setZoneUnitLimit(uint64 limit) internal {
         state.set(Rel.ZoneUnitLimit.selector, 0, Node.GameSettings(), Node.GameSettings(), uint64(limit));
     }
 }

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -51,6 +51,9 @@ contract DownstreamGame is BaseGame {
     address public zoneOwnership;
     address public tokens;
 
+    uint256 public zoneUnitLimit = 1;
+    uint256 public unitTimeoutBlocks = 10;
+
     modifier ownerOnly() {
         require(msg.sender == owner, "DownstreamGame: Sender is not the owner");
         _;
@@ -137,5 +140,21 @@ contract DownstreamGame is BaseGame {
 
     function autorizeStateMutation(address addr) public ownerOnly {
         state.authorizeContract(addr);
+    }
+
+    function getUnitTimeoutBlocks() public view returns (uint256) {
+        return unitTimeoutBlocks;
+    }
+
+    function setUnitTimeoutBlocks(uint256 blocks) public ownerOnly {
+        unitTimeoutBlocks = blocks;
+    }
+
+    function getZoneUnitLimit() public view returns (uint256) {
+        return zoneUnitLimit;
+    }
+
+    function setZoneUnitLimit(uint256 limit) public ownerOnly {
+        zoneUnitLimit = limit;
     }
 }

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -47,12 +47,12 @@ contract DownstreamRouter is BaseRouter {
 }
 
 contract DownstreamGame is BaseGame {
+    uint64 constant DEFAULT_ZONE_UNIT_LIMIT = 20;
+    uint64 constant DEFAULT_UNIT_TIMEOUT_BLOCKS = 10;
+
     address public owner;
     address public zoneOwnership;
     address public tokens;
-
-    uint256 public zoneUnitLimit = 1;
-    uint256 public unitTimeoutBlocks = 10;
 
     modifier ownerOnly() {
         require(msg.sender == owner, "DownstreamGame: Sender is not the owner");
@@ -88,6 +88,7 @@ contract DownstreamGame is BaseGame {
         state.registerNodeType(Kind.ID.selector, "ID", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.OwnedToken.selector, "OwnedToken", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.Zone.selector, "Zone", CompoundKeyKind.UINT160);
+        state.registerNodeType(Kind.GameSettings.selector, "GameSettings", CompoundKeyKind.NONE);
 
         // register the relationship ids we are using
         state.registerEdgeType(Rel.Owner.selector, "Owner", WeightKind.UINT64);
@@ -112,6 +113,8 @@ contract DownstreamGame is BaseGame {
         state.registerEdgeType(Rel.ID.selector, "ID", WeightKind.UINT64);
         state.registerEdgeType(Rel.HasBlockNum.selector, "HasBlockNum", WeightKind.UINT64);
         state.registerEdgeType(Rel.Parent.selector, "Parent", WeightKind.UINT64);
+        state.registerEdgeType(Rel.ZoneUnitLimit.selector, "ZoneUnitLimit", WeightKind.UINT64);
+        state.registerEdgeType(Rel.UnitTimeoutBlocks.selector, "UnitTimeoutBlocks", WeightKind.UINT64);
 
         // create a session router
         BaseRouter router = new DownstreamRouter();
@@ -127,6 +130,9 @@ contract DownstreamGame is BaseGame {
         _registerState(state);
         _registerRouter(router);
         _registerDispatcher(dispatcher);
+
+        _setZoneUnitLimit(DEFAULT_ZONE_UNIT_LIMIT);
+        _setUnitTimeoutBlocks(DEFAULT_UNIT_TIMEOUT_BLOCKS);
     }
 
     function registerRule(Rule rule) public ownerOnly {
@@ -142,19 +148,29 @@ contract DownstreamGame is BaseGame {
         state.authorizeContract(addr);
     }
 
-    function getUnitTimeoutBlocks() public view returns (uint256) {
+    function getUnitTimeoutBlocks() public view returns (uint64) {
+        (, uint64 unitTimeoutBlocks) = state.get(Rel.UnitTimeoutBlocks.selector, 0, Node.GameSettings());
         return unitTimeoutBlocks;
     }
 
     function setUnitTimeoutBlocks(uint256 blocks) public ownerOnly {
-        unitTimeoutBlocks = blocks;
+        _setUnitTimeoutBlocks(blocks);
     }
 
-    function getZoneUnitLimit() public view returns (uint256) {
+    function _setUnitTimeoutBlocks(uint256 blocks) internal {
+        state.set(Rel.UnitTimeoutBlocks.selector, 0, Node.GameSettings(), Node.GameSettings(), uint64(blocks));
+    }
+
+    function getZoneUnitLimit() public view returns (uint64) {
+        (, uint64 zoneUnitLimit) = state.get(Rel.ZoneUnitLimit.selector, 0, Node.GameSettings());
         return zoneUnitLimit;
     }
 
     function setZoneUnitLimit(uint256 limit) public ownerOnly {
-        zoneUnitLimit = limit;
+        _setZoneUnitLimit(limit);
+    }
+
+    function _setZoneUnitLimit(uint256 limit) internal {
+        state.set(Rel.ZoneUnitLimit.selector, 0, Node.GameSettings(), Node.GameSettings(), uint64(limit));
     }
 }

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -11,6 +11,8 @@ import "./IDownstream.sol";
 import {Schema, Node, Rel, Kind} from "@ds/schema/Schema.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 
+import {ERC721} from "solmate/tokens/ERC721.sol";
+
 using Schema for BaseState;
 
 // -----------------------------------------------
@@ -51,7 +53,7 @@ contract DownstreamGame is BaseGame {
     uint64 constant DEFAULT_UNIT_TIMEOUT_BLOCKS = 10;
 
     address public owner;
-    address public zoneOwnership;
+    ERC721 public zoneOwnership;
     address public tokens;
 
     modifier ownerOnly() {
@@ -59,7 +61,7 @@ contract DownstreamGame is BaseGame {
         _;
     }
 
-    constructor(address _owner, address _zoneOwnership) BaseGame("DOWNSTREAM", "http://downstream.game/") {
+    constructor(address _owner, ERC721 _zoneOwnership) BaseGame("DOWNSTREAM", "http://downstream.game/") {
         owner = _owner;
 
         // create a state
@@ -67,7 +69,7 @@ contract DownstreamGame is BaseGame {
 
         // setup the zone ownership contract
         zoneOwnership = _zoneOwnership;
-        state.authorizeContract(zoneOwnership);
+        state.authorizeContract(address(zoneOwnership));
 
         // register the kind ids we are using
         state.registerNodeType(Kind.Player.selector, "Player", CompoundKeyKind.ADDRESS);

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -206,4 +206,6 @@ interface Actions {
     function DEV_DISABLE_CHEATS() external;
 
     function SET_DATA_ON_BUILDING(bytes24 buildingID, string memory key, bytes32 data) external;
+
+    function KICK_UNIT_FROM_ZONE(bytes24 mobileUnitID) external;
 }

--- a/contracts/src/rules/MovementRule.sol
+++ b/contracts/src/rules/MovementRule.sol
@@ -128,7 +128,10 @@ contract MovementRule is Rule {
             bytes24 player = state.getOwner(mobileUnit);
 
             // If player doesn't own zone check limit
-            if (zoneUnitCount[z] > game.getZoneUnitLimit() && game.zoneOwnership().ownerOf(uint16(z)) != address(uint160(uint192(player)))) {
+            if (
+                zoneUnitCount[z] > game.getZoneUnitLimit()
+                    && game.zoneOwnership().ownerOf(uint16(z)) != address(uint160(uint192(player)))
+            ) {
                 revert("Limit reached on zone");
             }
         }

--- a/contracts/src/rules/MovementRule.sol
+++ b/contracts/src/rules/MovementRule.sol
@@ -151,7 +151,6 @@ contract MovementRule is Rule {
         zoneUnitCount[z] -= 1;
 
         state.setNextLocation(mobileUnit, Node.Tile(0, 0, 0, 0), nowTime);
-        // assign to parent zone
-        state.setParent(mobileUnit, state.getParent(Node.Tile(0, 0, 0, 0)));
+        state.setParent(mobileUnit, bytes24(0));
     }
 }

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -27,6 +27,8 @@ interface Rel {
     function ID() external;
     function HasBlockNum() external;
     function Parent() external;
+    function ZoneUnitLimit() external;
+    function UnitTimeoutBlocks() external;
 }
 
 interface Kind {
@@ -48,6 +50,7 @@ interface Kind {
     function ID() external;
     function OwnedToken() external;
     function Zone() external;
+    function GameSettings() external;
 }
 
 uint64 constant BLOCK_TIME_SECS = 2;
@@ -198,6 +201,10 @@ library Node {
     function Quest(string memory name) internal pure returns (bytes24) {
         uint64 id = uint64(uint256(keccak256(abi.encodePacked("quest/", name))));
         return CompoundKeyEncoder.BYTES(Kind.Quest.selector, bytes20(abi.encodePacked(uint32(0), uint64(0), id)));
+    }
+
+    function GameSettings() internal pure returns (bytes24) {
+        return bytes24(Kind.GameSettings.selector);
     }
 }
 

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -632,4 +632,9 @@ library Schema {
         int16[4] memory keys = CompoundKeyDecoder.INT16_ARRAY(tile);
         return (keys[0], keys[1], keys[2], keys[3]);
     }
+
+    function getTileZone(State, /*state*/ bytes24 tile) external pure returns (int16 z) {
+        int16[4] memory keys = CompoundKeyDecoder.INT16_ARRAY(tile);
+        return (keys[0]);
+    }
 }

--- a/contracts/test/helpers/GameTest.sol
+++ b/contracts/test/helpers/GameTest.sol
@@ -102,7 +102,7 @@ abstract contract GameTest {
         dev = new Dev();
 
         zoneOwnership = new Zones721(address(this));
-        game = new DownstreamGame(address(this), address(zoneOwnership));
+        game = new DownstreamGame(address(this), zoneOwnership);
         zoneOwnership.registerState(game.getState());
 
         // tests are allowed to directly maniuplate the state

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -208,6 +208,14 @@ fragment ZoneState on Node {
 
 fragment GlobalState on State {
     block
+    gameSettings: node(match: { kinds: ["GameSettings"] }) {
+        zoneUnitLimit: edge(match: { kinds: "GameSettings", via: { rel: "ZoneUnitLimit" } }) {
+            weight
+        }
+        unitTimeoutBlocks: edge(match: { kinds: "GameSettings", via: { rel: "UnitTimeoutBlocks" } }) {
+            weight
+        }
+    }
     items: nodes(match: { kinds: "Item" }) {
         ...Item
     }

--- a/frontend/src/components/map/MobileUnit.tsx
+++ b/frontend/src/components/map/MobileUnit.tsx
@@ -4,7 +4,7 @@ import { WorldBuildingFragment, WorldMobileUnitFragment, getCoords, PluginMapPro
 import { memo, useCallback, useMemo, useState } from 'react';
 import Icon from './Icon';
 import { getBuildingAtTile } from '@downstream/core/src/utils';
-import { BLOCK_TIME_SECS } from '@app/fixtures/block-time-secs';
+// import { BLOCK_TIME_SECS } from '@app/fixtures/block-time-secs';
 
 // public int q;
 // public int r;
@@ -16,8 +16,6 @@ import { BLOCK_TIME_SECS } from '@app/fixtures/block-time-secs';
 // public bool visible;
 
 export const DEBUG_ALWAYS_SHOW_UNITS = false;
-export const UNIT_DISPLAY_TIMEOUT_SECS = 60 * 30;
-export const UNIT_DISPLAY_TIMEOUT_BLOCK_COUNT = 10; //Math.floor(UNIT_DISPLAY_TIMEOUT_SECS / BLOCK_TIME_SECS);
 
 export interface MobileUnitData {
     q: number;
@@ -151,6 +149,7 @@ export const MobileUnits = memo(
         onClickMobileUnit,
         playerID,
         pluginProperties,
+        unitTimeoutBlocks,
     }: {
         currentBlock: number;
         mobileUnits?: WorldMobileUnitFragment[];
@@ -159,6 +158,7 @@ export const MobileUnits = memo(
         playerID?: string;
         onClickMobileUnit: (id: string) => void;
         pluginProperties: PluginMapProperty[];
+        unitTimeoutBlocks: number;
     }) => {
         const [unitPositions, setUnitPositions] = useState({}); // New state for positions
 
@@ -182,7 +182,7 @@ export const MobileUnits = memo(
                     }
 
                     // Hide units if they haven't moved in `UNIT_DISPLAY_TIMEOUT_BLOCK_COUNT` blocks;
-                    return currentBlock - u.nextLocation.time < UNIT_DISPLAY_TIMEOUT_BLOCK_COUNT;
+                    return currentBlock - u.nextLocation.time < unitTimeoutBlocks;
                 })
                 .map((u) => {
                     const tile = u.nextLocation?.tile;

--- a/frontend/src/components/map/MobileUnit.tsx
+++ b/frontend/src/components/map/MobileUnit.tsx
@@ -17,7 +17,7 @@ import { BLOCK_TIME_SECS } from '@app/fixtures/block-time-secs';
 
 export const DEBUG_ALWAYS_SHOW_UNITS = false;
 export const UNIT_DISPLAY_TIMEOUT_SECS = 60 * 30;
-export const UNIT_DISPLAY_TIMEOUT_BLOCK_COUNT = Math.floor(UNIT_DISPLAY_TIMEOUT_SECS / BLOCK_TIME_SECS);
+export const UNIT_DISPLAY_TIMEOUT_BLOCK_COUNT = 10; //Math.floor(UNIT_DISPLAY_TIMEOUT_SECS / BLOCK_TIME_SECS);
 
 export interface MobileUnitData {
     q: number;

--- a/frontend/src/components/panels/tile-info-panel.tsx
+++ b/frontend/src/components/panels/tile-info-panel.tsx
@@ -31,7 +31,7 @@ import { FunctionComponent, useCallback, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { colors } from '@app/styles/colors';
 import { getMaterialStats } from '@app/plugins/combat/helpers';
-import { UNIT_DISPLAY_TIMEOUT_BLOCK_COUNT } from '../map/MobileUnit';
+import { unitTimeoutBlocks } from '../map/MobileUnit';
 
 interface KeyedThing {
     key: number;
@@ -279,7 +279,7 @@ const TileAvailable: FunctionComponent<TileAvailableProps> = ({ player, mobileUn
 
     const visibleUnits = tileMobileUnits
         .filter(excludeSelected)
-        .filter((u) => currentBlock - (u.nextLocation?.time || 0) < UNIT_DISPLAY_TIMEOUT_BLOCK_COUNT);
+        .filter((u) => currentBlock - (u.nextLocation?.time || 0) < unitTimeoutBlocks);
 
     const lastTile = selectedTiles?.slice(-1, 1).find(() => true);
     if (!lastTile) {

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -60,6 +60,9 @@ export const Shell: FunctionComponent<ShellProps> = () => {
     const selectedTileBags = selectedBags?.filter((sb) => !sb.isCombatReward);
     const selectedRewardBags = selectedBags?.filter((sb) => sb.isCombatReward);
     const kinds = global?.buildingKinds || [];
+    const unitTimeoutBlocks = global?.gameSettings?.unitTimeoutBlocks?.weight || 0;
+    const zoneUnitLimit = global?.gameSettings?.zoneUnitLimit?.weight || 0;
+
     const ui = usePluginState();
     const [questsActive, setQuestsActive] = useState<boolean>(true);
     const toggleQuestsActive = useCallback(() => setQuestsActive((prev) => !prev), []);
@@ -382,6 +385,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                         selectedMobileUnitID={selectedMobileUnit?.id}
                         playerID={player?.id}
                         pluginProperties={unitColorsModifiedByPlugins}
+                        unitTimeoutBlocks={unitTimeoutBlocks}
                     />
                     <Bags
                         tiles={tiles || []}
@@ -446,6 +450,8 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                                 onClickConnect={connect}
                                 zone={zone}
                                 block={blockNumber}
+                                unitTimeoutBlocks={unitTimeoutBlocks}
+                                zoneUnitLimit={zoneUnitLimit}
                             />
                         )}
                     {player && playerUnits.length > 0 && <TileInfoPanel kinds={kinds || []} ui={ui || []} />}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -130,7 +130,7 @@ const ZoneItem = ({ zone, units, currentBlock }: { zone: Zone; units: ZoneUnit[]
     const description = zone.description?.value ? ethers.decodeBytes32String(zone.description.value) : `no description`;
     const url = `/zones/${id}`;
     const zoneUnits = units.filter((u) => u.location?.tile?.coords && u.location.tile?.coords[0] === zone.key);
-    const activeUnits = zoneUnits.filter((u) => u.location && u.location.time + ACTIVE_UNIT_TIMEOUT < currentBlock);
+    const activeUnits = zoneUnits.filter((u) => u.location && u.location.time + ACTIVE_UNIT_TIMEOUT > currentBlock);
     const availableSlots = UNIT_CAP - activeUnits.length;
     const owner = (zone.owner?.addr || '0x0').slice(0, 6) + '...' + (zone.owner?.addr || '0x0').slice(-4);
 


### PR DESCRIPTION
# What

- Adds configurable (set globally) zone unit limit and unit timeout. 
- Limits on a zone are enforced in the movement rule
- When a zone is at capacity, the owner of the zone is still allowed to join
- After a unit is inactive in a zone for a given amount of `unitTimeoutBlocks` their slot on the zone will be free for the next person take.
- When someone joins a zone, the first inactive unit in the list will be kicked out via the `KICK_UNIT_FROM_ZONE` action which is dispatched before the move action

# How

The zone unit limit and unit timeout are written to the graph using a new `GameSettings` node and `UnitTimeoutBlocks` and `ZoneUnitLimit` edges. Get and set functions for these are exposed on the game contract. Defaults for these are set in the `Downstream.sol` contracts constructor.

When a unit joins a zone, the first inactive unit is kicked out. If the owner had joined an at capacity zone and pushed the unit count over the capacity, the next person to join will kick out 2 units to bring it back under capacity.

# Changing the zone unit limit and unit timeout on a running local build

It's possible to adjust the limits on a build by calling functions on the game contract. One way of doing this is to use `cast` which is part of the foundry suite of tools. 

## Set zone unit limit

Following example sets the zone limit to 1 unit

```shell
cast send --rpc-url http://localhost:8545 --private-key 0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8 0xF8311e28c658003929A7c1218fb8E44cE7A814DE "setZoneUnitLimit(uint64)" 1
```

## Set unit timeout blocks

The Following example sets the unit timeout to 10 blocks (20 seconds)

```shell
cast send --rpc-url http://localhost:8545 --private-key 0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8 0xF8311e28c658003929A7c1218fb8E44cE7A814DE "setUnitTimeoutBlocks(uint64)" 10
```