### PR TITLE
Zoned quests

### DIFF
--- a/cli/src/utils/applier.ts
+++ b/cli/src/utils/applier.ts
@@ -28,13 +28,12 @@ const encodePluginID = ({ name }) => {
     return CompoundKeyEncoder.encodeUint160(NodeSelectors.ClientPlugin, id);
 };
 
-const encodeTaskID = ({ name, kind }) => {
-    const id = Number(BigInt.asUintN(32, BigInt(keccak256UTF8(`task/${name}`))));
-    const kindHash = Number(BigInt.asUintN(32, BigInt(keccak256UTF8(kind))));
-
+const encodeTaskID = ({ zone, name, kind }) => {
+    const id = BigInt.asUintN(64, BigInt(keccak256UTF8(`task/${name}`)));
+    const kindHash = BigInt.asUintN(32, BigInt(keccak256UTF8(kind)));
     return solidityPacked(
-        ['bytes4', 'uint32', 'uint32', 'uint32', 'uint32', 'uint32'],
-        [NodeSelectors.Task, 0, 0, 0, kindHash, id]
+        ['bytes4', 'uint32', 'uint32', 'uint32', 'uint64'],
+        [NodeSelectors.Task, zone, 0, kindHash, id]
     );
 };
 
@@ -42,8 +41,8 @@ const getQuestKey = (name: string) => {
     return BigInt.asUintN(64, BigInt(keccak256UTF8(`quest/${name}`)));
 };
 
-const encodeQuestID = ({ name }) => {
-    return solidityPacked(['bytes4', 'uint32', 'uint64', 'uint64'], [NodeSelectors.Quest, 0, 0, getQuestKey(name)]);
+const encodeQuestID = ({ zone, name }) => {
+    return solidityPacked(['bytes4', 'uint32', 'uint64', 'uint64'], [NodeSelectors.Quest, zone, 0, getQuestKey(name)]);
 };
 
 const itemKindDeploymentActions = async (
@@ -260,7 +259,7 @@ const questDeploymentActions = async (
             }
             case 'questAccept':
             case 'questComplete': {
-                return coder.encode(['bytes24'], [encodeQuestID({ name: task.quest })]);
+                return coder.encode(['bytes24'], [encodeQuestID({ name: task.quest, zone: zoneId })]);
             }
             case 'combat': {
                 const combatState = task.combatState == 'winAttack' ? 0 : 1;
@@ -288,29 +287,26 @@ const questDeploymentActions = async (
     };
 
     // register tasks
-    // const questKey = getQuestKey(spec.name); // TODO: Add questKey to taskID so tasks do not require a unique name globally
     ops.push(
         ...spec.tasks.map((task): CogAction => {
-            const id = encodeTaskID(task);
             const taskData = encodeTaskData(task);
             return {
                 name: 'REGISTER_TASK',
-                args: [id, task.name, taskData],
+                args: [zoneId, task.name, task.kind, taskData],
             };
         })
     );
 
     // register quest
-    const questId = encodeQuestID(spec);
-    const taskIds = spec.tasks.map((task) => encodeTaskID(task));
-    const nextQuestIds = spec.next?.map((questName) => encodeQuestID({ name: questName })) || [];
+    const taskIds = spec.tasks.map((task) => encodeTaskID({ ...task, zone: zoneId }));
+    const nextQuestIds = spec.next?.map((questName) => encodeQuestID({ name: questName, zone: zoneId })) || [];
     const [z, q, r, s] = spec.location
         ? [zoneId, spec.location[0], spec.location[1], spec.location[2]]
         : [zoneId, 0, 0, 0];
 
     ops.push({
         name: 'REGISTER_QUEST',
-        args: [questId, spec.name, spec.description, !!spec.location, z, q, r, s, taskIds, nextQuestIds],
+        args: [zoneId, spec.name, spec.description, !!spec.location, z, q, r, s, taskIds, nextQuestIds],
     });
 
     return ops;

--- a/cli/src/utils/helpers.ts
+++ b/cli/src/utils/helpers.ts
@@ -1,12 +1,8 @@
-import { NodeSelectors } from '@downstream/core';
-import { ItemFragment } from '@downstream/core/src/gql/graphql';
+import { ItemFragment, NodeSelectors } from '@downstream/core';
 import { id as keccak256UTF8, solidityPacked } from 'ethers';
-import {
-    BuildingCategoryEnum,
-    BuildingCategoryEnumVals,
-} from '../utils/manifest';
+import { BuildingCategoryEnum, BuildingCategoryEnumVals } from '../utils/manifest';
 
-export const encodeTileID = ({ z, q, r, s }: { z:number;  q: number; r: number; s: number }) => {
+export const encodeTileID = ({ z, q, r, s }: { z: number; q: number; r: number; s: number }) => {
     return solidityPacked(
         ['bytes4', 'uint96', 'int16', 'int16', 'int16', 'int16'],
         [NodeSelectors.Tile, 0, z, q, r, s]
@@ -29,7 +25,7 @@ export const encodeItemID = ({
     );
 };
 
-export const encodeBagID = ({ z, q, r, s }: { z:number; q: number; r: number; s: number }) => {
+export const encodeBagID = ({ z, q, r, s }: { z: number; q: number; r: number; s: number }) => {
     return solidityPacked(['bytes4', 'uint96', 'int16', 'int16', 'int16', 'int16'], [NodeSelectors.Bag, 0, z, q, r, s]);
 };
 

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -2,9 +2,30 @@ import fs from 'fs';
 import { z } from 'zod';
 import YAML from 'yaml';
 
-export const BuildingCategoryEnumVals = ['none', 'blocker', 'extractor', 'factory', 'custom', 'display', 'billboard'] as const;
+export const BuildingCategoryEnumVals = [
+    'none',
+    'blocker',
+    'extractor',
+    'factory',
+    'custom',
+    'display',
+    'billboard',
+] as const;
 export const BuildingCategoryEnum = z.enum(BuildingCategoryEnumVals);
 export type BuildingCategoryEnum = z.infer<typeof BuildingCategoryEnum>;
+
+export const TaskKindEnumVals = [
+    'none',
+    'coord',
+    'inventory',
+    'message',
+    'questAccept',
+    'questComplete',
+    'combat',
+    'construct',
+    'unitStats',
+    'deployBuilding',
+] as const;
 
 export const ContractSource = z.object({
     file: z.string().optional(),

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -66,13 +66,21 @@ const toYAML = (o: any): string => {
 export function output(ctx) {
     ctx.output = {
         write: (entities: any[]) => {
-            const args = entities.map((entity) => {
-                const o = { ...entity };
-                if (ctx.status === false && o.status) {
-                    delete o.status;
+            console.log(entities);
+            let args: any[] = [];
+            try {
+                if (entities && typeof entities.map !== 'function') {
+                    args = entities.map((entity) => {
+                        const o = { ...entity };
+                        if (ctx.status === false && o.status) {
+                            delete o.status;
+                        }
+                        return o;
+                    });
                 }
-                return o;
-            });
+            } catch (e) {
+                console.warn('executed ok, but failed to format output', e);
+            }
             if (ctx.format == 'json') {
                 const data = args.map((d) => JSON.stringify(d, null, 4));
                 console.log(...data);

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -80,8 +80,8 @@ contract DownstreamGame is BaseGame {
         state.registerNodeType(Kind.Hash.selector, "Hash", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.Atom.selector, "Atom", CompoundKeyKind.UINT160);
         state.registerNodeType(Kind.BlockNum.selector, "BlockNum", CompoundKeyKind.UINT160);
-        state.registerNodeType(Kind.Quest.selector, "Quest", CompoundKeyKind.UINT160);
-        state.registerNodeType(Kind.Task.selector, "Task", CompoundKeyKind.UINT32_ARRAY);
+        state.registerNodeType(Kind.Quest.selector, "Quest", CompoundKeyKind.BYTES);
+        state.registerNodeType(Kind.Task.selector, "Task", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.ID.selector, "ID", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.OwnedToken.selector, "OwnedToken", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.Zone.selector, "Zone", CompoundKeyKind.UINT160);

--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -85,6 +85,7 @@ contract DownstreamGame is BaseGame {
         state.registerNodeType(Kind.ID.selector, "ID", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.OwnedToken.selector, "OwnedToken", CompoundKeyKind.BYTES);
         state.registerNodeType(Kind.Zone.selector, "Zone", CompoundKeyKind.UINT160);
+        state.registerNodeType(Kind.ZonedPlayer.selector, "ZonedPlayer", CompoundKeyKind.BYTES);
 
         // register the relationship ids we are using
         state.registerEdgeType(Rel.Owner.selector, "Owner", WeightKind.UINT64);

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -138,7 +138,7 @@ interface Actions {
     // Quests
 
     function REGISTER_QUEST(
-        bytes24 quest,
+        int16 zone,
         string calldata name,
         string calldata description,
         bool hasLocation,
@@ -150,7 +150,7 @@ interface Actions {
         bytes24[] calldata nextQuests
     ) external;
 
-    function REGISTER_TASK(bytes24 task, string calldata name, bytes calldata taskData) external;
+    function REGISTER_TASK(int16 zone, string calldata name, string calldata kind, bytes calldata taskData) external;
 
     function ACCEPT_QUEST(bytes24 quest, uint8 questNum) external;
 

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 // TODO: Move BuildingCategory into this file
-import {BuildingCategory} from "@ds/schema/Schema.sol";
+import {BuildingCategory, TaskKind} from "@ds/schema/Schema.sol";
 
 enum BiomeKind {
     UNDISCOVERED,
@@ -35,9 +35,6 @@ enum CombatActionKind {
 interface Actions {
     // move the sending player's mobileUnit to target location
     function MOVE_MOBILE_UNIT(int16 z, int16 q, int16 r, int16 s) external;
-
-    // action to set the type of quest the player should begin with
-    function AUTO_QUEST(string calldata name, uint8 index) external;
 
     // transfer a qty of items from itemSlot[0] in equipees[0]'s equipSlots[0] bag
     // to itemSlot[1] in equipees[1]'s equipSlots[1] bag
@@ -150,7 +147,7 @@ interface Actions {
         bytes24[] calldata nextQuests
     ) external;
 
-    function REGISTER_TASK(int16 zone, string calldata name, string calldata kind, bytes calldata taskData) external;
+    function REGISTER_TASK(int16 zone, string calldata name, TaskKind kind, bytes calldata taskData) external;
 
     function ACCEPT_QUEST(bytes24 quest, uint8 questNum) external;
 
@@ -161,6 +158,9 @@ interface Actions {
     // only available by a single authorized account and only for a short
     // period after initial world deployment.
     // ---------------------
+
+    // action to set the type of quest the player should begin with
+    function DEV_ASSIGN_AUTO_QUEST(string memory name, uint16 zone) external;
 
     // spawn a tile at any location
     function DEV_SPAWN_TILE(int16 z, int16 q, int16 r, int16 s) external;

--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -62,6 +62,10 @@ contract CheatsRule is Rule {
                 bytes24[] memory slotContents
             ) = abi.decode(action[4:], (bytes24, address, bytes24, uint8, bytes24[]));
             _destroyBag(state, ctx, bagID, owner, equipee, equipSlot, slotContents);
+        } else if (bytes4(action) == Actions.DEV_ASSIGN_AUTO_QUEST.selector) {
+            (string memory name, int16 zone) = abi.decode(action[4:], (string, int16));
+
+            _assignAutoQuest(state, ctx, name, zone);
         }
 
         return state;
@@ -102,6 +106,13 @@ contract CheatsRule is Rule {
         state.setParent(tile, zone);
         state.setBiome(tile, BiomeKind.DISCOVERED);
         state.setTileAtomValues(tile, [uint64(255), uint64(255), uint64(255)]);
+    }
+
+    function _assignAutoQuest(State state, Context calldata ctx, string memory name, int16 zone) private {
+        bytes24 nZone = Node.Zone(zone);
+        require(state.getOwner(nZone) == Node.Player(ctx.sender), "owner only");
+        bytes24 quest = Node.Quest(zone, name);
+        state.setParent(quest, nZone);
     }
 
     // allow constructing a building without any materials

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -5,16 +5,13 @@ import "cog/IState.sol";
 import "cog/IRule.sol";
 import "cog/IDispatcher.sol";
 
-import {Schema, Node} from "@ds/schema/Schema.sol";
+import {Schema, Node, QuestStatus} from "@ds/schema/Schema.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 import {ItemUtils} from "@ds/utils/ItemUtils.sol";
 
 using Schema for State;
 
 contract NewPlayerRule is Rule {
-    string[] names;
-    uint8[] indexes;
-
     function reduce(State state, bytes calldata action, Context calldata ctx) public returns (State) {
         // spawn a mobileUnit for any player at any location
         if (bytes4(action) == Actions.SPAWN_MOBILE_UNIT.selector) {
@@ -41,12 +38,6 @@ contract NewPlayerRule is Rule {
             state.setItemSlot(bag1, 0, ItemUtils.GreenGoo(), 100);
             state.setItemSlot(bag1, 1, ItemUtils.BlueGoo(), 100);
             state.setItemSlot(bag1, 2, ItemUtils.RedGoo(), 100);
-        }
-
-        if (bytes4(action) == Actions.AUTO_QUEST.selector) {
-            (string memory name, uint8 index) = abi.decode(action[4:], (string, uint8));
-            names.push(name);
-            indexes.push(index);
         }
 
         return state;

--- a/contracts/src/rules/NewPlayerRule.sol
+++ b/contracts/src/rules/NewPlayerRule.sol
@@ -41,11 +41,6 @@ contract NewPlayerRule is Rule {
             state.setItemSlot(bag1, 0, ItemUtils.GreenGoo(), 100);
             state.setItemSlot(bag1, 1, ItemUtils.BlueGoo(), 100);
             state.setItemSlot(bag1, 2, ItemUtils.RedGoo(), 100);
-
-            // Accept the first quest in the chain
-            for (uint8 i = 0; i < names.length; i++) {
-                state.setQuestAccepted(Node.Quest(names[i]), Node.Player(ctx.sender), indexes[i]);
-            }
         }
 
         if (bytes4(action) == Actions.AUTO_QUEST.selector) {

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -87,6 +87,19 @@ enum QuestStatus {
     COMPLETED
 }
 
+enum TaskKind {
+    NONE,
+    COORD,
+    INVENTORY,
+    MESSAGE,
+    QUEST_ACCEPT,
+    QUEST_COMPLETE,
+    COMBAT,
+    CONSTRUCT,
+    UNIT_STATS,
+    DEPLOY_BUILDING
+}
+
 enum BuildingBlockNumKey {
     CONSTRUCTION,
     EXTRACTION
@@ -195,11 +208,11 @@ library Node {
         return bytes24(Kind.BlockNum.selector);
     }
 
-    function Task(int16 zone, string memory name, string memory kind) internal pure returns (bytes24) {
+    function Task(int16 zone, string memory name, TaskKind kind) internal pure returns (bytes24) {
         uint64 nameHash = uint64(uint256(keccak256(abi.encodePacked("task/", name))));
-        uint32 kindHash = uint32(uint256(keccak256(abi.encodePacked(kind))));
         return CompoundKeyEncoder.BYTES(
-            Kind.Task.selector, bytes20(abi.encodePacked(uint32(uint16(zone)), uint32(0), kindHash, nameHash))
+            Kind.Task.selector,
+            bytes20(abi.encodePacked(uint32(uint16(zone)), uint32(0), uint32(uint8(kind)), nameHash))
         );
     }
 

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -33,6 +33,7 @@ interface Kind {
     function ClientPlugin() external;
     function Extension() external;
     function Player() external;
+    function ZonedPlayer() external;
     function MobileUnit() external;
     function Bag() external;
     function Tile() external;
@@ -144,6 +145,12 @@ library Node {
         return CompoundKeyEncoder.ADDRESS(Kind.Player.selector, addr);
     }
 
+    function ZonedPlayer(int16 zone, address addr) internal pure returns (bytes24) {
+        return CompoundKeyEncoder.UINT64(
+            Kind.ZonedPlayer.selector, uint64(uint256(keccak256(abi.encodePacked(zone, addr))))
+        );
+    }
+
     function BuildingKind(uint64 id, BuildingCategory category) internal pure returns (bytes24) {
         return CompoundKeyEncoder.BYTES(
             Kind.BuildingKind.selector, bytes20(abi.encodePacked(uint32(0), id, uint64(category)))
@@ -188,16 +195,19 @@ library Node {
         return bytes24(Kind.BlockNum.selector);
     }
 
-    function Task(uint32 id, string memory kind) internal pure returns (bytes24) {
-        uint32 kindHash = uint32(uint256(keccak256(abi.encode(kind))));
+    function Task(int16 zone, string memory name, string memory kind) internal pure returns (bytes24) {
+        uint64 nameHash = uint64(uint256(keccak256(abi.encodePacked("task/", name))));
+        uint32 kindHash = uint32(uint256(keccak256(abi.encodePacked(kind))));
         return CompoundKeyEncoder.BYTES(
-            Kind.Task.selector, bytes20(abi.encodePacked(uint32(0), uint32(0), uint32(0), kindHash, id))
+            Kind.Task.selector, bytes20(abi.encodePacked(uint32(uint16(zone)), uint32(0), kindHash, nameHash))
         );
     }
 
-    function Quest(string memory name) internal pure returns (bytes24) {
+    function Quest(int16 zone, string memory name) internal pure returns (bytes24) {
         uint64 id = uint64(uint256(keccak256(abi.encodePacked("quest/", name))));
-        return CompoundKeyEncoder.BYTES(Kind.Quest.selector, bytes20(abi.encodePacked(uint32(0), uint64(0), id)));
+        return CompoundKeyEncoder.BYTES(
+            Kind.Quest.selector, bytes20(abi.encodePacked(uint32(uint16(zone)), uint64(0), id))
+        );
     }
 }
 
@@ -553,20 +563,27 @@ library Schema {
         return state.getBlockNum(buildingID, uint8(BuildingBlockNumKey.CONSTRUCTION));
     }
 
-    function getTaskKind(State, /*state*/ bytes24 task) internal pure returns (uint32) {
-        return uint32(uint192(task) >> 32 & type(uint32).max);
+    function setZonedPlayerQuest(
+        State state,
+        bytes24 quest,
+        int16 zone,
+        address player,
+        uint8 questNum,
+        QuestStatus status
+    ) internal {
+        bytes24 zonedPlayer = Node.ZonedPlayer(zone, player);
+        state.setParent(zonedPlayer, Node.Zone(zone));
+        state.setOwner(zonedPlayer, Node.Player(player));
+        state.set(Rel.HasQuest.selector, questNum, zonedPlayer, quest, uint8(status));
     }
 
-    function setQuestAccepted(State state, bytes24 quest, bytes24 player, uint8 questNum) internal {
-        state.set(Rel.HasQuest.selector, questNum, player, quest, uint8(QuestStatus.ACCEPTED));
-    }
-
-    function setQuestCompleted(State state, bytes24 quest, bytes24 player, uint8 questNum) internal {
-        state.set(Rel.HasQuest.selector, questNum, player, quest, uint8(QuestStatus.COMPLETED));
-    }
-
-    function getPlayerQuest(State state, bytes24 player, uint8 questNum) internal view returns (bytes24, QuestStatus) {
-        (bytes24 quest, uint64 status) = state.get(Rel.HasQuest.selector, questNum, player);
+    function getZonedPlayerQuest(State state, int16 zone, address player, uint8 questNum)
+        internal
+        view
+        returns (bytes24, QuestStatus)
+    {
+        bytes24 zonedPlayer = Node.ZonedPlayer(zone, player);
+        (bytes24 quest, uint64 status) = state.get(Rel.HasQuest.selector, questNum, zonedPlayer);
         return (quest, QuestStatus(status));
     }
 

--- a/core/src/helpers.ts
+++ b/core/src/helpers.ts
@@ -16,6 +16,7 @@ export const NodeSelectors = {
     Item: getSelector('Item'),
     MobileUnit: getSelector('MobileUnit'),
     Player: getSelector('Player'),
+    ZonedPlayer: getSelector('ZonedPlayer'),
     Building: getSelector('Building'),
     BuildingKind: getSelector('BuildingKind'),
     ClientPlugin: getSelector('ClientPlugin'),

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -26,6 +26,7 @@ export type {
     LocationFragment,
     GetZonesQuery,
     ItemFragment,
+    AssignedQuestFragment,
 } from './gql/graphql';
 
 export { GetZonesDocument, GetZoneDocument, GetGlobalDocument } from './gql/graphql';

--- a/core/src/player.graphql
+++ b/core/src/player.graphql
@@ -1,11 +1,18 @@
+fragment AssignedQuest on Edge {
+    id
+    key
+    status: weight
+    node {
+        ...Quest
+    }
+}
+
 fragment SelectedPlayer on Node {
     ...WorldPlayer
 
-    quests: edges(match: { via: { rel: "HasQuest", dir: OUT } }) {
-        key
-        status: weight
-        node {
-            ...Quest
+    zone: node(match: { ids: [$zonedPlayerID], via: { rel: "Owner", dir: IN } }) {
+        quests: edges(match: { via: { rel: "HasQuest", dir: OUT } }) {
+            ...AssignedQuest
         }
     }
 
@@ -22,7 +29,7 @@ fragment SelectedPlayer on Node {
     }
 }
 
-query GetSelectedPlayer($gameID: ID!, $id: String!) {
+query GetSelectedPlayer($gameID: ID!, $id: String!, $zonedPlayerID: String!) {
     game(id: $gameID) {
         id
         state(simulated: true) {

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -106,7 +106,7 @@ export function makePluginUI(
                                     ? {
                                           id: state.player.id,
                                           addr: state.player.addr,
-                                          quests: state.player.quests,
+                                          zone: state.player.zone,
                                           tokens: state.player.tokens,
                                       }
                                     : undefined,

--- a/core/src/quest.graphql
+++ b/core/src/quest.graphql
@@ -24,7 +24,6 @@ fragment Quest on Node {
 
 fragment QuestTask on Node {
     id
-    keys
     name: annotation(name: "name") {
         value
     }

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -13,6 +13,7 @@ import {
     WorldMobileUnitFragment,
     WorldPlayerFragment,
     WorldTileFragment,
+    AssignedQuestFragment,
 } from './gql/graphql';
 import { Logger } from './logger';
 import { GlobalState, ZoneWithBags } from './world';
@@ -401,8 +402,6 @@ export type UnconnectedPlayer = undefined;
 
 export type SelectedMapElement = { id: string; type: string };
 
-export type QuestFragment = SelectedPlayerFragment['quests'][0];
-
 // TODO: Generate these from the contract
 export enum TaskKinds {
     coord = 'coord',
@@ -416,7 +415,7 @@ export enum TaskKinds {
     unitStats = 'unitStats',
 }
 
-export type QuestTaskEdge = QuestFragment['node']['tasks'][0];
+export type QuestTaskEdge = AssignedQuestFragment['node']['tasks'][0];
 
 export const QUEST_STATUS_ACCEPTED = 1;
 export const QUEST_STATUS_COMPLETED = 2;

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -402,19 +402,6 @@ export type UnconnectedPlayer = undefined;
 
 export type SelectedMapElement = { id: string; type: string };
 
-// TODO: Generate these from the contract
-export enum TaskKinds {
-    coord = 'coord',
-    message = 'message',
-    inventory = 'inventory',
-    combat = 'combat',
-    questAccept = 'questAccept',
-    questComplete = 'questComplete',
-    construct = 'construct',
-    deployBuilding = 'deployBuilding',
-    unitStats = 'unitStats',
-}
-
 export type QuestTaskEdge = AssignedQuestFragment['node']['tasks'][0];
 
 export const QUEST_STATUS_ACCEPTED = 1;

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -2,7 +2,7 @@ import {
     BuildingKindFragment,
     ConnectedPlayer,
     Log,
-    QuestFragment,
+    AssignedQuestFragment,
     ZoneWithBags,
     WorldTileFragment,
 } from '@app/../../core/src';
@@ -235,7 +235,7 @@ const StyledQuestItem = styled.div`
 
 export const QuestItem: FunctionComponent<{
     expanded: boolean;
-    quest: QuestFragment;
+    quest: AssignedQuestFragment;
     zone: ZoneWithBags;
     tiles: WorldTileFragment[];
     player: ConnectedPlayer;
@@ -263,7 +263,7 @@ export const QuestItem: FunctionComponent<{
         setCompletionPerc(quest.node.tasks.length > 0 ? completionCount / quest.node.tasks.length : 0);
     }, [quest, taskCompletion, setAllCompleted]);
 
-    const onCompleteClick = (quest: QuestFragment) => {
+    const onCompleteClick = (quest: AssignedQuestFragment) => {
         player
             .dispatch({
                 name: 'COMPLETE_QUEST',
@@ -342,7 +342,7 @@ export interface QuestPanelProps {
     player: ConnectedPlayer;
     zone: ZoneWithBags;
     tiles: WorldTileFragment[];
-    acceptedQuests: QuestFragment[];
+    acceptedQuests: AssignedQuestFragment[];
     questMessages?: Log[];
 }
 

--- a/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-accept.tsx
@@ -1,4 +1,4 @@
-import { QuestFragment } from '@downstream/core';
+import { AssignedQuestFragment } from '@downstream/core';
 import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 
@@ -8,7 +8,7 @@ export const TaskQuestAccept = memo(
         quests,
         setTaskCompletion,
     }: {
-        quests?: QuestFragment[];
+        quests?: AssignedQuestFragment[];
     } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         // console.log(`evaluating TaskQuestAccept`);
         const isCompleted = !!quests?.some((q) => q.node.id == task.node.quest?.id);

--- a/frontend/src/components/quest-task/kinds/task-quest-complete.tsx
+++ b/frontend/src/components/quest-task/kinds/task-quest-complete.tsx
@@ -1,4 +1,4 @@
-import { QuestFragment, QUEST_STATUS_COMPLETED } from '@downstream/core';
+import { QUEST_STATUS_COMPLETED, AssignedQuestFragment } from '@downstream/core';
 import { memo, useEffect } from 'react';
 import { TaskItemProps } from '../task-item';
 
@@ -8,7 +8,7 @@ export const TaskQuestComplete = memo(
         quests,
         setTaskCompletion,
     }: {
-        quests?: QuestFragment[];
+        quests?: AssignedQuestFragment[];
     } & Pick<TaskItemProps, 'task' | 'setTaskCompletion'>) => {
         // console.log(`evaluating TaskQuestCompleted`);
         const isCompleted = !!quests?.some(

--- a/frontend/src/components/quest-task/task-item.tsx
+++ b/frontend/src/components/quest-task/task-item.tsx
@@ -1,34 +1,15 @@
-import {
-    QuestTaskEdge,
-    Player,
-    Log,
-    TaskKinds,
-    ZoneWithBags,
-    BuildingKindFragment,
-    WorldTileFragment,
-} from '@downstream/core';
+import { QuestTaskEdge, Player, Log, ZoneWithBags, BuildingKindFragment, WorldTileFragment } from '@downstream/core';
 import { FunctionComponent, Dispatch, SetStateAction, useRef } from 'react';
 import { TaskCoord } from './kinds/task-coord';
 import { TaskInventory } from './kinds/task-inventory';
 import { TaskMessage } from './kinds/task-message';
 import { TaskQuestAccept } from './kinds/task-quest-accept';
 import { TaskQuestComplete } from './kinds/task-quest-complete';
-import { id as keccak256UTF8 } from 'ethers';
 import { TaskConstruct } from './kinds/task-construct';
 import { TaskCombat } from './kinds/task-combat';
 import { TaskDeployBuilding } from './kinds/task-deploy-building';
 import { TaskUnitStats } from './kinds/task-unit-stats';
-
-// TODO: Generate these
-const taskCoord = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.coord))).toString(16);
-const taskMessage = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.message))).toString(16);
-const taskInventory = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.inventory))).toString(16);
-const taskQuestAccept = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.questAccept))).toString(16);
-const taskQuestComplete = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.questComplete))).toString(16);
-const taskCombat = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.combat))).toString(16);
-const taskConstruct = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.construct))).toString(16);
-const taskDeployBuilding = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.deployBuilding))).toString(16);
-const taskUnitStats = '0x' + BigInt.asUintN(32, BigInt(keccak256UTF8(TaskKinds.unitStats))).toString(16);
+import { TaskKindEnumVals } from '@downstream/cli/utils/manifest';
 
 export interface TaskItemProps {
     task: QuestTaskEdge;
@@ -76,17 +57,18 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
     setTaskCompletion,
 }) => {
     const quests = player?.zone?.quests || [];
-    const taskKind = task.node.keys[0];
+    const taskKindIndex = Number(BigInt.asUintN(8, BigInt(task.node.id) >> BigInt(64)));
+    const taskKindValue = TaskKindEnumVals[taskKindIndex];
     const playerUnits = zone?.mobileUnits.filter((mu) => mu.owner && player && mu.owner.id === player.id) || [];
 
     // The ref to the array containing the IDs is only updated if the IDs change. Needed so the CombatMemo didn't update every time we supplied it with a newly filtered list
     const playerUnitIDs = usePlayerUnitIDsMemo(playerUnits.map((u) => u.id));
     const taskMemo = useTaskMemo(task);
 
-    switch (taskKind) {
-        case taskCoord:
+    switch (taskKindValue) {
+        case 'coord':
             return <TaskCoord task={taskMemo} mobileUnits={playerUnits || []} setTaskCompletion={setTaskCompletion} />;
-        case taskInventory:
+        case 'inventory':
             return (
                 <TaskInventory
                     bags={zone?.bags || []}
@@ -95,13 +77,13 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
                     setTaskCompletion={setTaskCompletion}
                 />
             );
-        case taskMessage:
+        case 'message':
             return <TaskMessage task={taskMemo} questMessages={questMessages} setTaskCompletion={setTaskCompletion} />;
-        case taskQuestAccept:
+        case 'questAccept':
             return <TaskQuestAccept task={taskMemo} quests={quests} setTaskCompletion={setTaskCompletion} />;
-        case taskQuestComplete:
+        case 'questComplete':
             return <TaskQuestComplete task={taskMemo} quests={quests} setTaskCompletion={setTaskCompletion} />;
-        case taskConstruct:
+        case 'construct':
             return (
                 <TaskConstruct
                     buildings={zone?.buildings || []}
@@ -111,7 +93,7 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
                     setTaskCompletion={setTaskCompletion}
                 />
             );
-        case taskCombat:
+        case 'combat':
             return (
                 <TaskCombat
                     sessions={zone?.sessions || []}
@@ -120,7 +102,7 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
                     setTaskCompletion={setTaskCompletion}
                 />
             );
-        case taskDeployBuilding:
+        case 'deployBuilding':
             return (
                 <TaskDeployBuilding
                     task={taskMemo}
@@ -129,7 +111,7 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
                     setTaskCompletion={setTaskCompletion}
                 />
             );
-        case taskUnitStats:
+        case 'unitStats':
             return (
                 <TaskUnitStats
                     worldBags={zone?.bags || []}
@@ -138,6 +120,8 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
                     setTaskCompletion={setTaskCompletion}
                 />
             );
+        default:
+            console.warn(`unexpected task kind: ${taskKindValue}`);
     }
 
     return null;

--- a/frontend/src/components/quest-task/task-item.tsx
+++ b/frontend/src/components/quest-task/task-item.tsx
@@ -75,6 +75,7 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
     questMessages,
     setTaskCompletion,
 }) => {
+    const quests = player?.zone?.quests || [];
     const taskKind = task.node.keys[0];
     const playerUnits = zone?.mobileUnits.filter((mu) => mu.owner && player && mu.owner.id === player.id) || [];
 
@@ -97,9 +98,9 @@ export const TaskItem: FunctionComponent<TaskItemProps> = ({
         case taskMessage:
             return <TaskMessage task={taskMemo} questMessages={questMessages} setTaskCompletion={setTaskCompletion} />;
         case taskQuestAccept:
-            return <TaskQuestAccept task={taskMemo} quests={player.quests} setTaskCompletion={setTaskCompletion} />;
+            return <TaskQuestAccept task={taskMemo} quests={quests} setTaskCompletion={setTaskCompletion} />;
         case taskQuestComplete:
-            return <TaskQuestComplete task={taskMemo} quests={player.quests} setTaskCompletion={setTaskCompletion} />;
+            return <TaskQuestComplete task={taskMemo} quests={quests} setTaskCompletion={setTaskCompletion} />;
         case taskConstruct:
             return (
                 <TaskConstruct

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -68,9 +68,11 @@ export const Shell: FunctionComponent<ShellProps> = () => {
     const questMessages = useQuestMessages(10);
     const acceptedQuests = useMemo(() => {
         return (
-            (player?.quests || []).filter((q) => q.status == QUEST_STATUS_ACCEPTED).sort((a, b) => a.key - b.key) || []
+            (player?.zone?.quests || [])
+                .filter((q) => q.status == QUEST_STATUS_ACCEPTED)
+                .sort((a, b) => a.key - b.key) || []
         );
-    }, [player?.quests]);
+    }, [player?.zone?.quests]);
     const unfinalisedCombatSessions = useMemo(
         () =>
             (zone?.sessions || []).filter((s) => {

--- a/frontend/src/hooks/use-game-state.tsx
+++ b/frontend/src/hooks/use-game-state.tsx
@@ -19,6 +19,7 @@ import {
     makeSelection,
     makeWallet,
     makeZone,
+    NodeSelectors,
     PluginUpdateResponse,
     Sandbox,
     SelectedMapElement,
@@ -94,7 +95,9 @@ export const GameStateProvider = ({ config, zoneId, children }: DSContextProvide
         const { wallet, selectProvider } = makeWallet();
         const { client } = makeCogClient(config);
         const { logger, logs } = makeLogger({ name: 'main' });
-        const player = makeConnectedPlayer(client, wallet, logger);
+
+        const zoneKey = zoneId ? Number(BigInt.asIntN(16, BigInt(zoneId.replace(NodeSelectors.Zone, '')))) : 0;
+        const player = makeConnectedPlayer(client, wallet, logger, zoneKey);
         const global = makeGlobal(client);
         const zone = makeZone(client, zoneId || '');
         const { selection, ...selectors } = makeSelection(client, zone, player);


### PR DESCRIPTION
## what

Creates a `ZonedPlayer` entity, to act as a per-player-per-zone point to attach things like quests to.

Attaches quests to that entity, and updates the player query to fetch the zoned data.

Since quests/tasks did not have globally unique ids, I've added the zone into the id and always hash the names to generate the ids to prevent claiming ids that dont conform.

There was no owner check for registering quest/task ids, so I added that

## related

* fixes: #1265 

## notes

until the auto-quest stuff is in you'll have to manually accept the quest from the cli.

* `make dev` to bring up an empty map
* `ds -v -k 0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8 apply -n local -z 1 -R -f contracts/src/maps/tutorial-room-3` to apply tutorial 3 to zone 1
* go spawn your unit in zone 1
* `ds -k 0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8 -n local -z 1 dispatch ACCEPT_QUEST '["0xadbb33ce00000001000000000000000065f3c5f275072c3c",0]'` to manually accept the auto quest