### PR TITLE
Using `setData` to store game settings. Checking ownership via graph

### DIFF
--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -14,6 +14,7 @@ import {Actions} from "@ds/actions/Actions.sol";
 import {ERC721} from "solmate/tokens/ERC721.sol";
 
 using Schema for BaseState;
+using Schema for State;
 
 // -----------------------------------------------
 // a Game sets up the State, Dispatcher and Router
@@ -115,8 +116,6 @@ contract DownstreamGame is BaseGame {
         state.registerEdgeType(Rel.ID.selector, "ID", WeightKind.UINT64);
         state.registerEdgeType(Rel.HasBlockNum.selector, "HasBlockNum", WeightKind.UINT64);
         state.registerEdgeType(Rel.Parent.selector, "Parent", WeightKind.UINT64);
-        state.registerEdgeType(Rel.ZoneUnitLimit.selector, "ZoneUnitLimit", WeightKind.UINT64);
-        state.registerEdgeType(Rel.UnitTimeoutBlocks.selector, "UnitTimeoutBlocks", WeightKind.UINT64);
 
         // create a session router
         BaseRouter router = new DownstreamRouter();
@@ -133,8 +132,8 @@ contract DownstreamGame is BaseGame {
         _registerRouter(router);
         _registerDispatcher(dispatcher);
 
-        _setZoneUnitLimit(DEFAULT_ZONE_UNIT_LIMIT);
-        _setUnitTimeoutBlocks(DEFAULT_UNIT_TIMEOUT_BLOCKS);
+        state.setZoneUnitLimit(DEFAULT_ZONE_UNIT_LIMIT);
+        state.setUnitTimeoutBlocks(DEFAULT_UNIT_TIMEOUT_BLOCKS);
     }
 
     function registerRule(Rule rule) public ownerOnly {
@@ -151,28 +150,18 @@ contract DownstreamGame is BaseGame {
     }
 
     function getUnitTimeoutBlocks() public view returns (uint64) {
-        (, uint64 unitTimeoutBlocks) = state.get(Rel.UnitTimeoutBlocks.selector, 0, Node.GameSettings());
-        return unitTimeoutBlocks;
+        return state.getUnitTimeoutBlocks();
     }
 
     function setUnitTimeoutBlocks(uint64 blocks) public ownerOnly {
-        _setUnitTimeoutBlocks(blocks);
-    }
-
-    function _setUnitTimeoutBlocks(uint64 blocks) internal {
-        state.set(Rel.UnitTimeoutBlocks.selector, 0, Node.GameSettings(), Node.GameSettings(), uint64(blocks));
+        state.setUnitTimeoutBlocks(blocks);
     }
 
     function getZoneUnitLimit() public view returns (uint64) {
-        (, uint64 zoneUnitLimit) = state.get(Rel.ZoneUnitLimit.selector, 0, Node.GameSettings());
-        return zoneUnitLimit;
+        return state.getZoneUnitLimit();
     }
 
     function setZoneUnitLimit(uint64 limit) public ownerOnly {
-        _setZoneUnitLimit(limit);
-    }
-
-    function _setZoneUnitLimit(uint64 limit) internal {
-        state.set(Rel.ZoneUnitLimit.selector, 0, Node.GameSettings(), Node.GameSettings(), uint64(limit));
+        state.setZoneUnitLimit(limit);
     }
 }

--- a/contracts/src/rules/MovementRule.sol
+++ b/contracts/src/rules/MovementRule.sol
@@ -11,19 +11,16 @@ import {TileUtils} from "@ds/utils/TileUtils.sol";
 import {Bounds} from "@ds/utils/Bounds.sol";
 import {Actions} from "@ds/actions/Actions.sol";
 import {BuildingKind} from "@ds/ext/BuildingKind.sol";
-import {DownstreamGame} from "@ds/Downstream.sol";
-
-// import {ERC721} from "solmate/tokens/ERC721.sol";
 
 using Schema for State;
 
 contract MovementRule is Rule {
-    DownstreamGame game;
+    Game game;
 
     // Maps zone id to the number of units in that zone
     mapping(int16 => uint256) public zoneUnitCount;
 
-    constructor(DownstreamGame g) {
+    constructor(Game g) {
         game = g;
     }
 
@@ -132,8 +129,8 @@ contract MovementRule is Rule {
 
                 // If player doesn't own zone check limit
                 if (
-                    zoneUnitCount[z] > game.getZoneUnitLimit()
-                        && game.zoneOwnership().ownerOf(uint16(z)) != address(uint160(uint192(player)))
+                    zoneUnitCount[z] > state.getZoneUnitLimit()
+                        && state.getOwner(Node.Zone(z)) != player
                 ) {
                     revert("Limit reached on zone");
                 }
@@ -147,7 +144,7 @@ contract MovementRule is Rule {
 
         require(z > 0, "Unit not in zone");
 
-        require((nowTime > arrivalTime) && nowTime - arrivalTime >= game.getUnitTimeoutBlocks(), "Unit not timed out");
+        require((nowTime > arrivalTime) && nowTime - arrivalTime >= state.getUnitTimeoutBlocks(), "Unit not timed out");
 
         zoneUnitCount[z] -= 1;
 

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -27,8 +27,6 @@ interface Rel {
     function ID() external;
     function HasBlockNum() external;
     function Parent() external;
-    function ZoneUnitLimit() external;
-    function UnitTimeoutBlocks() external;
 }
 
 interface Kind {
@@ -636,5 +634,21 @@ library Schema {
     function getTileZone(State, /*state*/ bytes24 tile) external pure returns (int16 z) {
         int16[4] memory keys = CompoundKeyDecoder.INT16_ARRAY(tile);
         return (keys[0]);
+    }
+
+    function setZoneUnitLimit(State state, uint64 limit) internal {
+        state.setData(Node.GameSettings(), "zoneUnitLimit", bytes32(uint256(limit)));
+    }
+
+    function getZoneUnitLimit(State state) internal view returns (uint64) {
+        return uint64(uint256(state.getData(Node.GameSettings(), "zoneUnitLimit")));
+    }
+
+    function setUnitTimeoutBlocks(State state, uint64 blocks) internal {
+        state.setData(Node.GameSettings(), "unitTimeoutBlocks", bytes32(uint256(blocks)));
+    }
+
+    function getUnitTimeoutBlocks(State state) internal view returns (uint64) {
+        return uint64(uint256(state.getData(Node.GameSettings(), "unitTimeoutBlocks")));
     }
 }

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -209,11 +209,11 @@ fragment ZoneState on Node {
 fragment GlobalState on State {
     block
     gameSettings: node(match: { kinds: ["GameSettings"] }) {
-        zoneUnitLimit: edge(match: { kinds: "GameSettings", via: { rel: "ZoneUnitLimit" } }) {
-            weight
+        zoneUnitLimit: data(name: "zoneUnitLimit") {
+            value
         }
-        unitTimeoutBlocks: edge(match: { kinds: "GameSettings", via: { rel: "UnitTimeoutBlocks" } }) {
-            weight
+        unitTimeoutBlocks: data(name: "unitTimeoutBlocks") {
+            value
         }
     }
     items: nodes(match: { kinds: "Item" }) {

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -60,8 +60,8 @@ export const Shell: FunctionComponent<ShellProps> = () => {
     const selectedTileBags = selectedBags?.filter((sb) => !sb.isCombatReward);
     const selectedRewardBags = selectedBags?.filter((sb) => sb.isCombatReward);
     const kinds = global?.buildingKinds || [];
-    const unitTimeoutBlocks = global?.gameSettings?.unitTimeoutBlocks?.weight || 0;
-    const zoneUnitLimit = global?.gameSettings?.zoneUnitLimit?.weight || 0;
+    const unitTimeoutBlocks = parseInt(global?.gameSettings?.unitTimeoutBlocks?.value || '0x0', 16);
+    const zoneUnitLimit = parseInt(global?.gameSettings?.zoneUnitLimit?.value || '0x0', 16);
 
     const ui = usePluginState();
     const [questsActive, setQuestsActive] = useState<boolean>(true);

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -171,8 +171,8 @@ const Index = ({ config }: { config: Partial<GameConfig> | undefined }) => {
     const block = useBlock();
     const [zonesData, setZonesData] = useState<GetZonesQuery>();
     const global = useGlobal();
-    const unitTimeoutBlocks = global?.gameSettings?.unitTimeoutBlocks?.weight || 0;
-    const zoneUnitLimit = global?.gameSettings?.zoneUnitLimit?.weight || 0;
+    const unitTimeoutBlocks = parseInt(global?.gameSettings?.unitTimeoutBlocks?.value || '0x0', 16);
+    const zoneUnitLimit = parseInt(global?.gameSettings?.zoneUnitLimit?.value || '0x0', 16);
 
     useEffect(() => {
         if (!config?.gameID) {


### PR DESCRIPTION
# What

- Instead of setting each game setting variable as an edge, using `setData` instead
- Instead of checking ownership via the NFT contract, checking the zone node owner via the graph

# Why

Checking the ownership via the NFT contract directly was convoluted and as the ownership is already recorded on the graph there's a more direct way to look for the zone's owner.

Have an edge to represent each setting wouldn't scale well if we decide to add more settings also calling the game contract to get at them is more expensive than using the `Schema` library