### PR TITLE
Changing default Unit timeout to 30 minutes

### DIFF
--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -51,7 +51,7 @@ contract DownstreamRouter is BaseRouter {
 
 contract DownstreamGame is BaseGame {
     uint64 constant DEFAULT_ZONE_UNIT_LIMIT = 20;
-    uint64 constant DEFAULT_UNIT_TIMEOUT_BLOCKS = 10;
+    uint64 constant DEFAULT_UNIT_TIMEOUT_BLOCKS = (30 * 60) / 2; // 30 minutes (2 second blocks)
 
     address public owner;
     ERC721 public zoneOwnership;


### PR DESCRIPTION
# What

Changing default time to 30 minutes (900 blocks)

# Why

Was set to 20 seconds for testing and it is too short for a deployment