### PR TITLE
Lazy version of accepting zone quests

### DIFF
--- a/contracts/src/utils/ItemUtils.sol
+++ b/contracts/src/utils/ItemUtils.sol
@@ -41,24 +41,4 @@ library ItemUtils {
     function IDCard() internal pure returns (bytes24) {
         return Node.Item("ID Card", [uint32(100), uint32(100), uint32(76)], true);
     }
-
-    // register is a helper to declare a new kind of item
-    function register(Game ds, ItemConfig memory cfg) internal returns (bytes24) {
-        Dispatcher dispatcher = ds.getDispatcher();
-        uint32[3] memory outputItemAtoms = [uint32(cfg.greenGoo), uint32(cfg.blueGoo), uint32(cfg.redGoo)];
-        bytes24 itemKind = Node.Item(uint32(cfg.id), outputItemAtoms, cfg.stackable);
-        dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_ITEM_KIND, (itemKind, cfg.name, cfg.icon)));
-        if (address(cfg.implementation) != address(0)) {
-            dispatcher.dispatch(abi.encodeCall(Actions.REGISTER_KIND_IMPLEMENTATION, (itemKind, cfg.implementation)));
-        }
-        if (abi.encodePacked(cfg.plugin).length != 0) {
-            dispatcher.dispatch(
-                abi.encodeCall(
-                    Actions.REGISTER_KIND_PLUGIN,
-                    (Node.ClientPlugin(uint64(cfg.id)), itemKind, cfg.name, cfg.plugin, cfg.alwaysActivePlugin)
-                )
-            );
-        }
-        return itemKind;
-    }
 }

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -207,6 +207,12 @@ fragment ZoneState on Node {
     tiles: nodes(match: { kinds: "Tile", via: { rel: "Parent", dir: IN } }) {
         ...WorldTile
     }
+    availableQuests: nodes(match: { kinds: "Quest", via: { rel: "Parent", dir: IN } }) {
+        id
+        name: annotation(name: "name") {
+            value
+        }
+    }
 }
 
 fragment GlobalState on State {
@@ -265,7 +271,7 @@ query GetZones($gameID: ID!) {
                 }
                 url: annotation(name: "url") {
                     value
-                }                
+                }
                 owner: node(match: { via: { rel: "Owner" } }) {
                     id
                     addr: key

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -326,6 +326,42 @@ export const Shell: FunctionComponent<ShellProps> = () => {
         }
     }, [combatSessionTick, player, prevCombatSessionTick, blockNumber, selectedMobileUnit, zone?.mobileUnits]);
 
+    // if there is an available quest to accept in this zone
+    // and the player has not accept it, automatically accept it now
+    const [acceptingAutoQuest, setAcceptingAutoQuest] = useState(false);
+    useEffect(() => {
+        if (!player) {
+            return;
+        }
+        if (!zone?.availableQuests) {
+            return;
+        }
+        if (acceptingAutoQuest) {
+            return;
+        }
+        const actions = zone.availableQuests
+            .filter((available) => !player?.zone?.quests.some((accepted) => accepted.node.id == available.id))
+            .map(
+                ({ id }, idx): CogAction => ({
+                    name: 'ACCEPT_QUEST',
+                    args: [id, idx],
+                })
+            );
+        if (actions.length == 0) {
+            return;
+        }
+        setAcceptingAutoQuest(true);
+        // NOTE: it is intensional that setAcceptingAutoQuest is not in a finally() and only in the then()
+        // this is so that any errors do not cause an infinite loop. this is just a best effort attempt to
+        // assign all the quests, but the way quests are assigned is not currently setup to handle changing
+        // the auto assigned quests after they have been assigned, so the chances of this getting in a bad
+        // state are quite high... so just give up if it fails for now
+        player
+            .dispatch(...actions)
+            .then(() => setAcceptingAutoQuest(false))
+            .catch((err) => console.error('failed to accept auto assigned quest', err));
+    }, [player, zone?.availableQuests, acceptingAutoQuest]);
+
     const tileClick = useCallback(
         (id) => {
             if (!selectTiles) {

--- a/frontend/src/pages/building-fabricator.tsx
+++ b/frontend/src/pages/building-fabricator.tsx
@@ -1144,6 +1144,7 @@ const BuildingFabricator = () => {
                 tiles: [],
                 mobileUnits: [],
                 sessions: [],
+                availableQuests: [],
             };
             validate();
             const yaml = getManifestsYAML({

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -585,16 +585,14 @@ const Index = ({ config }: { config: Partial<GameConfig> | undefined }) => {
                             ? [currentZone]
                             : zones
                         ).map((z) => (
-                            <>
-                                <ZoneItem
-                                    key={z.id}
-                                    zone={z}
-                                    units={units}
-                                    currentBlock={block || 0}
-                                    unitTimeoutBlocks={unitTimeoutBlocks}
-                                    zoneUnitLimit={zoneUnitLimit}
-                                />
-                            </>
+                            <ZoneItem
+                                key={z.id}
+                                zone={z}
+                                units={units}
+                                currentBlock={block || 0}
+                                unitTimeoutBlocks={unitTimeoutBlocks}
+                                zoneUnitLimit={zoneUnitLimit}
+                            />
                         ))}
                     </ul>
                 </StyledPanel>


### PR DESCRIPTION
## what

cherry-picked some bits from @JackPlaymint's work in #1275 to create a quick-n-dirty version that automatically enrolls any player visiting a zone in any zone quests that they do not have.

this is NOT as good as what the other PR was aiming for where it gives the player some UI and option to accept the available zone quests, and we probably still want that too.... but it's a quick fix so that we can use the quest-map today.

**the way quests are assigned really isn't setup for changing things after they are initially deployed (you can't remove quests from existing players, you can't assign a quest to an existing quest index, etc) so I've just made this try it's best then give up.**

PR also contains some boyscouting fixes spotted along the way