### PR TITLE
ds-cli: default max-connections=10

### DIFF
--- a/cli/src/commands/apply.ts
+++ b/cli/src/commands/apply.ts
@@ -63,7 +63,7 @@ const deploy = {
             .option('max-connections', {
                 describe: 'max number of connections to use for submitting parallel tx',
                 type: 'number',
-                default: 250,
+                default: 10,
             })
             .check((ctx) => {
                 if (ctx.filename === '-') {

--- a/cli/src/commands/destroy.ts
+++ b/cli/src/commands/destroy.ts
@@ -61,7 +61,7 @@ const destroy = {
             .option('max-connections', {
                 describe: 'max number of connections to use for submitting parallel tx',
                 type: 'number',
-                default: 250,
+                default: 10,
             })
             .check((ctx) => {
                 if (ctx.filename === '-') {
@@ -83,7 +83,7 @@ const destroy = {
         }
         const manifestFilenames = getManifestFilenames(ctx.filename, ctx.recursive);
         const docs = (await Promise.all(manifestFilenames.map(readManifestsDocumentsSync))).flatMap((docs) => docs);
-      
+
         const zone = await getZone(ctx);
         const global = await getGlobal(ctx);
 


### PR DESCRIPTION
sending too many tx too quickly can get you rate limited or generally put too much stress on the RPC endpoint

so be a good netizen and lower the amount ds-cli hammers the transactions during `ds apply` and `ds destroy`

this makes apply much slower, but also much more likely to succeed first time on public endpoints.