### PR TITLE
Zone aware Auto-Quests

### DIFF
--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -207,7 +207,7 @@ fragment ZoneState on Node {
     tiles: nodes(match: { kinds: "Tile", via: { rel: "Parent", dir: IN } }) {
         ...WorldTile
     }
-    availableQuests: nodes(match: { kinds: "Quest", via: { rel: "Parent", dir: IN } }) {
+    autoquests: nodes(match: { kinds: "Quest", via: { rel: "Parent", dir: IN } }) {
         id
         name: annotation(name: "name") {
             value

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -338,6 +338,39 @@ export const QuestItem: FunctionComponent<{
     );
 };
 
+export const AutoQuestItem: FunctionComponent<{
+    id: number;
+    questName: string;
+    player: ConnectedPlayer;
+}> = ({ id, questName, player }) => {
+    const onAcceptClick = () => {
+        player
+            .dispatch({
+                name: 'ACCEPT_QUEST',
+                args: [id, 0],
+            })
+            .catch((e) => {
+                console.error('Failed to accept quest', questName, e);
+            });
+    };
+
+    return (
+        <StyledQuestItem expanded={true}>
+            <>
+                <div className="header">
+                    <h3>{questName?.value}</h3>
+                </div>
+
+                <div className="buttonContainer">
+                    <CompleteQuestButton onClick={() => onAcceptClick()} className="completeQuestButton">
+                        Accept Quest
+                    </CompleteQuestButton>
+                </div>
+            </>
+        </StyledQuestItem>
+    );
+};
+
 export interface QuestPanelProps {
     player: ConnectedPlayer;
     zone: ZoneWithBags;
@@ -393,6 +426,9 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
 
     return (
         <StyledQuestPanel className="no-scrollbars">
+            {!acceptedQuests.find((quest) => quest.node.id == zone.autoquests[0].id) && (
+                <AutoQuestItem id={zone.autoquests[0].id} questName={zone.autoquests[0].name} player={player} />
+            )}
             {acceptedQuests.map((quest, questIdx) => (
                 <QuestItem
                     tiles={tiles}

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -428,7 +428,7 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
         <StyledQuestPanel className="no-scrollbars">
             {zone?.autoquests.map(
                 (autoquest) =>
-                    acceptedQuests.find((quest) => quest.node.id === autoquest.id) && (
+                    !acceptedQuests.find((quest) => quest.node.id === autoquest.id) && (
                         <AutoQuestItem
                             key={autoquest.id}
                             id={autoquest.id || ''}
@@ -436,13 +436,6 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
                             player={player}
                         />
                     )
-            )}
-            {zone?.autoquests.length > 0 && !acceptedQuests.find((quest) => quest.node.id == zone.autoquests[0].id) && (
-                <AutoQuestItem
-                    id={zone.autoquests[0].id}
-                    questName={zone.autoquests[0].name?.value || ''}
-                    player={player}
-                />
             )}
             {acceptedQuests.map((quest, questIdx) => (
                 <QuestItem

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -426,17 +426,18 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
 
     return (
         <StyledQuestPanel className="no-scrollbars">
-            {zone?.autoquests.map(
-                (autoquest) =>
-                    !acceptedQuests.find((quest) => quest.node.id === autoquest.id) && (
+            {acceptedQuests.length === 0 &&
+                zone?.autoquests
+                    .filter((autoquests) => !acceptedQuests.some((quest) => quest.node.id === autoquests.id))
+                    .map((autoquest) => (
                         <AutoQuestItem
                             key={autoquest.id}
                             id={autoquest.id || ''}
                             questName={autoquest.name?.value || ''}
                             player={player}
                         />
-                    )
-            )}
+                    ))}
+
             {acceptedQuests.map((quest, questIdx) => (
                 <QuestItem
                     tiles={tiles}

--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -339,7 +339,7 @@ export const QuestItem: FunctionComponent<{
 };
 
 export const AutoQuestItem: FunctionComponent<{
-    id: number;
+    id: string;
     questName: string;
     player: ConnectedPlayer;
 }> = ({ id, questName, player }) => {
@@ -358,7 +358,7 @@ export const AutoQuestItem: FunctionComponent<{
         <StyledQuestItem expanded={true}>
             <>
                 <div className="header">
-                    <h3>{questName?.value}</h3>
+                    <h3>{questName}</h3>
                 </div>
 
                 <div className="buttonContainer">
@@ -426,8 +426,23 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
 
     return (
         <StyledQuestPanel className="no-scrollbars">
-            {!acceptedQuests.find((quest) => quest.node.id == zone.autoquests[0].id) && (
-                <AutoQuestItem id={zone.autoquests[0].id} questName={zone.autoquests[0].name} player={player} />
+            {zone?.autoquests.map(
+                (autoquest) =>
+                    acceptedQuests.find((quest) => quest.node.id === autoquest.id) && (
+                        <AutoQuestItem
+                            key={autoquest.id}
+                            id={autoquest.id || ''}
+                            questName={autoquest.name?.value || ''}
+                            player={player}
+                        />
+                    )
+            )}
+            {zone?.autoquests.length > 0 && !acceptedQuests.find((quest) => quest.node.id == zone.autoquests[0].id) && (
+                <AutoQuestItem
+                    id={zone.autoquests[0].id}
+                    questName={zone.autoquests[0].name?.value || ''}
+                    player={player}
+                />
             )}
             {acceptedQuests.map((quest, questIdx) => (
                 <QuestItem

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -325,42 +325,6 @@ export const Shell: FunctionComponent<ShellProps> = () => {
         }
     }, [combatSessionTick, player, prevCombatSessionTick, blockNumber, selectedMobileUnit, zone?.mobileUnits]);
 
-    // if there is an available quest to accept in this zone
-    // and the player has not accept it, automatically accept it now
-    const [acceptingAutoQuest, setAcceptingAutoQuest] = useState(false);
-    useEffect(() => {
-        if (!player) {
-            return;
-        }
-        if (!zone?.availableQuests) {
-            return;
-        }
-        if (acceptingAutoQuest) {
-            return;
-        }
-        const actions = zone.availableQuests
-            .filter((available) => !player?.zone?.quests.some((accepted) => accepted.node.id == available.id))
-            .map(
-                ({ id }, idx): CogAction => ({
-                    name: 'ACCEPT_QUEST',
-                    args: [id, idx],
-                })
-            );
-        if (actions.length == 0) {
-            return;
-        }
-        setAcceptingAutoQuest(true);
-        // NOTE: it is intensional that setAcceptingAutoQuest is not in a finally() and only in the then()
-        // this is so that any errors do not cause an infinite loop. this is just a best effort attempt to
-        // assign all the quests, but the way quests are assigned is not currently setup to handle changing
-        // the auto assigned quests after they have been assigned, so the chances of this getting in a bad
-        // state are quite high... so just give up if it fails for now
-        player
-            .dispatch(...actions)
-            .then(() => setAcceptingAutoQuest(false))
-            .catch((err) => console.error('failed to accept auto assigned quest', err));
-    }, [player, zone?.availableQuests, acceptingAutoQuest]);
-
     const tileClick = useCallback(
         (id) => {
             if (!selectTiles) {
@@ -452,15 +416,19 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                             walletItemsActive={walletItemsActive}
                             zone={zone}
                         />
-                        {zone && player && questsActive && acceptedQuests.length > 0 && (
-                            <QuestPanel
-                                zone={zone}
-                                tiles={tiles || []}
-                                player={player}
-                                acceptedQuests={acceptedQuests}
-                                questMessages={questMessages}
-                            />
-                        )}
+                        {zone &&
+                            player &&
+                            questsActive &&
+                            selected?.mobileUnit &&
+                            (acceptedQuests.length > 0 || zone.autoquests.length > 0) && (
+                                <QuestPanel
+                                    zone={zone}
+                                    tiles={tiles || []}
+                                    player={player}
+                                    acceptedQuests={acceptedQuests}
+                                    questMessages={questMessages}
+                                />
+                            )}
                         {zone && player && walletItemsActive && global?.gameID && (
                             <WalletItemsPanel player={player} blockNumber={blockNumber} gameAddress={global?.gameID} />
                         )}

--- a/frontend/src/pages/building-fabricator.tsx
+++ b/frontend/src/pages/building-fabricator.tsx
@@ -1144,7 +1144,7 @@ const BuildingFabricator = () => {
                 tiles: [],
                 mobileUnits: [],
                 sessions: [],
-                availableQuests: [],
+                autoquests: [],
             };
             validate();
             const yaml = getManifestsYAML({


### PR DESCRIPTION
This PR adds a UI panel which shows if there is an unaccepted AutoQuest Quest.
It provides a button which allows the player to accept the first quest for that zone.
It also removes the automatic quest accepting code which Farms implemented (although now I'm wondering if that's better? It's closer to what originally happened with AutoQuests ¯\_(ツ)_/¯ )
