### PR TITLE
ds destroy auto quests

### DIFF
--- a/cli/src/utils/destroyer.ts
+++ b/cli/src/utils/destroyer.ts
@@ -152,6 +152,26 @@ export const getOpsForManifests = async (
         });
     }
 
+        // destroy AutoQuests
+        opn++;
+        opsets[opn] = [];
+        for (const doc of docs) {
+            if (doc.manifest.kind != 'AutoQuest') {
+                continue;
+            }
+            const spec = doc.manifest.spec;
+            opsets[opn].push({
+                doc,
+                actions: [
+                    {
+                        name: 'DEV_DESTROY_AUTO_QUEST',
+                        args: [spec.name, zoneId],
+                    },
+                ],
+                note: `destroyed auto-quest ${spec.name}`,
+            });
+        }
+
     return opsets;
 };
 

--- a/contracts/src/actions/Actions.sol
+++ b/contracts/src/actions/Actions.sol
@@ -163,6 +163,9 @@ interface Actions {
     // action to set the type of quest the player should begin with
     function DEV_ASSIGN_AUTO_QUEST(string memory name, uint16 zone) external;
 
+    // action to destroy the auto quest
+    function DEV_DESTROY_AUTO_QUEST(string memory name, uint16 zone) external;
+
     // spawn a tile at any location
     function DEV_SPAWN_TILE(int16 z, int16 q, int16 r, int16 s) external;
 

--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -53,6 +53,10 @@ contract CheatsRule is Rule {
             (int16 z, int16 q, int16 r, int16 s) = abi.decode(action[4:], (int16, int16, int16, int16));
 
             _destroyBuilding(state, ctx, z, q, r, s);
+        } else if (bytes4(action) == Actions.DEV_DESTROY_AUTO_QUEST.selector) {
+            (string memory name, int16 zone) = abi.decode(action[4:], (string, int16));
+
+            _destroyAutoQuest(state, ctx, name, zone);
         } else if (bytes4(action) == Actions.DEV_DESTROY_BAG.selector) {
             (
                 bytes24 bagID,
@@ -113,6 +117,13 @@ contract CheatsRule is Rule {
         require(state.getOwner(nZone) == Node.Player(ctx.sender), "owner only");
         bytes24 quest = Node.Quest(zone, name);
         state.setParent(quest, nZone);
+    }
+
+    function _destroyAutoQuest(State state, Context calldata ctx, string memory name, int16 zone) private {
+        bytes24 nZone = Node.Zone(zone);
+        require(state.getOwner(nZone) == Node.Player(ctx.sender), "owner only");
+        bytes24 quest = Node.Quest(zone, name);
+        state.removeParent(quest);
     }
 
     // allow constructing a building without any materials


### PR DESCRIPTION
## What
Added `DEV_DESTROY_AUTO_QUEST` action so that auto quests are removed via `ds destroy` by a zoner.

## Notes
Running this new command does remove the auto-quest from the zone, but it doesn't find all players with a quest already active, which is the expected behavior based on what was discussed during kick-off.
Therefore to test (& expected behavior):
- apply `tutorial-room-3`
- join zone & see quest ui
- destroy `tutorial-room-3`
- join zone on burner wallet & quest ui should be gone