### PR TITLE
Allow Buildings to destroy themselves

### DIFF
--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -191,8 +191,15 @@ contract CheatsRule is Rule {
 
     function _destroyBuilding(State state, Context calldata ctx, int16 z, int16 q, int16 r, int16 s) private {
         require(Bounds.isInBounds(q, r, s), "coords out of bounds");
-        require(state.getOwner(Node.Zone(z)) == Node.Player(ctx.sender), "owner only");
         bytes24 buildingInstance = Node.Building(z, q, r, s);
+        
+        // Only the building implementation or the owner can destroy the building
+        if (state.getOwner(Node.Zone(z)) != Node.Player(ctx.sender)) {
+            bytes24 buildingKind = state.getBuildingKind(buildingInstance);
+            address implementation = state.getImplementation(buildingKind);
+            require(ctx.sender == implementation, "owner only");
+        }
+
         state.removeBuildingKind(buildingInstance);
         state.removeOwner(buildingInstance);
         state.removeParent(buildingInstance);

--- a/contracts/src/rules/CheatsRule.sol
+++ b/contracts/src/rules/CheatsRule.sol
@@ -192,7 +192,7 @@ contract CheatsRule is Rule {
     function _destroyBuilding(State state, Context calldata ctx, int16 z, int16 q, int16 r, int16 s) private {
         require(Bounds.isInBounds(q, r, s), "coords out of bounds");
         bytes24 buildingInstance = Node.Building(z, q, r, s);
-        
+
         // Only the building implementation or the owner can destroy the building
         if (state.getOwner(Node.Zone(z)) != Node.Player(ctx.sender)) {
             bytes24 buildingKind = state.getBuildingKind(buildingInstance);


### PR DESCRIPTION
# What

Currently only the owner of the zone can destroy buildings. This PR allows the building kind implementation contract to destroy any instances of its building kind.

# Why

There are games that need to be able to destroy things either as part of the gameplay or as part of a game reset process.
(The selfish reason is that the Turf Wars game would use this)