### PR TITLE
Fix for ds-cli dependency traversal problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ cli: node_modules core/dist/core.js
 	(cd cli && $(NPM) run build && $(NPM) install -g --force .)
 
 publish: cli
-	(cd cli && $(NPM) version patch && $(NPM) publish)
+	(cd cli && $(NPM) version patch && rm -rf /tmp/ds-cli && mkdir -p /tmp/ds-cli && cp -r dist /tmp/ds-cli/dist && jq 'del(.dependencies, .devDependencies)' package.json > /tmp/ds-cli/package.json && cd /tmp/ds-cli && $(NPM) publish)
 
 release: contracts node_modules cli
 	./scripts/release.mjs -i --max-connections 10

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playmint/ds-cli",
-  "version": "0.0.29",
+  "version": "0.0.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playmint/ds-cli",
-      "version": "0.0.29",
+      "version": "0.0.31",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/ethereum-provider": "^2.9.1",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playmint/ds-cli",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@playmint/ds-cli",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/ethereum-provider": "^2.9.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,51 +1,52 @@
 {
-  "name": "@playmint/ds-cli",
-  "version": "0.0.28",
-  "description": "cli client for interacting with downstream.game",
-  "main": "index.js",
-  "bin": {
-    "ds": "./dist/ds.js"
-  },
-  "scripts": {
-    "prepack": "npm run build",
-    "build": "mkdir -p dist && rm -rf ./dist/contracts && cp -r ../contracts/src ./dist/contracts && cp -r ../contracts/lib/cog/contracts/src ./dist/contracts/cog && npx esbuild src/main.ts --bundle --outfile=dist/ds.js --platform=node --target=node12",
-    "exec": "npm run build >/dev/null && ./dist/ds.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "playmint",
-  "repository": "github:playmint/ds",
-  "keywords": [
-    "downstream",
-    "playmint",
-    "ds-cli",
-    "ds"
-  ],
-  "license": "MIT",
-  "devDependencies": {
-    "@types/node": "^20.4.5",
-    "@typescript-eslint/eslint-plugin": "^6.2.0",
-    "@typescript-eslint/parser": "^6.2.0",
-    "esbuild": "^0.18.17",
-    "eslint": "^8.46.0",
-    "eslint-config-prettier": "8.5.0",
-    "eslint-plugin-import": "^2.28.0",
-    "prettier": "2.8.8",
-    "typescript": "^5.1.6"
-  },
-  "dependencies": {
-    "@downstream/core": "file:core",
-    "@walletconnect/ethereum-provider": "^2.9.1",
-    "chalk": "^5.3.0",
-    "cli-table3": "^0.6.3",
-    "cross-fetch": "^4.0.0",
-    "glob": "10.3.3",
-    "lokijs": "^1.5.12",
-    "qrcode-terminal": "^0.12.0",
-    "solc": "0.8.19",
-    "tiny-updater": "^3.5.1",
-    "ws": "^8.13.0",
-    "yaml": "^2.3.1",
-    "yargs": "^17.7.2",
-    "zod": "^3.21.4"
-  }
+    "name": "@playmint/ds-cli",
+    "version": "0.0.29",
+    "description": "cli client for interacting with downstream.game",
+    "main": "index.js",
+    "bin": {
+        "ds": "./dist/ds.js"
+    },
+    "scripts": {
+        "prepack": "npm run build && mkdir -p /tmp/ds-cli && cp package.json /tmp/ds-cli/ && jq 'del(.dependencies, .devDependencies)' package.json > package.json.tmp && mv package.json.tmp package.json",
+        "postpack": "cp /tmp/ds-cli/package.json . && rm -rf /tmp/ds-cli",
+        "build": "mkdir -p dist && rm -rf ./dist/contracts && cp -r ../contracts/src ./dist/contracts && cp -r ../contracts/lib/cog/contracts/src ./dist/contracts/cog && npx esbuild src/main.ts --bundle --outfile=dist/ds.js --platform=node --target=node12",
+        "exec": "npm run build >/dev/null && ./dist/ds.js",
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "playmint",
+    "repository": "github:playmint/ds",
+    "keywords": [
+        "downstream",
+        "playmint",
+        "ds-cli",
+        "ds"
+    ],
+    "license": "MIT",
+    "devDependencies": {
+        "@types/node": "^20.4.5",
+        "@typescript-eslint/eslint-plugin": "^6.2.0",
+        "@typescript-eslint/parser": "^6.2.0",
+        "esbuild": "^0.18.17",
+        "eslint": "^8.46.0",
+        "eslint-config-prettier": "8.5.0",
+        "eslint-plugin-import": "^2.28.0",
+        "prettier": "2.8.8",
+        "typescript": "^5.1.6"
+    },
+    "dependencies": {
+        "@downstream/core": "file:core",
+        "@walletconnect/ethereum-provider": "^2.9.1",
+        "chalk": "^5.3.0",
+        "cli-table3": "^0.6.3",
+        "cross-fetch": "^4.0.0",
+        "glob": "10.3.3",
+        "lokijs": "^1.5.12",
+        "qrcode-terminal": "^0.12.0",
+        "solc": "0.8.19",
+        "tiny-updater": "^3.5.1",
+        "ws": "^8.13.0",
+        "yaml": "^2.3.1",
+        "yargs": "^17.7.2",
+        "zod": "^3.21.4"
+    }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,14 +1,12 @@
 {
     "name": "@playmint/ds-cli",
-    "version": "0.0.29",
+    "version": "0.0.31",
     "description": "cli client for interacting with downstream.game",
     "main": "index.js",
     "bin": {
         "ds": "./dist/ds.js"
     },
     "scripts": {
-        "prepack": "npm run build && mkdir -p /tmp/ds-cli && cp package.json /tmp/ds-cli/ && jq 'del(.dependencies, .devDependencies)' package.json > package.json.tmp && mv package.json.tmp package.json",
-        "postpack": "cp /tmp/ds-cli/package.json . && rm -rf /tmp/ds-cli",
         "build": "mkdir -p dist && rm -rf ./dist/contracts && cp -r ../contracts/src ./dist/contracts && cp -r ../contracts/lib/cog/contracts/src ./dist/contracts/cog && npx esbuild src/main.ts --bundle --outfile=dist/ds.js --platform=node --target=node12",
         "exec": "npm run build >/dev/null && ./dist/ds.js",
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
# What

I have added to the `publish` target in the `Makefile` to:
- copy the `dist` folder to `/tmp/ds-cli`
- use jq to remove dependency fields on `package.json` and write the output to `/tmp/ds-cli`
- publish the package from the `/tmp/ds-cli` folder

I have removed the `prepack` script from the `package.json` as npm was trying to build the temporary package again which would fail due to the relative paths to the contracts being incorrect

# Why

When installing `ds-cli` via npm outside of our repo, npm would throw an error when it tried to traverse the `@downstream/core` dependency which is a symlink into a workspace which only exists if running from our main ds repo

# Notes

I have tested this by publishing version 0.0.31
Installing ds-cli as a global package

I checked the `package.json` that's published at https://registry.npmjs.org/@playmint%2fds-cli
I can see that it has published the version without the deps

