### PR TITLE
set/get featured zone

### DIFF
--- a/contracts/src/Downstream.sol
+++ b/contracts/src/Downstream.sol
@@ -117,6 +117,7 @@ contract DownstreamGame is BaseGame {
         state.registerEdgeType(Rel.ID.selector, "ID", WeightKind.UINT64);
         state.registerEdgeType(Rel.HasBlockNum.selector, "HasBlockNum", WeightKind.UINT64);
         state.registerEdgeType(Rel.Parent.selector, "Parent", WeightKind.UINT64);
+        state.registerEdgeType(Rel.IsFeatured.selector, "IsFeatured", WeightKind.UINT64);
 
         // create a session router
         BaseRouter router = new DownstreamRouter();
@@ -164,5 +165,13 @@ contract DownstreamGame is BaseGame {
 
     function setZoneUnitLimit(uint64 limit) public ownerOnly {
         state.setZoneUnitLimit(limit);
+    }
+
+    function getZoneIsFeatured(uint64 zoneId) public view returns (bool) {
+        return state.getZoneIsFeatured(zoneId);
+    }
+
+    function setZoneIsFeatured(uint64 zoneId, bool isFeatured) public ownerOnly {
+        state.setZoneIsFeatured(zoneId, isFeatured);
     }
 }

--- a/contracts/src/schema/Schema.sol
+++ b/contracts/src/schema/Schema.sol
@@ -27,6 +27,7 @@ interface Rel {
     function ID() external;
     function HasBlockNum() external;
     function Parent() external;
+    function IsFeatured() external;
 }
 
 interface Kind {
@@ -672,6 +673,15 @@ library Schema {
 
     function getZoneUnitLimit(State state) internal view returns (uint64) {
         return uint64(uint256(state.getData(Node.GameSettings(), "zoneUnitLimit")));
+    }
+
+    function setZoneIsFeatured(State state, uint64 zoneId, bool isFeatured) internal {
+        return state.set(Rel.IsFeatured.selector, 0x0, Node.Zone(zoneId), 0x0, isFeatured ? 1 : 0);
+    }
+
+    function getZoneIsFeatured(State state, uint64 zoneId) internal view returns (bool) {
+        (, uint64 isFeatured) = state.get(Rel.IsFeatured.selector, 0x0, Node.Zone(zoneId));
+        return isFeatured == 1;
     }
 
     function setUnitTimeoutBlocks(State state, uint64 blocks) internal {

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -191,6 +191,9 @@ fragment ZoneState on Node {
     url: annotation(name: "url") {
         value
     }
+    isFeatured: edge(match: { via: { rel: "IsFeatured", key: 0 } }) {
+        value: weight
+    }
     owner: node(match: { via: { rel: "Owner" } }) {
         id
         addr: key
@@ -271,6 +274,9 @@ query GetZones($gameID: ID!) {
                 }
                 url: annotation(name: "url") {
                     value
+                }
+                isFeatured: edge(match: { via: { rel: "IsFeatured", key: 0 } }) {
+                    value: weight
                 }
                 owner: node(match: { via: { rel: "Owner" } }) {
                     id


### PR DESCRIPTION
## What
- Adds the ability to set a zone as `isFeatured` (true/false)
- Adds "Featured Zones" to the filter drop down
- Adds a "⭐" emoji next to featured zones

![image](https://github.com/playmint/ds/assets/27741109/3e7f6ddf-64fc-4fb6-8690-c92c38bcb958)


## Why
We want to have a "Featured" section on the page that shows all the zones.

## Change zone isFeatured on a running local build
An easy way to test this feature is to run this command:
```bash
cast send --rpc-url http://localhost:8545 --private-key 0x6335c92c05660f35b36148bbfb2105a68dd40275ebf16eff9524d487fb5d57a8 0xF8311e28c658003929A7c1218fb8E44cE7A814DE "setZoneIsFeatured(uint64,bool)" 1 true
```

This example sets zone 1 `isFeatured` to `true`.

## Notes
Setting a zone as featured is currently only possible to do by zone owners:
```solidity
    function setZoneIsFeatured(uint64 zoneId, bool isFeatured) public ownerOnly {
        state.setZoneIsFeatured(zoneId, isFeatured);
    }
```

Assuming this should be changed to something like `playmintOnly`, I'm wondering what the best way would be to implement that.

Resolves #1314 