### PR TITLE
cli: allow authenticating via browser

### DIFF
--- a/chart/templates/app.yaml
+++ b/chart/templates/app.yaml
@@ -13,7 +13,7 @@ networkName: "Garnet"
 networkID: "17069"
 wallets:
   metamask: true
-  walletconnect: true
+  walletconnect: false
   burner: false
 {{ end }}
 zonesAddress: {{ $.Values.frontend.zonesAddress | quote }}

--- a/cli/package.json
+++ b/cli/package.json
@@ -39,6 +39,7 @@
         "cross-fetch": "^4.0.0",
         "fastify": "^4.26.2",
         "glob": "10.3.3",
+        "http-errors": "^2.0.0",
         "lokijs": "^1.5.12",
         "qrcode-terminal": "^0.12.0",
         "solc": "0.8.19",

--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,7 @@
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.3",
         "cross-fetch": "^4.0.0",
+        "fastify": "^4.26.2",
         "glob": "10.3.3",
         "lokijs": "^1.5.12",
         "qrcode-terminal": "^0.12.0",

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -47,6 +47,14 @@ yargs
         choices: networks.map((n) => n.name),
         type: 'string',
     })
+    .option('wallet', {
+        alias: 'w',
+        demandOption: true,
+        default: 'metamask',
+        describe: 'wallet authentication method',
+        choices: ['metamask', 'walletconnect', 'private-key'],
+        type: 'string',
+    })
     .option('ws-endpoint', {
         describe: 'override websocket query endpoint',
         type: 'string',

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -47,12 +47,11 @@ yargs
         choices: networks.map((n) => n.name),
         type: 'string',
     })
-    .option('wallet', {
-        alias: 'w',
+    .option('auth', {
         demandOption: true,
-        default: 'metamask',
-        describe: 'wallet authentication method',
-        choices: ['metamask', 'walletconnect', 'private-key'],
+        default: 'browser',
+        describe: 'authentication method',
+        choices: ['browser', 'walletconnect', 'private-key'],
         type: 'string',
     })
     .option('ws-endpoint', {
@@ -78,7 +77,7 @@ yargs
     })
     .option('private-key', {
         alias: 'k',
-        describe: 'player private key (insecure!)',
+        describe: 'player private key (implies --auth private-key)',
         type: 'string',
     })
     .middleware(session)

--- a/cli/src/utils/auth.ts
+++ b/cli/src/utils/auth.ts
@@ -50,7 +50,7 @@ export const authenticate = async (loginURL: string): Promise<SessionData> => {
             try {
                 const session = JSON.parse(atob(req.params.auth));
                 resolve(session);
-                return 'ok! you can close this window and return to the command line now';
+                return `OK! you are authenticated as ${session.owner}, you can close this window and return to the command line now`;
             } catch (err) {
                 reject(err);
                 return 'failed to authenticate, return to command line';

--- a/cli/src/utils/auth.ts
+++ b/cli/src/utils/auth.ts
@@ -48,7 +48,6 @@ export const authenticate = async (loginURL: string): Promise<SessionData> => {
 
         server.get('/session/:auth', async function (req:AuthRequest, _res:FastifyReply): Promise<any> {
             try {
-                console.log(atob(req.params.auth));
                 const session = JSON.parse(atob(req.params.auth));
                 resolve(session);
                 return 'ok! you can close this window and return to the command line now';
@@ -66,7 +65,7 @@ export const authenticate = async (loginURL: string): Promise<SessionData> => {
                 return;
             }
             console.log(`
-                Please authenticate with metamask via ${loginURL}
+                Please authenticate via ${loginURL}
             `);
         });
 

--- a/cli/src/utils/auth.ts
+++ b/cli/src/utils/auth.ts
@@ -1,0 +1,75 @@
+import fastify, {FastifyRequest, FastifyReply} from 'fastify'
+import {opener} from './opener';
+
+export const AUTH_PORT = 7947;
+
+type AuthRequest = FastifyRequest<{
+	Params: {
+		auth: string;
+	}
+}>
+
+export interface SessionData {
+    key: string;
+    expires: number;
+    owner: string;
+}
+
+// starts a local http server that listens for a request
+// containing session data opens a browser to the network's
+// login URL and waits for the page to redirect to the
+// listening server. on recv, shutdown server and use the
+// receved session
+export const authenticate = async (loginURL: string): Promise<SessionData> => {
+    let done = false;
+    return new Promise((resolve, reject) => {
+        const server = fastify({
+            maxParamLength: 10000,
+        });
+
+        const shutdown = () => {
+            setTimeout(() => {
+                if (done) {
+                    return;
+                }
+                done = true;
+                server.close().then(() => {
+                    console.log('successfully closed!')
+                }, (err) => {
+                    console.log('an error happened', err)
+                })
+            }, 0);
+        };
+
+        server.get('/', async function (): Promise<string> {
+            return 'this is authenication for the ds-cli ... return to the command line to follow instructions';
+        });
+
+
+        server.get('/session/:auth', async function (req:AuthRequest, _res:FastifyReply): Promise<any> {
+            try {
+                console.log(atob(req.params.auth));
+                const session = JSON.parse(atob(req.params.auth));
+                resolve(session);
+                return 'ok! you can close this window and return to the command line now';
+            } catch (err) {
+                reject(err);
+                return 'failed to authenticate, return to command line';
+            } finally {
+                shutdown();
+            }
+        });
+
+        server.listen(AUTH_PORT, '0.0.0.0', (err, _address) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+            console.log(`
+                Please authenticate with metamask via ${loginURL}
+            `);
+        });
+
+        opener(loginURL);
+    });
+}

--- a/cli/src/utils/auth.ts
+++ b/cli/src/utils/auth.ts
@@ -59,7 +59,7 @@ export const authenticate = async (loginURL: string): Promise<SessionData> => {
             }
         });
 
-        server.listen(AUTH_PORT, '0.0.0.0', (err, _address) => {
+        server.listen({ port: AUTH_PORT }, (err, _address) => {
             if (err) {
                 reject(err);
                 return;

--- a/cli/src/utils/networks.ts
+++ b/cli/src/utils/networks.ts
@@ -4,21 +4,24 @@ export type Network = {
     default?: boolean;
     wsEndpoint: string;
     httpEndpoint: string;
+    loginEndpoint: string;
 };
 
 const ephemeralNetworks = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16].map((i) => ({
     name: `hexwood${i}`,
-    description: 'ephemeral private test network',
+    description: 'ephemeral private testnet',
     wsEndpoint: `wss://services-hexwood${i}.downstream.game/query`,
     httpEndpoint: `https://services-hexwood${i}.downstream.game/query`,
+    loginEndpoint: `https://hexwood${i}.downstream.game/login`
 }))
 
 const localNetworks = [
     {
         name: 'local',
-        description: 'ephermal local instance of the game',
+        description: 'local private devnet',
         wsEndpoint: 'ws://localhost:8080/query',
         httpEndpoint: 'http://localhost:8080/query',
+        loginEndpoint: `http://localhost:3000/login`
     },
 ];
 

--- a/cli/src/utils/opener.ts
+++ b/cli/src/utils/opener.ts
@@ -1,0 +1,49 @@
+import childProcess from 'child_process';
+import os from 'os';
+
+export function opener(url: string) {
+    var platform = process.platform;
+
+    // Attempt to detect Windows Subystem for Linux (WSL). WSL  itself as Linux (which works in most cases), but in
+    // this specific case we need to treat it as actually being Windows. The "Windows-way" of opening things through
+    // cmd.exe works just fine here, whereas using xdg-open does not, since there is no X Windows in WSL.
+    if (platform === "linux" && os.release().indexOf("Microsoft") !== -1) {
+        platform = "win32";
+    }
+
+    // http://stackoverflow.com/q/1480971/3191, but see below for Windows.
+    var command;
+    switch (platform) {
+        case "win32": {
+            command = "cmd.exe";
+            break;
+        }
+        case "darwin": {
+            command = "open";
+            break;
+        }
+        default: {
+            command = "xdg-open";
+            break;
+        }
+    }
+
+    let args = [url];
+
+    if (platform === "win32") {
+        // On Windows, we really want to use the "start" command. But, the rules regarding arguments with spaces, and
+        // escaping them with quotes, can get really arcane. So the easiest way to deal with this is to pass off the
+        // responsibility to "cmd /c", which has that logic built in.
+        //
+        // Furthermore, if "cmd /c" double-quoted the first parameter, then "start" will interpret it as a window title,
+        // so we need to add a dummy empty-string window title: http://stackoverflow.com/a/154090/3191
+        //
+        // Additionally, on Windows ampersand and caret need to be escaped when passed to "start"
+        args = args.map(function (value) {
+            return value.replace(/[&^]/g, "^$&");
+        });
+        args = ["/c", "start", "\"\""].concat(args);
+    }
+
+    return childProcess.execFile(command, args, {});
+};

--- a/cli/src/utils/session.ts
+++ b/cli/src/utils/session.ts
@@ -93,6 +93,7 @@ export const session = async (ctx) => {
         const { logger } = makeLogger({ name: 'main', level: LogLevel.FATAL });
         const { client } = ctx.makeClient();
         if (ctx.k) {
+            ctx.auth = 'private-key';
             const wallet = makeKeyWallet(ctx.k.startsWith('0x') ? ctx.k : `0x${ctx.k}`);
             const player = pipe(
                 makeConnectedPlayer(client, wallet, logger, ctx.zone || 0),
@@ -106,7 +107,7 @@ export const session = async (ctx) => {
             }
             await p.login();
             return p;
-        } else if (ctx.wallet === 'metamask') {
+        } else if (ctx.auth === 'browser') {
             const session = await authenticate(network.loginEndpoint);
             const wallet = makeKeylessWallet(session.owner);
             const player = pipe(
@@ -121,7 +122,7 @@ export const session = async (ctx) => {
             await p.load(new ethers.Wallet(session.key), session.expires)
             console.log(`authenticated as player ${session.owner}`);
             return p;
-        } else if (ctx.wallet === 'walletconnect') {
+        } else if (ctx.auth === 'walletconnect') {
             const { wallet, selectProvider } = makeWallet();
             const player = pipe(
                 makeConnectedPlayer(client, wallet, logger, ctx.zone || 0),

--- a/cli/src/utils/session.ts
+++ b/cli/src/utils/session.ts
@@ -119,6 +119,7 @@ export const session = async (ctx) => {
                 throw new Error('authentication failure: unable to setup player, maybe try again');
             }
             await p.load(new ethers.Wallet(session.key), session.expires)
+            console.log(`authenticated as player ${session.owner}`);
             return p;
         } else if (ctx.wallet === 'walletconnect') {
             const { wallet, selectProvider } = makeWallet();

--- a/core/src/wallet.ts
+++ b/core/src/wallet.ts
@@ -57,6 +57,18 @@ export function makeKeyWallet(keyHexString: string): Source<Wallet> {
     );
 }
 
+export function makeKeylessWallet(address: string): Source<Wallet> {
+    const signer = ethers.Wallet.createRandom(); // not actually used
+    return lazy(() =>
+        fromValue({
+            id: CompoundKeyEncoder.encodeAddress(NodeSelectors.Player, address),
+            address,
+            signer: async () => signer,
+            method: 'privatekey',
+        }),
+    );
+}
+
 function newBrowserAccountSource({ provider, method }: WalletProvider): Source<WalletProvider> {
     const { source, next } = makeSubject<string | undefined>();
 

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -296,3 +296,14 @@ query GetZones($gameID: ID!) {
         }
     }
 }
+
+query GetSession($gameID: ID!, $sessionID: ID!) {
+    game(id: $gameID) {
+        id
+        router {
+            session(id: $sessionID) {
+                owner
+            }
+        }
+    }
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,6 @@
 const nextConfig = {
-    reactStrictMode: true,
+    // enabling strict mode will confuse the session keys, I guess just be careful
+    reactStrictMode: false,
     compiler: {
         styledComponents: true,
     },

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -9,7 +9,7 @@
     "networkName": "hexwoodlocal",
     "wallets": {
         "metamask": true,
-        "walletconnect": true,
+        "walletconnect": false,
         "burner": true
     }
 }

--- a/frontend/src/hooks/use-localstorage.tsx
+++ b/frontend/src/hooks/use-localstorage.tsx
@@ -1,7 +1,16 @@
 import { useEffect, useState } from 'react';
 
 export function useLocalStorage<T>(key: string, defaultValue: T): [T, (v: T) => void] {
-    const [value, setValue] = useState<T>(() => {
+    const [value, setValue] = useState<T>(defaultValue);
+
+    useEffect(() => {
+        if (!value || value === defaultValue) {
+            return;
+        }
+        localStorage.setItem(key, JSON.stringify(value));
+    }, [value, key, defaultValue]);
+
+    useEffect(() => {
         let currentValue: T;
 
         try {
@@ -9,13 +18,8 @@ export function useLocalStorage<T>(key: string, defaultValue: T): [T, (v: T) => 
         } catch (error) {
             currentValue = defaultValue;
         }
-
-        return currentValue;
-    });
-
-    useEffect(() => {
-        localStorage.setItem(key, JSON.stringify(value));
-    }, [value, key]);
+        setValue(currentValue);
+    }, [defaultValue, key]);
 
     return [value, setValue];
 }

--- a/frontend/src/hooks/use-session.tsx
+++ b/frontend/src/hooks/use-session.tsx
@@ -6,8 +6,8 @@ import { ethers } from 'ethers';
 import Image from 'next/image';
 import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { usePlayer } from './use-game-state';
-// import { useLocalStorage } from './use-localstorage';
 import { useWalletProvider } from './use-wallet-provider';
+import { useLocalStorage } from './use-localstorage';
 
 export const disableSessionRefresh = 'this export only exists to disable fast-refresh of this file';
 
@@ -15,6 +15,7 @@ export interface SessionContextValue {
     newSession: () => void;
     clearSession: () => void;
     loadingSession: boolean;
+    session?: SessionData;
 }
 
 export interface SessionData {
@@ -49,8 +50,7 @@ export const SessionProvider = ({ children }: { children: ReactNode }) => {
     const [authorizing, setAuthorizing] = useState<boolean>(false);
     const player = usePlayer();
     const closeAuthroizer = useCallback(() => setAuthorizing(false), []);
-    // const [sessionData, setSessionData] = useLocalStorage<SessionData | null>(SESSION_LOCALSTORAGE_KEY, null);
-    const [sessionData, setSessionData] = useState<SessionData | null>(null);
+    const [sessionData, setSessionData] = useLocalStorage<SessionData | null>(SESSION_LOCALSTORAGE_KEY, null);
     const [loadingSession, setLoading] = useState<boolean>(!!sessionData);
     const session = useMemo(() => (sessionData ? decodeSessionData(sessionData) : undefined), [sessionData]);
     const [sessionLoaded, setSessionLoaded] = useState<boolean>(false);
@@ -141,8 +141,8 @@ export const SessionProvider = ({ children }: { children: ReactNode }) => {
     }, [newSession, loadSession, clearSession, session, sessionLoaded, player]);
 
     const value: SessionContextValue = useMemo(() => {
-        return { newSession, clearSession, loadingSession };
-    }, [newSession, clearSession, loadingSession]);
+        return { newSession, clearSession, loadingSession, session };
+    }, [newSession, clearSession, loadingSession, session]);
 
     return (
         <SessionContext.Provider value={value}>

--- a/frontend/src/hooks/use-wallet-provider.tsx
+++ b/frontend/src/hooks/use-wallet-provider.tsx
@@ -15,6 +15,7 @@ export interface WalletContextValue {
     connecting?: boolean;
     provider?: WalletProvider;
     connect?: () => void;
+    connectMetamask?: () => void;
     disconnect?: () => void;
 }
 
@@ -211,8 +212,8 @@ export const WalletProviderProvider = ({ children, config }: { children: ReactNo
     }, []);
 
     const value = useMemo(() => {
-        return { connect, connecting, provider, disconnect };
-    }, [connect, provider, connecting, disconnect]);
+        return { connect, connectMetamask, connecting, provider, disconnect };
+    }, [connect, provider, connecting, disconnect, connectMetamask]);
 
     return (
         <WalletProviderContext.Provider value={value}>

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,0 +1,45 @@
+import DownstreamLogo from '@app/assets/downstream-logo-dark.svg';
+import { useConfig } from '@app/hooks/use-config';
+import { GameStateProvider } from '@app/hooks/use-game-state';
+import { SessionProvider, useSession } from '@app/hooks/use-session';
+import { WalletProviderProvider, useWalletProvider } from '@app/hooks/use-wallet-provider';
+import { TextButton } from '@app/styles/button.styles';
+import { GameConfig } from '@downstream/core';
+import Image from 'next/image';
+import { useEffect } from 'react';
+
+const AUTH_PORT = 7947;
+
+const Login = ({}: { config: Partial<GameConfig> | undefined }) => {
+    const { connectMetamask } = useWalletProvider();
+    const { session } = useSession();
+
+    useEffect(() => {
+        if (!session) {
+            return;
+        }
+        const auth = btoa(JSON.stringify(session));
+        window.location.href = `http://localhost:${AUTH_PORT}/session/${auth}`;
+    }, [session]);
+
+    return (
+        <div className="page" style={{ margin: '0 auto', width: 200 }}>
+            <Image src={DownstreamLogo} alt="Downstream Logo" className="logo" width={200} />
+            {!session && <TextButton onClick={connectMetamask}>CONNECT</TextButton>}
+        </div>
+    );
+};
+
+export default function IndexPage() {
+    const config = useConfig();
+
+    return (
+        <WalletProviderProvider config={config}>
+            <GameStateProvider config={config}>
+                <SessionProvider>
+                    <Login config={config} />
+                </SessionProvider>
+            </GameStateProvider>
+        </WalletProviderProvider>
+    );
+}

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -25,6 +25,7 @@ const Login = ({}: { config: Partial<GameConfig> | undefined }) => {
     return (
         <div className="page" style={{ margin: '0 auto', width: 200 }}>
             <Image src={DownstreamLogo} alt="Downstream Logo" className="logo" width={200} />
+            <p>Authenticate by signing in to Downstream with your wallet.</p>
             {!session && <TextButton onClick={connectMetamask}>CONNECT</TextButton>}
         </div>
     );

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,6 +1,6 @@
 import DownstreamLogo from '@app/assets/downstream-logo-dark.svg';
 import { useConfig } from '@app/hooks/use-config';
-import { GameStateProvider } from '@app/hooks/use-game-state';
+import { GameStateProvider, usePlayer } from '@app/hooks/use-game-state';
 import { SessionProvider, useSession } from '@app/hooks/use-session';
 import { WalletProviderProvider, useWalletProvider } from '@app/hooks/use-wallet-provider';
 import { TextButton } from '@app/styles/button.styles';
@@ -12,21 +12,25 @@ const AUTH_PORT = 7947;
 
 const Login = ({}: { config: Partial<GameConfig> | undefined }) => {
     const { connectMetamask } = useWalletProvider();
+    const player = usePlayer();
     const { session } = useSession();
 
     useEffect(() => {
         if (!session) {
             return;
         }
+        if (!player) {
+            return;
+        }
         const auth = btoa(JSON.stringify(session));
         window.location.href = `http://localhost:${AUTH_PORT}/session/${auth}`;
-    }, [session]);
+    }, [session, player]);
 
     return (
         <div className="page" style={{ margin: '0 auto', width: 200 }}>
             <Image src={DownstreamLogo} alt="Downstream Logo" className="logo" width={200} />
             <p>Authenticate by signing in to Downstream with your wallet.</p>
-            {!session && <TextButton onClick={connectMetamask}>CONNECT</TextButton>}
+            {(!session || !player) && <TextButton onClick={connectMetamask}>CONNECT</TextButton>}
         </div>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,10 @@
         "cross-fetch": "^4.0.0",
         "fastify": "^4.26.2",
         "glob": "10.3.3",
+        "http-errors": "^2.0.0",
         "lokijs": "^1.5.12",
+        "open": "^10.1.0",
+        "opener": "^1.5.2",
         "qrcode-terminal": "^0.12.0",
         "solc": "0.8.19",
         "tiny-updater": "^3.5.1",
@@ -11415,6 +11418,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -12322,6 +12339,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -12345,6 +12388,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -12374,6 +12428,14 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dependency-graph": {
@@ -15677,6 +15739,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-6.1.1.tgz",
@@ -16407,6 +16484,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extendable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -16481,6 +16572,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -16770,6 +16878,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -23437,6 +23559,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/opentype.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
@@ -26871,6 +27018,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-async": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
@@ -27146,6 +27304,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -27437,6 +27600,14 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw=="
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",
@@ -28115,6 +28286,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "cli": {
       "name": "@playmint/ds-cli",
-      "version": "0.0.28",
+      "version": "0.0.31",
       "license": "MIT",
       "dependencies": {
         "@downstream/core": "file:core",
@@ -34,6 +34,7 @@
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.3",
         "cross-fetch": "^4.0.0",
+        "fastify": "^4.26.2",
         "glob": "10.3.3",
         "lokijs": "^1.5.12",
         "qrcode-terminal": "^0.12.0",
@@ -3996,6 +3997,57 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ]
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz",
+      "integrity": "sha512-ebbEtlI7dxXF5ziNdr05mOY8NnDiPB1XvAlLHctRt/Rc+C3LCOVW5imUVX+mhvUhnNzmPBHewUkOFgGlCxgdAA==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@fastify/error": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
+      "integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ=="
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
+      "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
+      "dependencies": {
+        "fast-json-stringify": "^5.7.0"
+      }
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
+      "integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
     },
     "node_modules/@floating-ui/core": {
       "version": "1.5.0",
@@ -10470,6 +10522,22 @@
         "@zag-js/dom-query": "0.16.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "node_modules/acorn": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
@@ -10552,6 +10620,42 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -10618,6 +10722,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -10906,6 +11015,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.3.0.tgz",
+      "integrity": "sha512-VBVH0jubFr9LdFASy/vNtm5giTrnbVquWBhT0fyizuNK2rQ7e7ONU2plZQWUNqtE1EmxFEb+kbSkFRkstiaS9Q==",
+      "dependencies": {
+        "@fastify/error": "^3.3.0",
+        "archy": "^1.0.0",
+        "debug": "^4.0.0",
+        "fastq": "^1.17.1"
       }
     },
     "node_modules/axe-core": {
@@ -11975,6 +12095,14 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -13487,6 +13615,14 @@
         }
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -13579,11 +13715,15 @@
         "url": "https://github.com/sponsors/jaydenseric"
       }
     },
+    "node_modules/fast-content-type-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
+      "integrity": "sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ=="
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -13629,6 +13769,56 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "node_modules/fast-json-stringify": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.14.1.tgz",
+      "integrity": "sha512-J1Grbf0oSXV3lKsBf3itz1AvRk43qVrx3Ac10sNvi3LZaz1by4oDdYKFrJycPhS8+Gb7y8rgV/Jqw1UZVjyNvw==",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.1.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^3.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^2.1.0",
+        "json-schema-ref-resolver": "^1.0.1",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -13639,7 +13829,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "dev": true,
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
@@ -13652,6 +13841,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.3.0.tgz",
+      "integrity": "sha512-eel5UKGn369gGEWOqBShmFJWfq/xSJvsgDzgLYC845GneayWvXBf0lJCBn5qTABfewy1ZDPoaR5OZCP+kssfuw=="
+    },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
@@ -13661,11 +13855,153 @@
         "punycode": "^1.3.2"
       }
     },
+    "node_modules/fastify": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.2.tgz",
+      "integrity": "sha512-90pjTuPGrfVKtdpLeLzND5nyC4woXZN5VadiNQCicj/iJU4viNHKhsAnb7jmv1vu2IzkLXyBiCzdWuzeXgQ5Ug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@fastify/ajv-compiler": "^3.5.0",
+        "@fastify/error": "^3.4.0",
+        "@fastify/fast-json-stringify-compiler": "^4.3.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.3.0",
+        "fast-content-type-parse": "^1.1.0",
+        "fast-json-stringify": "^5.8.0",
+        "find-my-way": "^8.0.0",
+        "light-my-request": "^5.11.0",
+        "pino": "^8.17.0",
+        "process-warning": "^3.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.7.0",
+        "semver": "^7.5.4",
+        "toad-cache": "^3.3.0"
+      }
+    },
+    "node_modules/fastify/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/fastify/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/fastify/node_modules/pino": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.20.0.tgz",
+      "integrity": "sha512-uhIfMj5TVp+WynVASaVEJFTncTUe4dHBq6CWplu/vBgvGHhvBvQfxz+vcOrnnBQdORH3izaGEurLfNlq3YxdFQ==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.1.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/fastify/node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/fastify/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    },
+    "node_modules/fastify/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+    },
+    "node_modules/fastify/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/fastify/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/fastify/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/fastify/node_modules/thread-stream": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.6.0.tgz",
+      "integrity": "sha512-t4eNiKdGwd1EV6tx76mRbrOqwvkxz+ssOiQXEXw88m4p/Xp6679vg16sf39BAstRjHOiWIqp5+J2ylHk3pU30g==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "dev": true,
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -13793,6 +14129,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/find-my-way": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.1.0.tgz",
+      "integrity": "sha512-41QwjCGcVTODUmLLqTMeoHeiozbMXYMAE1CKFiDyi9zVZ2Vjh0yz3MF0WQZoIb+cmzP/XlbFjlF2NtJmvZHznA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/find-replace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
@@ -13907,6 +14256,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/framer-motion": {
@@ -15849,6 +16206,14 @@
       "resolved": "https://registry.npmjs.org/ionstore/-/ionstore-1.0.0.tgz",
       "integrity": "sha512-ikEvmeZFh9u5SkjKbFqJlmmhaQTulB3P7QoSoZ/xL8EDP5uj5QWbPeKcQ8ZJtszBLHRRnhIJJE8P1dhFx/oCMw=="
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -16637,6 +17002,14 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
+      "integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -16904,6 +17277,21 @@
       "dependencies": {
         "immediate": "~3.0.5"
       }
+    },
+    "node_modules/light-my-request": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.13.0.tgz",
+      "integrity": "sha512-9IjUN9ZyCS9pTG+KqTDEQo68Sui2lHsYBrfMyVUTTZ3XhH8PMZq7xO94Kr+eP9dhi/kcKsx4N41p2IXEBil1pQ==",
+      "dependencies": {
+        "cookie": "^0.6.0",
+        "process-warning": "^3.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
@@ -23575,6 +23963,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -23616,6 +24012,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/proxy-compare": {
@@ -26328,11 +26736,18 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -26341,8 +26756,7 @@
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "dev": true
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -26563,6 +26977,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "dependencies": {
+        "ret": "~0.2.0"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
@@ -26620,6 +27042,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
+    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -26673,6 +27100,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
     "node_modules/set-function-name": {
       "version": "2.0.1",
@@ -27669,6 +28101,14 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/toggle-selection": {


### PR DESCRIPTION
## what

allow ds-cli to get authentication by asking the user to login in a browser window.

makes this the default method for authentication

use `--auth walletconnect` for the old behaviour

## why

so that metamask-extension users have a way of using the cli without needing to setup a walletconnect wallet with the same key in it.

although this is not metamask specific... any method supported by the game login flow is now usable by the ds-cli. for example you could use this to login with a burner, but I don't recommend it

fixes: #1267 
fixes: #1282 

## how

the (slightly mental) flow is:

* a ds cli command that requires dispatch is called ie `ds apply -n $NETWORK -z $ZONE`
* a local http server is started at a well-known port $PORT
* a web browser is opened on the network's game URL (ie localhost:3000 for $NETWORK=local, hexwood1.downstream.game for $NETWORK=hexwood1 etc)
* $NETWORK does the login/auth flow as per the normal game
* $NETWORK redirects the user to the temp local server at `localhost:$PORT/auth=$SESSIONDATA`
* the local http server recvs the $SESSIONDATA and uses it to build the player/dispatcher
* the local http server is shutdown
* cli flow is now authenticated and continues
* a message is left in the browser that it safe to close the window and return to cli

## todo

* [x] considering caching the session key to avoid doing the browser flow for every command
* [x] make the local server messages bit prettier
* [x] call it "browser" not "metamask" auth, it's not just metamask
* [x] do an anvil deploy and test against a remote network
* [x] how can we better invalidate the session data so that stale keys are auto ignored?
* [x] confirm this has not broken the `-k` flow
* [x] remove walletconnect flow from cli
* [x] remove walletconnect flow from game?
* [ ] test works on windows
* [x] test works on linux/wsl

## notes for testing

* you will need to build the cli locally `make cli`
* auth flow will not work against any deployment not deployed from this branch
* since session data is cached, you should clear localstorage in the browser before using any fresh deploy (ie clear localhost:3000 localstorage after a `make dev`, or clear hexwoodX.downstream.game storage after a fresh hexwood deploy)