### PR TITLE
Updated Zone Traits

### DIFF
--- a/contracts/src/Zones721.sol
+++ b/contracts/src/Zones721.sol
@@ -27,7 +27,7 @@ contract Zones721 is ERC721 {
 
     string constant LOCATION_LABEL = "Location";
 
-    string constant GOO_TYPE_LABEL = "Goo type";
+    string constant GOO_TYPE_LABEL = "Goo Type";
     uint256 constant GOO_TYPE_COUNT = 18;
     string[] private GOO_TYPE_VALUES = [
         "Aromatic Surfactant",
@@ -50,12 +50,12 @@ contract Zones721 is ERC721 {
         "Viscoelastic Synthetic Polymer"
     ];
 
-    string constant TILE_ROTATION_LABEL = "Tile rotation";
+    string constant TILE_ROTATION_LABEL = "Tile Rotation";
     uint256 constant TILE_ROTATION_COUNT = 16;
     string[] private TILE_ROTATION_VALUES =
         ["000", "060", "120", "180", "240", "300", "360", "420", "480", "540", "600", "660", "720", "780", "840", "900"];
 
-    string constant HISTORICAL_GOVERNANCE_LABEL = "Historical governance";
+    string constant HISTORICAL_GOVERNANCE_LABEL = "Historical Governance";
     uint256 constant HISTORICAL_GOVERNANCE_COUNT = 12;
     string[] private HISTORICAL_GOVERNANCE_VALUES = [
         "Archeofuturist Patchwork",

--- a/contracts/src/Zones721.sol
+++ b/contracts/src/Zones721.sol
@@ -27,7 +27,7 @@ contract Zones721 is ERC721 {
 
     string constant LOCATION_LABEL = "Location";
 
-    string constant GOO_TYPE_LABEL = "Goo Type";
+    string constant GOO_TYPE_LABEL = "GooType";
     uint256 constant GOO_TYPE_COUNT = 18;
     string[] private GOO_TYPE_VALUES = [
         "Aromatic Surfactant",
@@ -50,12 +50,12 @@ contract Zones721 is ERC721 {
         "Viscoelastic Synthetic Polymer"
     ];
 
-    string constant TILE_ROTATION_LABEL = "Tile Rotation";
+    string constant TILE_ROTATION_LABEL = "TileRotation";
     uint256 constant TILE_ROTATION_COUNT = 16;
     string[] private TILE_ROTATION_VALUES =
         ["000", "060", "120", "180", "240", "300", "360", "420", "480", "540", "600", "660", "720", "780", "840", "900"];
 
-    string constant HISTORICAL_GOVERNANCE_LABEL = "Historical Governance";
+    string constant HISTORICAL_GOVERNANCE_LABEL = "HistoricalGovernance";
     uint256 constant HISTORICAL_GOVERNANCE_COUNT = 12;
     string[] private HISTORICAL_GOVERNANCE_VALUES = [
         "Archeofuturist Patchwork",
@@ -182,39 +182,40 @@ contract Zones721 is ERC721 {
     }
 
     function getTraitLocation(uint256 tokenId) internal pure returns (bytes memory) {
-        return
-            abi.encodePacked("{'trait_type': '", LOCATION_LABEL, "', 'value': '", UniverseValue.generate(tokenId), "'}");
+        return abi.encodePacked(
+            "{\"trait_type\": \"", LOCATION_LABEL, "\", \"value\": \"", UniverseValue.generate(tokenId), "\"}"
+        );
     }
 
     function getTraitGooType() internal view returns (bytes memory) {
         return abi.encodePacked(
-            "{'trait_type': '",
+            "{\"trait_type\": \"",
             GOO_TYPE_LABEL,
-            "', 'value': '",
+            "\", \"value\": \"",
             GOO_TYPE_VALUES[getTraitIndex(currentTokenId, GOO_TYPE_LABEL, GOO_TYPE_COUNT)],
-            "'}"
+            "\"}"
         );
     }
 
     function getTraitTileRotation() internal view returns (bytes memory) {
         return abi.encodePacked(
-            "{'trait_type': '",
+            "{\"trait_type\": \"",
             TILE_ROTATION_LABEL,
-            "', 'value': '",
+            "\", \"value\": \"",
             TILE_ROTATION_VALUES[getTraitIndex(currentTokenId, TILE_ROTATION_LABEL, TILE_ROTATION_COUNT)],
-            "'}"
+            "\"}"
         );
     }
 
     function getTraitHistoricalGovernance() internal view returns (bytes memory) {
         return abi.encodePacked(
-            "{'trait_type': '",
+            "{\"trait_type\": \"",
             HISTORICAL_GOVERNANCE_LABEL,
-            "', 'value': '",
+            "\", \"value\": \"",
             HISTORICAL_GOVERNANCE_VALUES[getTraitIndex(
                 currentTokenId, HISTORICAL_GOVERNANCE_LABEL, HISTORICAL_GOVERNANCE_COUNT
             )],
-            "'}"
+            "\"}"
         );
     }
 

--- a/contracts/src/Zones721.sol
+++ b/contracts/src/Zones721.sol
@@ -5,6 +5,7 @@ import "cog/IState.sol";
 import {Schema, BiomeKind, Node} from "@ds/schema/Schema.sol";
 import "@ds/utils/Base64.sol";
 import "@ds/utils/LibString.sol";
+import "@ds/utils/UniverseValue.sol";
 
 import {ERC721} from "solmate/tokens/ERC721.sol";
 
@@ -23,6 +24,8 @@ contract Zones721 is ERC721 {
     uint256 public currentTokenId;
     address owner; // The ZoneRule owns this
     State state;
+
+    string constant LOCATION_LABEL = "Location";
 
     string constant GOO_TYPE_LABEL = "Goo type";
     uint256 constant GOO_TYPE_COUNT = 18;
@@ -167,26 +170,51 @@ contract Zones721 is ERC721 {
     function getDataAttributes(uint256 tokenId) internal view returns (bytes memory) {
         return abi.encodePacked(
             "[",
-            '{"trait_type": "',
-            GOO_TYPE_LABEL,
-            '", "value": "',
-            GOO_TYPE_VALUES[getTraitIndex(tokenId, GOO_TYPE_LABEL, GOO_TYPE_COUNT)],
-            '"}',
+            getTraitLocation(tokenId),
             ",",
-            '{"trait_type": "',
-            TILE_ROTATION_LABEL,
-            '", "value": "',
-            TILE_ROTATION_VALUES[getTraitIndex(tokenId, TILE_ROTATION_LABEL, TILE_ROTATION_COUNT)],
-            '"}',
+            getTraitGooType(),
             ",",
-            '{"trait_type": "',
-            HISTORICAL_GOVERNANCE_LABEL,
-            '", "value": "',
-            HISTORICAL_GOVERNANCE_VALUES[getTraitIndex(
-                tokenId, HISTORICAL_GOVERNANCE_LABEL, HISTORICAL_GOVERNANCE_COUNT
-            )],
-            '"}',
+            getTraitTileRotation(),
+            ",",
+            getTraitHistoricalGovernance(),
             "]"
+        );
+    }
+
+    function getTraitLocation(uint256 tokenId) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked("{'trait_type': '", LOCATION_LABEL, "', 'value': '", UniverseValue.generate(tokenId), "'}");
+    }
+
+    function getTraitGooType() internal view returns (bytes memory) {
+        return abi.encodePacked(
+            "{'trait_type': '",
+            GOO_TYPE_LABEL,
+            "', 'value': '",
+            GOO_TYPE_VALUES[getTraitIndex(currentTokenId, GOO_TYPE_LABEL, GOO_TYPE_COUNT)],
+            "'}"
+        );
+    }
+
+    function getTraitTileRotation() internal view returns (bytes memory) {
+        return abi.encodePacked(
+            "{'trait_type': '",
+            TILE_ROTATION_LABEL,
+            "', 'value': '",
+            TILE_ROTATION_VALUES[getTraitIndex(currentTokenId, TILE_ROTATION_LABEL, TILE_ROTATION_COUNT)],
+            "'}"
+        );
+    }
+
+    function getTraitHistoricalGovernance() internal view returns (bytes memory) {
+        return abi.encodePacked(
+            "{'trait_type': '",
+            HISTORICAL_GOVERNANCE_LABEL,
+            "', 'value': '",
+            HISTORICAL_GOVERNANCE_VALUES[getTraitIndex(
+                currentTokenId, HISTORICAL_GOVERNANCE_LABEL, HISTORICAL_GOVERNANCE_COUNT
+            )],
+            "'}"
         );
     }
 

--- a/contracts/src/Zones721.sol
+++ b/contracts/src/Zones721.sol
@@ -24,19 +24,50 @@ contract Zones721 is ERC721 {
     address owner; // The ZoneRule owns this
     State state;
 
-    string constant DRIVING_SIDE_LABEL = "DrivingSide";
-    uint256 constant DRIVING_SIDE_COUNT = 3;
-    string[] private DRIVING_SIDE_VALUES = ["left", "right", "whatever"];
+    string constant GOO_TYPE_LABEL = "Goo type";
+    uint256 constant GOO_TYPE_COUNT = 18;
+    string[] private GOO_TYPE_VALUES = [
+        "Aromatic Surfactant",
+        "Biogenic Mucilage",
+        "Biphasic Hydrogel",
+        "Confectioner\u2019s Pastillage",
+        "Cosmetic Emollient",
+        "Echophagic Swarm",
+        "Lyotropic Liquid Crystal",
+        "Non-Newtonian Pseudoplastic",
+        "Petroleum Hydrocarbon",
+        "Pharmaceutical Paste",
+        "Primum Ens Salum",
+        "Programmable Nanotech",
+        "Pyroclastic Slurry",
+        "[REDACTED]",
+        "Rheopectic Synovia",
+        "Thixotropic Ground Substance",
+        "Unknown Exobiological",
+        "Viscoelastic Synthetic Polymer"
+    ];
 
-    string constant CLIMATE_LABEL = "Climate";
-    uint256 constant CLIMATE_COUNT = 7;
-    string[] private CLIMATE_VALUES =
-        ["damn cold", "endless drizzle", "arid", "tropical", "humid", "sweaty", "hot as hades"];
+    string constant TILE_ROTATION_LABEL = "Tile rotation";
+    uint256 constant TILE_ROTATION_COUNT = 16;
+    string[] private TILE_ROTATION_VALUES =
+        ["000", "060", "120", "180", "240", "300", "360", "420", "480", "540", "600", "660", "720", "780", "840", "900"];
 
-    string constant GOVERNMENT_LABEL = "Government";
-    uint256 constant GOVERNMENT_COUNT = 7;
-    string[] private GOVERNMENT_VALUES =
-        ["empire", "cyberocracy", "bureaucracy", "theocracy", "hexalopoly", "hive mind", "demarchy"];
+    string constant HISTORICAL_GOVERNANCE_LABEL = "Historical governance";
+    uint256 constant HISTORICAL_GOVERNANCE_COUNT = 12;
+    string[] private HISTORICAL_GOVERNANCE_VALUES = [
+        "Archeofuturist Patchwork",
+        "Autonomous Technocracy",
+        "Ex-human Pangalactic Strip Mining",
+        "Fully Automated Gay Space Luxury Communism",
+        "Hyper-Commodified Capitalism",
+        "Interplanetary Technofascist",
+        "Omnipresent AI Goddess",
+        "Pirate Sea-Steading",
+        "Post-Scarcity Technoreclusion",
+        "Psychic Megafauna Hypnowar",
+        "Recursive Matrioshka Brain",
+        "Universal Consciousness Upload"
+    ];
 
     modifier onlyOwner() {
         if (msg.sender != owner) {
@@ -137,21 +168,23 @@ contract Zones721 is ERC721 {
         return abi.encodePacked(
             "[",
             '{"trait_type": "',
-            DRIVING_SIDE_LABEL,
+            GOO_TYPE_LABEL,
             '", "value": "',
-            DRIVING_SIDE_VALUES[getTraitIndex(tokenId, DRIVING_SIDE_LABEL, DRIVING_SIDE_COUNT)],
+            GOO_TYPE_VALUES[getTraitIndex(tokenId, GOO_TYPE_LABEL, GOO_TYPE_COUNT)],
             '"}',
             ",",
             '{"trait_type": "',
-            CLIMATE_LABEL,
+            TILE_ROTATION_LABEL,
             '", "value": "',
-            CLIMATE_VALUES[getTraitIndex(tokenId, CLIMATE_LABEL, CLIMATE_COUNT)],
+            TILE_ROTATION_VALUES[getTraitIndex(tokenId, TILE_ROTATION_LABEL, TILE_ROTATION_COUNT)],
             '"}',
             ",",
             '{"trait_type": "',
-            GOVERNMENT_LABEL,
+            HISTORICAL_GOVERNANCE_LABEL,
             '", "value": "',
-            GOVERNMENT_VALUES[getTraitIndex(tokenId, GOVERNMENT_LABEL, GOVERNMENT_COUNT)],
+            HISTORICAL_GOVERNANCE_VALUES[getTraitIndex(
+                tokenId, HISTORICAL_GOVERNANCE_LABEL, HISTORICAL_GOVERNANCE_COUNT
+            )],
             '"}',
             "]"
         );

--- a/contracts/src/utils/UniverseValue.sol
+++ b/contracts/src/utils/UniverseValue.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library UniverseValue {
+    uint256 constant UNIVERSE_MAX = 8192;
+    uint256 constant MAJOR_MAX = 100; // 00-99
+    uint256 constant MINOR_MAX = 1000; // 000-999
+    uint256 constant PATCH_MAX = 10000; // 0000-9999
+
+    // Function to generate a zone based on a tokenId
+    function generate(uint256 tokenId) internal pure returns (string memory) {
+        uint256 universe = (uint256(keccak256(abi.encode(tokenId, "UNIVERSE"))) % UNIVERSE_MAX) + 1;
+        uint256 major = uint256(keccak256(abi.encode(tokenId, "MAJOR"))) % MAJOR_MAX;
+        uint256 minor = uint256(keccak256(abi.encode(tokenId, "MINOR"))) % MINOR_MAX;
+        uint256 patch = uint256(keccak256(abi.encode(tokenId, "PATCH"))) % PATCH_MAX;
+
+        return string(
+            abi.encodePacked(
+                formatNumber(universe, 4),
+                "-",
+                formatNumber(major, 2),
+                ".",
+                formatNumber(minor, 3),
+                ".",
+                formatNumber(patch, 4)
+            )
+        );
+    }
+
+    // Utility function to format numbers with leading zeros
+    function formatNumber(uint256 number, uint256 length) internal pure returns (string memory) {
+        bytes memory buffer = new bytes(length);
+        for (uint256 i = length; i > 0; i--) {
+            buffer[i - 1] = bytes1(uint8(48 + number % 10));
+            number /= 10;
+        }
+        return string(buffer);
+    }
+}


### PR DESCRIPTION
## What
New zone traits as suggested by Luke.

- Location
- Goo types
- Tile rotation
- Historical governance

Example metadata json:
```json
{
  "name": "Zone 2",
  "description": "Downstream Zone #2",
  "image": "https://assets.downstream.game/zone/2.png",
  "attributes": [
    {
      "trait_type": "Location",
      "value": "3484-74.115.7490"
    },
    {
      "trait_type": "GooType",
      "value": "Aromatic Surfactant"
    },
    {
      "trait_type": "TileRotation",
      "value": "300"
    },
    {
      "trait_type": "HistoricalGovernance",
      "value": "Archeofuturist Patchwork"
    }
  ]
}

```

## Notes
~~This is currently missing the "Location" trait (0000-00.000.0000). It's failing and giving me unrelated errors, so I'm PR'ing without it for now until I can get that solved so that this makes it into the next deploy.~~

Resolves #1324 