### PR TITLE
MetaMask switch network banner

### DIFF
--- a/frontend/src/components/panels/network-panel.tsx
+++ b/frontend/src/components/panels/network-panel.tsx
@@ -1,0 +1,48 @@
+import { useConfig } from '@app/hooks/use-config';
+import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { EthereumProvider, WalletProvider } from '@downstream/core';
+import { ethers } from 'ethers';
+import styled from 'styled-components';
+import { StyledBasePanel, StyledHeaderPanel } from '@app/styles/base-panel.styles';
+import { TextButton } from '@app/styles/button.styles';
+
+const Banner = styled(StyledHeaderPanel)`
+    position: fixed;
+    top: 0;
+    width: 100%;
+    background-color: #f9f9f9;
+    z-index: 9999;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px 0;
+    border-top: 0px;
+    border-left: 0px;
+    border-right: 0px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+`;
+
+const Text = styled.p`
+    margin: 0;
+    padding-right: 20px;
+`;
+
+export const NetworkPanel = () => {
+    const config = useConfig();
+    if (!config) return;
+    console.log('config file:', config.networkName);
+
+    return (
+        <Banner>
+            <Text>You need to switch to the XYZ network</Text>
+            <TextButton
+                onClick={() => {
+                    /* metamask switch network to correct one */
+                }}
+            >
+                Switch Network
+            </TextButton>
+        </Banner>
+    );
+};

--- a/frontend/src/components/panels/network-panel.tsx
+++ b/frontend/src/components/panels/network-panel.tsx
@@ -1,13 +1,13 @@
 import { useConfig } from '@app/hooks/use-config';
-import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { EthereumProvider, WalletProvider } from '@downstream/core';
-import { ethers } from 'ethers';
+import detectEthereumProvider from '@metamask/detect-provider';
 import styled from 'styled-components';
-import { StyledBasePanel, StyledHeaderPanel } from '@app/styles/base-panel.styles';
+import { StyledHeaderPanel } from '@app/styles/base-panel.styles';
 import { TextButton } from '@app/styles/button.styles';
 
 const Banner = styled(StyledHeaderPanel)`
-    position: fixed;
+    position: relative;
     top: 0;
     width: 100%;
     background-color: #f9f9f9;
@@ -28,21 +28,132 @@ const Text = styled.p`
     padding-right: 20px;
 `;
 
+export interface WalletContextValue {
+    provider?: WalletProvider;
+}
+
+export const WalletProviderContext = createContext<WalletContextValue>({});
+export const useWalletProvider = () => useContext(WalletProviderContext);
+
 export const NetworkPanel = () => {
     const config = useConfig();
-    if (!config) return;
-    console.log('config file:', config.networkName);
+    const [connecting, setConnecting] = useState<boolean>(false);
+    const [shouldRender, setShouldRender] = useState<boolean>(true);
+
+    const checkNetwork = useCallback(async () => {
+        const metamask = (await detectEthereumProvider()) as EthereumProvider;
+        if (!metamask || !config) {
+            console.warn('Browser provider not available or no config found');
+            setShouldRender(false);
+            return;
+        }
+
+        const gotChainId = (metamask as any).networkVersion || 'unknown';
+        if (gotChainId === config.networkID) {
+            console.log('Already on the correct network');
+            setShouldRender(false);
+            return;
+        }
+        setShouldRender(true);
+
+        // Listen for network changes
+        window.ethereum.on('chainChanged', async () => {
+            console.log('chainChanged event triggered');
+            try {
+                await checkNetwork();
+            } catch (error) {
+                console.error(error);
+            }
+        });
+    }, [config, connecting]);
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                await checkNetwork();
+            } catch (error) {
+                console.error('Error checking network:', error);
+            }
+        })();
+    }, [checkNetwork]);
+
+    const switchMetamaskNetwork = useCallback(
+        async (provider: EthereumProvider) => {
+            if (!config) {
+                console.warn('no config found');
+                return;
+            }
+            const gotChainId = (provider as any).networkVersion || 'unknown';
+            if (gotChainId === config.networkID) {
+                console.log('already on the correct network');
+                return;
+            }
+            const chainId = `0x${BigInt(config.networkID).toString(16)}`;
+            try {
+                await provider.request({
+                    method: 'wallet_switchEthereumChain',
+                    params: [{ chainId }],
+                });
+            } catch (switchErr: any) {
+                // This error code indicates that the chain has not been added to MetaMask.
+                if (switchErr.code === 4902) {
+                    await provider.request({
+                        method: 'wallet_addEthereumChain',
+                        params: [
+                            {
+                                chainId,
+                                chainName: config.networkName,
+                                rpcUrls: [config.networkEndpoint],
+                                nativeCurrency: {
+                                    name: 'ETH',
+                                    symbol: 'ETH',
+                                    decimals: 18,
+                                },
+                            },
+                        ],
+                    });
+                } else {
+                    throw switchErr;
+                }
+            }
+        },
+        [config]
+    );
+
+    const switchNetwork = useCallback(async () => {
+        if (connecting) {
+            console.warn('already switching network');
+            return;
+        }
+        try {
+            console.log('clicked');
+            const metamask = (await detectEthereumProvider()) as EthereumProvider;
+            if (!metamask) {
+                console.warn('browser provider not available');
+                return;
+            }
+            try {
+                await switchMetamaskNetwork(metamask);
+            } catch (err) {
+                console.error(`failed to switch network:`, err);
+            }
+        } catch (err) {
+            console.error(`connect: ${err}`);
+        } finally {
+            setConnecting(false);
+        }
+    }, [connecting, switchMetamaskNetwork]);
+
+    if (!shouldRender) {
+        return null;
+    }
 
     return (
         <Banner>
-            <Text>You need to switch to the XYZ network</Text>
-            <TextButton
-                onClick={() => {
-                    /* metamask switch network to correct one */
-                }}
-            >
-                Switch Network
-            </TextButton>
+            <Text>
+                You need to switch to the <b>{config?.networkName}</b> network in MetaMask
+            </Text>
+            <TextButton onClick={switchNetwork}>Switch Network</TextButton>
         </Banner>
     );
 };

--- a/frontend/src/hooks/use-wallet-provider.tsx
+++ b/frontend/src/hooks/use-wallet-provider.tsx
@@ -28,51 +28,6 @@ export const WalletProviderProvider = ({ children, config }: { children: ReactNo
     const [walletConnectURI, setWalletConnectURI] = useState<string | null>(null);
     const [autoconnectProvider, setAutoconnectProvider] = useLocalStorage(`ds/autoconnectprovider`, '');
     const [burnerPhrase, setBurnerPhrase] = useLocalStorage(`ds/burnerphrase`, '');
-    const [failedToSwitchNetwork, setFailedToSwitchNetwork] = useState(false);
-
-    const switchMetamaskNetwork = useCallback(
-        async (provider: EthereumProvider) => {
-            if (!config) {
-                return;
-            }
-            if (failedToSwitchNetwork) {
-                return;
-            }
-            const gotChainId = (provider as any).networkVersion || 'unknown';
-            if (gotChainId === config.networkID) {
-                return;
-            }
-            const chainId = `0x${BigInt(config.networkID).toString(16)}`;
-            try {
-                await provider.request({
-                    method: 'wallet_switchEthereumChain',
-                    params: [{ chainId }],
-                });
-            } catch (switchErr: any) {
-                // This error code indicates that the chain has not been added to MetaMask.
-                if (switchErr.code === 4902) {
-                    await provider.request({
-                        method: 'wallet_addEthereumChain',
-                        params: [
-                            {
-                                chainId,
-                                chainName: config.networkName,
-                                rpcUrls: [config.networkEndpoint],
-                                nativeCurrency: {
-                                    name: 'ETH',
-                                    symbol: 'ETH',
-                                    decimals: 18,
-                                },
-                            },
-                        ],
-                    });
-                } else {
-                    throw switchErr;
-                }
-            }
-        },
-        [config, failedToSwitchNetwork]
-    );
 
     const connectMetamask = useCallback(async () => {
         try {

--- a/frontend/src/hooks/use-wallet-provider.tsx
+++ b/frontend/src/hooks/use-wallet-provider.tsx
@@ -81,12 +81,6 @@ export const WalletProviderProvider = ({ children, config }: { children: ReactNo
                 console.warn('browser provider not available');
                 return;
             }
-            try {
-                await switchMetamaskNetwork(metamask);
-            } catch (err) {
-                console.error(`failed to switch network: ${err}`);
-                setFailedToSwitchNetwork(true);
-            }
             setProvider({ method: 'metamask', provider: metamask });
             await metamask.request({ method: 'eth_requestAccounts' });
             setAutoconnectProvider('metamask'); // TODO: make this opt-in
@@ -96,7 +90,7 @@ export const WalletProviderProvider = ({ children, config }: { children: ReactNo
         } finally {
             setConnecting(false);
         }
-    }, [setAutoconnectProvider, switchMetamaskNetwork]);
+    }, [setAutoconnectProvider]);
 
     const connectWalletConnect = useCallback(async (): Promise<unknown> => {
         try {

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -2,6 +2,7 @@
 
 import Analytics from '@app/components/organisms/analytics';
 import { ConfigProvider } from '@app/hooks/use-config';
+import { NetworkPanel } from '@app/components/panels/network-panel';
 import { GlobalStyles } from '@app/styles/global.styles';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
@@ -37,6 +38,7 @@ export const App = ({ Component, pageProps }: AppProps) => {
             {enableAnalytics && <Analytics id="G-19E8TP90ZV" />}
             <GlobalStyles />
             <ConfigProvider>
+                <NetworkPanel />
                 <Component {...pageProps} />
             </ConfigProvider>
         </Fragment>


### PR DESCRIPTION
## What
- A banner that appears at the top of the page whenever you're on the wrong MetaMask network.

![image](https://github.com/playmint/ds/assets/27741109/dd30fa3f-762c-44ec-8215-e0f5b259cbdc)

- Stops it from trying to automatically switch network when connected to MetaMask (replaced for this banner)
  - This was causing problems when buying zones because the user wouldn't immediately know if they were on the correct network or not.

## Notes
There are currently a couple of problems I'm trying to resolve:
- the event listener: `window.ethereum.on('chainChanged', async () => {` is getting added repeatedly
- the `chainChanged` event is not always being called, most likely because it's not being set up at the right time


Resovles #1288 