### PR TITLE
Fix for Autoquest UI

### DIFF
--- a/frontend/src/components/panels/quest-panel.tsx
+++ b/frontend/src/components/panels/quest-panel.tsx
@@ -5,6 +5,8 @@ import {
     AssignedQuestFragment,
     ZoneWithBags,
     WorldTileFragment,
+    QUEST_STATUS_COMPLETED,
+    QUEST_STATUS_ACCEPTED,
 } from '@app/../../core/src';
 import { Locatable, getCoords } from '@app/helpers/tile';
 import { useGlobal } from '@app/hooks/use-game-state';
@@ -428,7 +430,14 @@ export const QuestPanel: FunctionComponent<QuestPanelProps> = ({
         <StyledQuestPanel className="no-scrollbars">
             {acceptedQuests.length === 0 &&
                 zone?.autoquests
-                    .filter((autoquests) => !acceptedQuests.some((quest) => quest.node.id === autoquests.id))
+                    .filter(
+                        (autoquests) =>
+                            !player?.zone?.quests.some(
+                                (quest) =>
+                                    quest.node.id === autoquests.id &&
+                                    (quest.status === QUEST_STATUS_COMPLETED || quest.status === QUEST_STATUS_ACCEPTED)
+                            )
+                    )
                     .map((autoquest) => (
                         <AutoQuestItem
                             key={autoquest.id}


### PR DESCRIPTION
This PR fixes a bug with autoquests where if you completed an autoquest, but didn't immediately accept another quest, the option to accept the first autoquest would appear again n a non-functioning state.
This has now been fixed so that option does not appear after any quests have been completed for the current zone.