### PR TITLE
MetaMask switch network banner (FIXES)

### DIFF
--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -34,8 +34,9 @@ const AccountButton = styled.button`
 `;
 
 const NavContainer = styled.div`
-    position: relative;
-    z-index: 10;
+    position: relative !important;
+    align-self: flex-start;
+    z-index: 99999;
     display: flex;
     justify-content: flex-start;
     height: 5rem;

--- a/frontend/src/components/panels/wallet-items-panel.tsx
+++ b/frontend/src/components/panels/wallet-items-panel.tsx
@@ -235,7 +235,7 @@ export const WalletItemsItem: FunctionComponent<{
             <div className="buttonContainer">
                 {provider && provider.method === 'metamask' && (
                     <WalletItemsActionButton onClick={addTokensMetamask} className="completeWalletItemsButton">
-                        Add Tokens To Metamask
+                        Add Tokens To MetaMask
                     </WalletItemsActionButton>
                 )}
             </div>

--- a/frontend/src/hooks/use-wallet-provider.tsx
+++ b/frontend/src/hooks/use-wallet-provider.tsx
@@ -183,7 +183,7 @@ export const WalletProviderProvider = ({ children, config }: { children: ReactNo
                         <h3>CONNECT USING...</h3>
                         {config?.wallets?.metamask !== false && (
                             <div>
-                                <ActionButton onClick={connectMetamask}>Metamask</ActionButton>
+                                <ActionButton onClick={connectMetamask}>MetaMask</ActionButton>
                             </div>
                         )}
                         {config?.wallets?.walletconnect !== false && (

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -2,7 +2,6 @@
 
 import Analytics from '@app/components/organisms/analytics';
 import { ConfigProvider } from '@app/hooks/use-config';
-import { NetworkPanel } from '@app/components/panels/network-panel';
 import { GlobalStyles } from '@app/styles/global.styles';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
@@ -38,7 +37,6 @@ export const App = ({ Component, pageProps }: AppProps) => {
             {enableAnalytics && <Analytics id="G-19E8TP90ZV" />}
             <GlobalStyles />
             <ConfigProvider>
-                <NetworkPanel />
                 <Component {...pageProps} />
             </ConfigProvider>
         </Fragment>

--- a/frontend/src/pages/building-fabricator.tsx
+++ b/frontend/src/pages/building-fabricator.tsx
@@ -4,6 +4,7 @@ import { FactoryBuilding } from '@app/components/map/FactoryBuilding';
 import { GroundPlane } from '@app/components/map/GroundPlane';
 import { Tile } from '@app/components/map/Tile';
 import { NavPanel } from '@app/components/panels/nav-panel';
+import { NetworkPanel } from '@app/components/panels/network-panel';
 import { getItemStructure } from '@app/helpers';
 import { useConfig } from '@app/hooks/use-config';
 import { GameStateProvider, useGlobal, usePlayer } from '@app/hooks/use-game-state';
@@ -1686,6 +1687,7 @@ export default function ShellPage() {
     return (
         <UnityMapProvider showLoading={false} display="none">
             <WalletProviderProvider config={config}>
+                <NetworkPanel />
                 <GameStateProvider config={config}>
                     <SessionProvider>
                         <InventoryProvider>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -20,6 +20,7 @@ import DownstreamLogo from '@app/assets/downstream-logo-dark.svg';
 import Image from 'next/image';
 import styled from 'styled-components';
 import { NavPanel } from '@app/components/panels/nav-panel';
+import { NetworkPanel } from '@app/components/panels/network-panel';
 import { Button, Key, Label, ListBox, ListBoxItem, Popover, Select, SelectValue } from 'react-aria-components';
 
 const StyledIndex = styled.div`
@@ -550,6 +551,7 @@ const Index = ({ config }: { config: Partial<GameConfig> | undefined }) => {
 
     return (
         <StyledIndex>
+            <NetworkPanel />
             <NavPanel className="navPanel" />
             <div className="page">
                 <Image src={DownstreamLogo} alt="Downstream Logo" className="logo" />

--- a/frontend/src/pages/zones/[id].tsx
+++ b/frontend/src/pages/zones/[id].tsx
@@ -1,4 +1,5 @@
 /** @format */
+import { NetworkPanel } from '@app/components/panels/network-panel';
 import Shell from '@app/components/views/shell';
 import { useConfig } from '@app/hooks/use-config';
 import { GameStateProvider } from '@app/hooks/use-game-state';
@@ -25,6 +26,7 @@ export default function ZonePage({ id }: ZonePageProps) {
     return (
         <UnityMapProvider>
             <WalletProviderProvider config={config}>
+                <NetworkPanel />
                 <GameStateProvider config={config} zoneId={zoneId}>
                     <SessionProvider>
                         <InventoryProvider>


### PR DESCRIPTION
## What
I noticed some problems with my [previous PR](https://github.com/playmint/ds/pull/1355) that added banner to switch networks on MetaMask.
This PR fixed:
- fixed banner not showing when connecting to MetaMask for the first time
- passes provider method (eg "metamask", "burner") from `useWalletProvider`
- fixed capitalization of "MetaMask"
- banner was covering the account button on the Zones page, the account button is now pushed below the banner so it can always be seen

Addresses #1288 