### PR TITLE
Zone sorting

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -667,16 +667,23 @@ const Index = ({ config }: { config: Partial<GameConfig> | undefined }) => {
                             ? [currentZone]
                             : zones
                         )
-                            .sort(
-                                (a, b) =>
-                                    units
-                                        .filter((u) => u.location?.tile?.coords && u.location.tile?.coords[0] === b.key)
-                                        .filter((u) => u.location && u.location.time + unitTimeoutBlocks > (block || 0))
-                                        .length -
-                                    units
-                                        .filter((u) => u.location?.tile?.coords && u.location.tile?.coords[0] === a.key)
-                                        .filter((u) => u.location && u.location.time + unitTimeoutBlocks > (block || 0))
-                                        .length
+                            .sort((a, b) =>
+                                selectedSorting === ZoneSorting.Newest
+                                    ? b.key - a.key
+                                    : units
+                                          .filter(
+                                              (u) => u.location?.tile?.coords && u.location.tile?.coords[0] === b.key
+                                          )
+                                          .filter(
+                                              (u) => u.location && u.location.time + unitTimeoutBlocks > (block || 0)
+                                          ).length -
+                                      units
+                                          .filter(
+                                              (u) => u.location?.tile?.coords && u.location.tile?.coords[0] === a.key
+                                          )
+                                          .filter(
+                                              (u) => u.location && u.location.time + unitTimeoutBlocks > (block || 0)
+                                          ).length
                             )
                             .map((z) => (
                                 <ZoneItem

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -587,8 +587,6 @@ const Index = ({ config }: { config: Partial<GameConfig> | undefined }) => {
                     <span>Zones</span>
                 </h2>
                 <StyledPanel className="zonePanel">
-                        &emsp;
-                        <ZoneSortSelect onSelectionChange={handleSortSelectionChange} selectedKey={selectedSorting} />
                     <div className="ZoneListHeader">
                         <div className="zoneImage"></div>
                         <div className="zoneProperties">
@@ -648,6 +646,8 @@ const Index = ({ config }: { config: Partial<GameConfig> | undefined }) => {
                             onSelectionChange={handleSelectionChange}
                             selectedKey={selectedFilter}
                         />
+                        &emsp;
+                        <ZoneSortSelect onSelectionChange={handleSortSelectionChange} selectedKey={selectedSorting} />
                         {player && playerZones.length == 0 && (
                             <ZoneMinter
                                 gameAddress={gameAddress}
@@ -657,7 +657,6 @@ const Index = ({ config }: { config: Partial<GameConfig> | undefined }) => {
                             />
                         )}
                     </div>
-
                     <ul>
                         {(selectedFilter == ZoneFilter.AllZones
                             ? zones


### PR DESCRIPTION
This PR adds the ability to sort the zones on the homepage by Newest or by Active Units.

While sorting by newest shows the most recently created zone first, I realised while setting this up that we may also want a 'Recently Updated' sorting option. However, that would require a fair bit more work so we can leave that to the back burner for now.