### PR TITLE
MetaMask switch network banner (MORE FIXES)

### DIFF
--- a/frontend/src/components/panels/network-panel.tsx
+++ b/frontend/src/components/panels/network-panel.tsx
@@ -8,25 +8,36 @@ import { TextButton } from '@app/styles/button.styles';
 import { useWalletProvider } from '@app/hooks/use-wallet-provider';
 
 const Banner = styled(StyledHeaderPanel)`
-    position: relative;
-    top: 0;
+    position: fixed;
+    bottom: 0;
     width: 100%;
-    background-color: #f9f9f9;
+    background-color: rgba(249, 249, 249, 0.8);
+    backdrop-filter: blur(10px);
     z-index: 9999;
     display: flex;
     justify-content: center;
     align-items: center;
     padding: 20px 0;
-    border-top: 0px;
+    border-top: 3px solid black;
     border-left: 0px;
     border-right: 0px;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+    border-bottom: 0px;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
 `;
 
 const Text = styled.p`
     margin: 0;
     padding-right: 20px;
+`;
+
+const CloseButton = styled.button`
+    position: absolute;
+    right: 20px;
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
 `;
 
 export interface WalletContextValue {
@@ -38,6 +49,10 @@ export const NetworkPanel = () => {
     const [connecting, setConnecting] = useState<boolean>(false);
     const [shouldRender, setShouldRender] = useState<boolean>(true);
     const { provider } = useWalletProvider();
+
+    const closeBanner = () => {
+        setShouldRender(false);
+    };
 
     const checkNetwork = useCallback(async () => {
         if (provider?.method.toLowerCase() !== 'metamask') {
@@ -169,6 +184,7 @@ export const NetworkPanel = () => {
                 You need to switch to the <b>{config?.networkName}</b> network in MetaMask
             </Text>
             <TextButton onClick={switchNetwork}>Switch Network</TextButton>
+            <CloseButton onClick={closeBanner}>x</CloseButton>
         </Banner>
     );
 };


### PR DESCRIPTION
## What

1. Changed banner from `relative` to `fixed`.
2. Moved the banner to the bottom of the screen.
3. Added a close/hide button to the banner.
4. Added slight blur effect.

![Screenshot 2024-05-02 112316](https://github.com/playmint/ds/assets/27741109/813cf051-5e7f-4f59-8c5d-23228eea51f5)
![Screenshot 2024-05-02 112343](https://github.com/playmint/ds/assets/27741109/be8bdbe7-f146-41d9-9f57-f42e940194d6)


## Why

1. `relative` caused the rest of the UI to be pushed down in most cases.
2. Jimmy suggested moving it to the bottom of the screen. Now that it's using `fixed`, it overlays the rest of the UI. This is a problem when the banner is at the top of the screen because it overlays the Account Settings button. As it's at the bottom of the screen, it doesn't block the more important things like that, and zone info etc.
3. Since it can still block some buttons, I think it makes sense to provide an option to hide the banner without being forced to switch networks.