### PR TITLE
Zone traits fix

### DIFF
--- a/contracts/src/Zones721.sol
+++ b/contracts/src/Zones721.sol
@@ -21,7 +21,7 @@ contract Zones721 is ERC721 {
     uint256 public mintPrice = 1 ether;
     string public baseURI = "https://assets.downstream.game";
 
-    uint256 public currentTokenId;
+    uint256 public lastTokenId;
     address owner; // The ZoneRule owns this
     State state;
 
@@ -79,7 +79,7 @@ contract Zones721 is ERC721 {
         _;
     }
 
-    constructor(address _owner) ERC721("DownstreamZone", "DSZ") {
+    constructor(address _owner) ERC721("Downstream Zone", "DSZ") {
         owner = _owner;
     }
 
@@ -87,11 +87,11 @@ contract Zones721 is ERC721 {
         if (msg.value != mintPrice) {
             revert MintPriceNotPaid();
         }
-        uint256 newTokenId = currentTokenId + 1;
+        uint256 newTokenId = lastTokenId + 1;
         if (newTokenId > TOTAL_SUPPLY) {
             revert MaxSupply();
         }
-        currentTokenId = newTokenId;
+        lastTokenId = newTokenId;
         _safeMint(recipient, newTokenId);
 
         // setup zone data
@@ -172,11 +172,11 @@ contract Zones721 is ERC721 {
             "[",
             getTraitLocation(tokenId),
             ",",
-            getTraitGooType(),
+            getTraitGooType(tokenId),
             ",",
-            getTraitTileRotation(),
+            getTraitTileRotation(tokenId),
             ",",
-            getTraitHistoricalGovernance(),
+            getTraitHistoricalGovernance(tokenId),
             "]"
         );
     }
@@ -187,33 +187,33 @@ contract Zones721 is ERC721 {
         );
     }
 
-    function getTraitGooType() internal view returns (bytes memory) {
+    function getTraitGooType(uint256 tokenId) internal view returns (bytes memory) {
         return abi.encodePacked(
             "{\"trait_type\": \"",
             GOO_TYPE_LABEL,
             "\", \"value\": \"",
-            GOO_TYPE_VALUES[getTraitIndex(currentTokenId, GOO_TYPE_LABEL, GOO_TYPE_COUNT)],
+            GOO_TYPE_VALUES[getTraitIndex(tokenId, GOO_TYPE_LABEL, GOO_TYPE_COUNT)],
             "\"}"
         );
     }
 
-    function getTraitTileRotation() internal view returns (bytes memory) {
+    function getTraitTileRotation(uint256 tokenId) internal view returns (bytes memory) {
         return abi.encodePacked(
             "{\"trait_type\": \"",
             TILE_ROTATION_LABEL,
             "\", \"value\": \"",
-            TILE_ROTATION_VALUES[getTraitIndex(currentTokenId, TILE_ROTATION_LABEL, TILE_ROTATION_COUNT)],
+            TILE_ROTATION_VALUES[getTraitIndex(tokenId, TILE_ROTATION_LABEL, TILE_ROTATION_COUNT)],
             "\"}"
         );
     }
 
-    function getTraitHistoricalGovernance() internal view returns (bytes memory) {
+    function getTraitHistoricalGovernance(uint256 tokenId) internal view returns (bytes memory) {
         return abi.encodePacked(
             "{\"trait_type\": \"",
             HISTORICAL_GOVERNANCE_LABEL,
             "\", \"value\": \"",
             HISTORICAL_GOVERNANCE_VALUES[getTraitIndex(
-                currentTokenId, HISTORICAL_GOVERNANCE_LABEL, HISTORICAL_GOVERNANCE_COUNT
+                tokenId, HISTORICAL_GOVERNANCE_LABEL, HISTORICAL_GOVERNANCE_COUNT
             )],
             "\"}"
         );

--- a/contracts/test/rules/Zones.t.sol
+++ b/contracts/test/rules/Zones.t.sol
@@ -26,7 +26,7 @@ contract ZoneTest is Test, GameTest {
         string memory dataURI1 = zoneOwnership.tokenURI(1);
         console2.log("Data for zone 1: ", dataURI1);
 
-        // Pick a random zone to output the data
+        // Output the data for zone 42
         string memory dataURI2 = zoneOwnership.tokenURI(42);
         console2.log("Data for zone 42: ", dataURI2);
     }

--- a/contracts/test/rules/Zones.t.sol
+++ b/contracts/test/rules/Zones.t.sol
@@ -16,12 +16,19 @@ contract ZoneTest is Test, GameTest {
     }
 
     function test_mint() public {
-        zoneOwnership.mintTo{value: 1 ether}(address(1));
+        for (uint256 i = 1; i <= 100; i++) {
+            zoneOwnership.mintTo{value: 1 ether}(address(1));
+        }
+
+        console2.log("100 zones have been minted.");
+
+        // Output the data for zone 1
         string memory dataURI1 = zoneOwnership.tokenURI(1);
-        console2.log(dataURI1);
-        zoneOwnership.mintTo{value: 1 ether}(address(1));
-        string memory dataURI2 = zoneOwnership.tokenURI(2);
-        console2.log(dataURI2);
+        console2.log("Data for zone 1: ", dataURI1);
+
+        // Pick a random zone to output the data
+        string memory dataURI2 = zoneOwnership.tokenURI(42);
+        console2.log("Data for zone 42: ", dataURI2);
     }
 
     function test_transferZoneOwnership() public {
@@ -49,10 +56,10 @@ contract ZoneTest is Test, GameTest {
     }
 
     function test_RevertMintMaxSupplyReached() public {
-        uint256 slot = stdstore.target(address(zoneOwnership)).sig("currentTokenId()").find();
+        uint256 slot = stdstore.target(address(zoneOwnership)).sig("lastTokenId()").find();
         bytes32 loc = bytes32(slot);
-        bytes32 mockedCurrentTokenId = bytes32(abi.encode(32000));
-        vm.store(address(zoneOwnership), loc, mockedCurrentTokenId);
+        bytes32 mockedLastTokenId = bytes32(abi.encode(32000));
+        vm.store(address(zoneOwnership), loc, mockedLastTokenId);
         vm.expectRevert(MaxSupply.selector);
         zoneOwnership.mintTo{value: 1 ether}(address(1));
     }


### PR DESCRIPTION
## What

- There was a bug in the previous Zones721.sol code which messed up most of the trait values. Whoops!
The relevant functions are now passed the `tokenId` as a parameters instead of using the latest minted zone's ID

- Zones.t.sol `test_mint` has been updated to mint 100 zones, and give you the output for zones 1 and 42. The expected output after running `forge test -vvv` in `ds/contracts` should look something like:
```
100 zones have been minted.
  Data for zone 1:  data:application/json;base64,eyJuYW1lIjogIlpvbmUgMSIsImRlc2NyaXB0aW9uIjogIkRvd25zdHJlYW0gWm9uZSAjMSIsImltYWdlIjogImh0dHBzOi8vYXNzZXRzLmRvd25zdHJlYW0uZ2FtZS96b25lLzEucG5nIiwiYXR0cmlidXRlcyI6IFt7InRyYWl0X3R5cGUiOiAiTG9jYXRpb24iLCAidmFsdWUiOiAiMTU5NS02Mi44MzQuMDI2NCJ9LHsidHJhaXRfdHlwZSI6ICJHb29UeXBlIiwgInZhbHVlIjogIkVjaG9waGFnaWMgU3dhcm0ifSx7InRyYWl0X3R5cGUiOiAiVGlsZVJvdGF0aW9uIiwgInZhbHVlIjogIjc4MCJ9LHsidHJhaXRfdHlwZSI6ICJIaXN0b3JpY2FsR292ZXJuYW5jZSIsICJ2YWx1ZSI6ICJQb3N0LVNjYXJjaXR5IFRlY2hub3JlY2x1c2lvbiJ9XX0=
  Data for zone 42:  data:application/json;base64,eyJuYW1lIjogIlpvbmUgNDIiLCJkZXNjcmlwdGlvbiI6ICJEb3duc3RyZWFtIFpvbmUgIzQyIiwiaW1hZ2UiOiAiaHR0cHM6Ly9hc3NldHMuZG93bnN0cmVhbS5nYW1lL3pvbmUvNDIucG5nIiwiYXR0cmlidXRlcyI6IFt7InRyYWl0X3R5cGUiOiAiTG9jYXRpb24iLCAidmFsdWUiOiAiNDkxNy0zMC44MDEuMzQ4OCJ9LHsidHJhaXRfdHlwZSI6ICJHb29UeXBlIiwgInZhbHVlIjogIlBoYXJtYWNldXRpY2FsIFBhc3RlIn0seyJ0cmFpdF90eXBlIjogIlRpbGVSb3RhdGlvbiIsICJ2YWx1ZSI6ICI3MjAifSx7InRyYWl0X3R5cGUiOiAiSGlzdG9yaWNhbEdvdmVybmFuY2UiLCAidmFsdWUiOiAiRXgtaHVtYW4gUGFuZ2FsYWN0aWMgU3RyaXAgTWluaW5nIn1dfQ==
```
It is expected that you get the same output as this.

## Resolves
- #1369 