### PR TITLE
Added name and symbol to item 1155 contract

### DIFF
--- a/contracts/src/Items1155.sol
+++ b/contracts/src/Items1155.sol
@@ -14,6 +14,9 @@ contract Items1155 is ERC1155 {
     address owner; // The InventoryRule owns this
     State state;
 
+    string public name = "Downstream Items";
+    string public symbol = "DSI";
+
     constructor(address _owner, State _state) {
         owner = _owner;
         state = _state;


### PR DESCRIPTION
This PR adds a collection name and symbol to the Item ERC1155 contract so that it should show up in redstone marketplace.
I'm not able to test it on the market place yet, but it seems to be working in metamask:
<img width="321" alt="Screenshot 2024-05-03 at 15 03 11" src="https://github.com/playmint/ds/assets/93523135/68e9d002-78ba-4977-93d2-6db3b82928ae">
