### PR TITLE
Set correct default rotation and fixed roof outline bug

### DIFF
--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -120,7 +120,7 @@ const nodeToManifest = (node): z.infer<typeof Manifest> => {
         const spec = {
             name: buildingKindName,
             location,
-            facingDirection: node.facingDirection?.value || FacingDirectionTypes[0],
+            facingDirection: node.facingDirection?.value || FacingDirectionTypes[1],
         };
         const status = { owner, id };
         return { kind, spec, status };

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -208,7 +208,7 @@ export const FacingDirectionTypes = ['RIGHT', 'LEFT'] as const;
 export const BuildingSpec = z.object({
     name: Name,
     location: Coords,
-    facingDirection: z.enum(FacingDirectionTypes).default(FacingDirectionTypes[0]),
+    facingDirection: z.enum(FacingDirectionTypes).default(FacingDirectionTypes[1]),
 });
 
 export const Building = z.object({

--- a/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/Roof_07.prefab
+++ b/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/Roof_07.prefab
@@ -221,7 +221,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: 313422e6fc3b0214e826cb22f9796a81,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 313422e6fc3b0214e826cb22f9796a81, type: 3}

--- a/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/Roof_16.prefab
+++ b/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/Roof_16.prefab
@@ -221,7 +221,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: 87b0c30af9511454a8a0bb6fc51c9bd8,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 87b0c30af9511454a8a0bb6fc51c9bd8, type: 3}


### PR DESCRIPTION
The default rotation of placed buildings was the opposite to what it should have been, this PR resolves that so that by default buildings face towards the right as intended.
This PR also contains a fix for two building roof models which had their outline objects deactivated, causing a visual outline glitch that potentially threatened the very fabric of reality!