### PR TITLE
fix "active" filter incorrectly filtering everything out when everyone timesout

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -221,7 +221,7 @@ const ZoneIndex = ({ config }: { config: Partial<GameConfig> | undefined }) => {
                 const activeUnits = zoneUnits.filter(
                     (u) => u.location && u.location.time + unitTimeoutBlocks > blockNumber
                 );
-                const lastActiveUnit = activeUnits.reduce(
+                const lastActiveUnit = zoneUnits.reduce(
                     (lastActiveUnit, u) =>
                         u.location && u.location.time > lastActiveUnit ? u.location.time : lastActiveUnit,
                     0


### PR DESCRIPTION
should calc lastActive based on all units not the already filtered units