### PR TITLE
expose item data to client

### DIFF
--- a/contracts/src/maps/cocktail-hut/Cocktail.js
+++ b/contracts/src/maps/cocktail-hut/Cocktail.js
@@ -1,20 +1,64 @@
 import ds from 'downstream';
 
-let numSips = 0;
-
 export default async function update({ selected }) {
+    // find the player's unit
     const { mobileUnit } = selected || {};
 
+    // find the items the player's unit has equiped in inventory
+    const equipedItems = mobileUnit?.bags.flatMap(
+        (bag) => bag.slots.flatMap(
+            (slot) => ({
+                item: slot.item,
+                bag: bag.equipee.key,
+                slot: slot.key,
+            })
+        )) || [];
+
+    // find any cocktails within those items
+    const equipedCocktails = equipedItems.filter(item => item.item.name?.value === 'Cocktail')
+
+    // find all the item's on-chain data attached to one of the cocktail items
+    const cocktailData = equipedCocktails.map((item) => item.item.allData).find(() => true) || [];
+
+    // fetch the value associated with the key "sips"
+    const encodedSips = cocktailData.find(({name, value}) => name === 'sips')?.value;
+
+    // decode the value as a number
+    const numSips = typeof encodedSips === 'string' ? parseInt(encodedSips, 16) : 0;
+
+    // for each cocktail equiped in inventory, take a sip and contribute to the
+    // global count of all sips ever sipped
     const action = () => {
-        // ds.dispatch(
-        //     {
-        //         name: 'BUILDING_USE',
-        //         args: [selectedBuilding.id, selectedEngineer.id, []]
-        //     },
-        // );
-        numSips++;
-        ds.log('Sipped!');
+        if (!mobileUnit) {
+            console.log('no selected unit');
+            return;
+        }
+        if (!equipedCocktails || equipedCocktails.length == 0) {
+            console.log('no equiped cocktails');
+            return;
+        }
+
+        const actions = equipedCocktails.map(({item}) => {
+            return {
+                name: 'ITEM_USE',
+                args: [
+                    item.id,
+                    mobileUnit.id,
+                    ds.encodeCall("function sip()", []),
+                ]
+            };
+        });
+
+        ds.dispatch(...actions);
     };
+
+    // due to a bug in the ITEM_USE implementation it is only possible to call
+    // ITEM_USE on an item that is equip to either bag-0-slot-0 or bag-1-slot-1
+    const isEquipToCompatibleSlot = equipedCocktails.some(({bag, slot}) => bag === slot);
+
+    const html = isEquipToCompatibleSlot
+        ? `<p>Total Sips Ever: ${numSips}</p>`
+        : '<p>Move cocktail to bottom left inventory slot to drink</p>';
 
     return {
         version: 1,
@@ -26,9 +70,7 @@ export default async function update({ selected }) {
                     {
                         id: 'default',
                         type: 'inline',
-                        html: `
-                            <p>Cocktail sips: ${numSips}</p>
-                        `,
+                        html,
                         buttons: [
                             {
                                 text: 'Sip',
@@ -42,3 +84,4 @@ export default async function update({ selected }) {
         ],
     };
 }
+

--- a/contracts/src/maps/cocktail-hut/Cocktail.sol
+++ b/contracts/src/maps/cocktail-hut/Cocktail.sol
@@ -10,7 +10,6 @@ import {Actions} from "@ds/actions/Actions.sol";
 using Schema for State;
 
 contract Cocktail is ItemKind {
-
     string constant KEY_SIPS = "sips";
 
     // encode/decode signatures
@@ -20,13 +19,13 @@ contract Cocktail is ItemKind {
     function use(
         Game ds,
         bytes24 itemID, // item being used
-        bytes24 /*mobileUnitID*/, // unit useing the item
+        bytes24, /*mobileUnitID*/ // unit useing the item
         bytes calldata payload // a blob of data for you to decide what to do with
     ) external override {
         if ((bytes4)(payload) == this.sip.selector) {
             _sip(ds, itemID);
         } else {
-            revert('unknown use action');
+            revert("unknown use action");
         }
     }
 
@@ -54,27 +53,29 @@ contract Cocktail is ItemKind {
         );
     }
 
-    function onExtract(Game /*ds*/, bytes24, /*entity*/ bytes24 /*buildingInstanceID*/, bytes24 /*itemID*/, uint64 /*itemQty*/ )
-        external
-        override
-        pure
-    {
-        revert('cannot extract cocktails');
+    function onExtract(
+        Game, /*ds*/
+        bytes24, /*entity*/
+        bytes24, /*buildingInstanceID*/
+        bytes24, /*itemID*/
+        uint64 /*itemQty*/
+    ) external pure override {
+        revert("cannot extract cocktails");
     }
 
-    function onSpawn(Game /*ds*/, bytes24 /*zoneOwner*/, bytes24, /*zoneID*/ bytes24 /*itemID*/, uint64 /*itemQty*/ )
+    function onSpawn(Game, /*ds*/ bytes24, /*zoneOwner*/ bytes24, /*zoneID*/ bytes24, /*itemID*/ uint64 /*itemQty*/ )
         external
-        override
         pure
+        override
     {
-        revert('cannot spawn cocktails');
+        revert("cannot spawn cocktails");
     }
 
-    function onReward(Game /*ds*/, bytes24, /*winner*/ bytes24 /*sessionID*/, bytes24 /*itemID*/, uint64 /*itemQty*/ )
+    function onReward(Game, /*ds*/ bytes24, /*winner*/ bytes24, /*sessionID*/ bytes24, /*itemID*/ uint64 /*itemQty*/ )
         external
-        override
         pure
+        override
     {
-        revert('cocktail spilt during combat');
+        revert("cocktail spilt during combat");
     }
 }

--- a/contracts/src/maps/cocktail-hut/Cocktail.sol
+++ b/contracts/src/maps/cocktail-hut/Cocktail.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "cog/IGame.sol";
+import "cog/IState.sol";
+import {ItemKind} from "@ds/ext/ItemKind.sol";
+import {Schema, Kind, Node} from "@ds/schema/Schema.sol";
+import {Actions} from "@ds/actions/Actions.sol";
+
+using Schema for State;
+
+contract Cocktail is ItemKind {
+
+    string constant KEY_SIPS = "sips";
+
+    // encode/decode signatures
+    function sip() external {}
+
+    // executed when ITEM_USE is called
+    function use(
+        Game ds,
+        bytes24 itemID, // item being used
+        bytes24 /*mobileUnitID*/, // unit useing the item
+        bytes calldata payload // a blob of data for you to decide what to do with
+    ) external override {
+        if ((bytes4)(payload) == this.sip.selector) {
+            _sip(ds, itemID);
+        } else {
+            revert('unknown use action');
+        }
+    }
+
+    function _sip(Game ds, bytes24 itemID) private {
+        State state = ds.getState();
+        uint64 numSips = uint64(uint256(state.getData(itemID, KEY_SIPS)));
+        numSips++;
+        bytes32 encodedSips = bytes32(uint256(numSips));
+        ds.getDispatcher().dispatch(abi.encodeCall(Actions.SET_DATA_ON_ITEM, (itemID, KEY_SIPS, encodedSips)));
+    }
+
+    function onCraft(Game ds, bytes24, /*entity*/ bytes24 buildingInstanceID, bytes24 itemID, uint64 /*itemQty*/ )
+        external
+        override
+    {
+        // crafting building owner and cocktail owner must match
+        State state = ds.getState();
+        bytes24 buildingKind = state.getBuildingKind(buildingInstanceID);
+        bytes24 buildingKindOwner = state.getOwner(buildingKind);
+        bytes24 itemKind = itemID;
+        bytes24 itemKindOwner = state.getOwner(itemKind);
+        require(
+            itemKindOwner == buildingKindOwner,
+            "crafting this item is restricted to building kinds made by the item owner"
+        );
+    }
+
+    function onExtract(Game /*ds*/, bytes24, /*entity*/ bytes24 /*buildingInstanceID*/, bytes24 /*itemID*/, uint64 /*itemQty*/ )
+        external
+        override
+        pure
+    {
+        revert('cannot extract cocktails');
+    }
+
+    function onSpawn(Game /*ds*/, bytes24 /*zoneOwner*/, bytes24, /*zoneID*/ bytes24 /*itemID*/, uint64 /*itemQty*/ )
+        external
+        override
+        pure
+    {
+        revert('cannot spawn cocktails');
+    }
+
+    function onReward(Game /*ds*/, bytes24, /*winner*/ bytes24 /*sessionID*/, bytes24 /*itemID*/, uint64 /*itemQty*/ )
+        external
+        override
+        pure
+    {
+        revert('cocktail spilt during combat');
+    }
+}

--- a/contracts/src/maps/cocktail-hut/Cocktail.yaml
+++ b/contracts/src/maps/cocktail-hut/Cocktail.yaml
@@ -3,6 +3,8 @@ kind: Item
 spec:
   name: Cocktail
   icon: 02-40
+  contract:
+    file: ./Cocktail.sol
   plugin:
     file: ./Cocktail.js
   goo:

--- a/core/src/world.graphql
+++ b/core/src/world.graphql
@@ -8,6 +8,10 @@ fragment Item on Node {
         id
         value
     }
+    allData {
+        name
+        value
+    }
 }
 
 fragment ItemSlot on Edge {


### PR DESCRIPTION
## what

ItemKind contracts can `SET_DATA_ITEM` just like BuildingKind contracts can `SET_DATA_BUILDING` to let them store data on-chain and read back in the client.... however we were not previously exposing the item data to the plugins so it was useless.

this exposes the item data so that plugins can do interesting stuff with it.

it updates the cocktail hut so that so "sips" are no longer just a client-local thing and are now a globally shared on-chain counter of all sips ever by everyone.

somewhat hilariously though, there's a bug in the implementation of ITEM_USE that means you can only "use" items that are in either bag-0-slot-0 or bag-1-slot-1 😂  ... so that's a bit annoying and I had to make the cocktail plugin ask you to move the cocktail before using it

<img width="294" alt="Screenshot 2024-05-11 at 14 35 01" src="https://github.com/playmint/ds/assets/45921/bd7fc2a2-e172-4abb-b1ae-371010db9532">


issue raised for that #1400 but it would be a contract change so not possible to fix quickly