### PR TITLE
disable construct intent for buggy zones

### DIFF
--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -35,7 +35,7 @@ import { styles } from './shell.styles';
 // fails for zone ids above 40. As a temporary measure to limit confusion we
 // will disable the construct button on these zones while we consider options
 // see: https://github.com/playmint/ds/issues/1402
-const isBuggyZone = (id: number) => id >= 40;
+const isBuggyZone = (id: number) => id > 40;
 
 export interface ShellProps extends ComponentProps {}
 

--- a/frontend/src/components/views/shell/index.tsx
+++ b/frontend/src/components/views/shell/index.tsx
@@ -31,6 +31,12 @@ import styled from 'styled-components';
 import { pipe, subscribe } from 'wonka';
 import { styles } from './shell.styles';
 
+// there is a bug that means that the CONSTRUCT_BUILDING_MOBILE_UNIT action
+// fails for zone ids above 40. As a temporary measure to limit confusion we
+// will disable the construct button on these zones while we consider options
+// see: https://github.com/playmint/ds/issues/1402
+const isBuggyZone = (id: number) => id >= 40;
+
 export interface ShellProps extends ComponentProps {}
 
 const StyledShell = styled('div')`
@@ -63,6 +69,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
     const kinds = global?.buildingKinds || [];
     const unitTimeoutBlocks = parseInt(global?.gameSettings?.unitTimeoutBlocks?.value || '0x0', 16);
     const zoneUnitLimit = parseInt(global?.gameSettings?.zoneUnitLimit?.value || '0x0', 16);
+    const zoneId = parseInt(zone?.key || 0, 16);
 
     const ui = usePluginState();
     const [questsActive, setQuestsActive] = useState<boolean>(true);
@@ -413,7 +420,7 @@ export const Shell: FunctionComponent<ShellProps> = () => {
                         <div className="flex-spacer"></div>
                         <div className="bottom-middle">
                             <ActionContextPanel pluginTileProperties={pluginTileProperties} />
-                            <ActionBar />
+                            <ActionBar move={true} combat={true} construct={!isBuggyZone(zoneId)} />
                         </div>
                         <div className="flex-spacer"></div>
                     </div>

--- a/frontend/src/plugins/action-bar/index.tsx
+++ b/frontend/src/plugins/action-bar/index.tsx
@@ -11,13 +11,17 @@ const CONSTRUCT_INTENT = 'construct';
 const MOVE_INTENT = 'move';
 const COMBAT_INTENT = 'combat';
 
-export interface ActionBarProps extends ComponentProps {}
+export interface ActionBarProps extends ComponentProps {
+    construct: boolean;
+    move: boolean;
+    combat: boolean;
+}
 
 const StyledActionBar = styled('div')`
     ${styles}
 `;
 
-export const ActionBar: FunctionComponent<ActionBarProps> = ({}: ActionBarProps) => {
+export const ActionBar: FunctionComponent<ActionBarProps> = ({ construct, move, combat }: ActionBarProps) => {
     const { selectIntent, intent, mobileUnit, selectTiles, selectMapElement } = useSelection();
 
     const handleSelectIntent = useCallback(
@@ -44,24 +48,30 @@ export const ActionBar: FunctionComponent<ActionBarProps> = ({}: ActionBarProps)
     return (
         <StyledActionBar>
             <div className="actions">
-                <UnitActionButton
-                    className={`${intent === MOVE_INTENT ? 'toggleOn' : ''}`}
-                    onClick={() => handleSelectIntent(MOVE_INTENT)}
-                >
-                    Move
-                </UnitActionButton>
-                <UnitActionButton
-                    className={`${intent === CONSTRUCT_INTENT ? 'toggleOn' : ''}`}
-                    onClick={() => handleSelectIntent(CONSTRUCT_INTENT)}
-                >
-                    Build
-                </UnitActionButton>
-                <UnitActionButton
-                    className={`${intent === COMBAT_INTENT ? 'toggleOn' : ''}`}
-                    onClick={() => handleSelectIntent(COMBAT_INTENT)}
-                >
-                    Attack
-                </UnitActionButton>
+                {move && (
+                    <UnitActionButton
+                        className={`${intent === MOVE_INTENT ? 'toggleOn' : ''}`}
+                        onClick={() => handleSelectIntent(MOVE_INTENT)}
+                    >
+                        Move
+                    </UnitActionButton>
+                )}
+                {construct && (
+                    <UnitActionButton
+                        className={`${intent === CONSTRUCT_INTENT ? 'toggleOn' : ''}`}
+                        onClick={() => handleSelectIntent(CONSTRUCT_INTENT)}
+                    >
+                        Build
+                    </UnitActionButton>
+                )}
+                {combat && (
+                    <UnitActionButton
+                        className={`${intent === COMBAT_INTENT ? 'toggleOn' : ''}`}
+                        onClick={() => handleSelectIntent(COMBAT_INTENT)}
+                    >
+                        Attack
+                    </UnitActionButton>
+                )}
             </div>
         </StyledActionBar>
     );


### PR DESCRIPTION
there's [a contract bug](https://github.com/playmint/ds/issues/1402) preventing the CONSTRUCT_BUILDING_MOBILE_UNIT action for working as intended when the zone id is 40 or more.

as a temporary measure we are disabling the build intent for the affected zones so that it reduces the potential confusion of either the resulting "out of bounds" error or the silent failing due to these errors only being debug visisble.

