### PR TITLE
Scrolly wallet panel

### DIFF
--- a/frontend/src/components/panels/wallet-items-panel.tsx
+++ b/frontend/src/components/panels/wallet-items-panel.tsx
@@ -79,6 +79,8 @@ const WalletItemsItemStyles = () => css`
     .taskContainer {
         font-size: 1.4rem;
         padding: var(--panel-padding) var(--panel-padding) 0 var(--panel-padding);
+        overflow: scroll;
+        max-height: 22rem;
     }
 
     .buttonContainer {


### PR DESCRIPTION
quick fix to stop wallet inventory taking over the whole screen and making it unusable