### PR TITLE
ENS Names used in Zones page and Account panel

### DIFF
--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -1,4 +1,4 @@
-import { decodeString } from '@app/helpers';
+import { decodeString, lookupENSName } from '@app/helpers';
 import { usePlayer, useWallet } from '@app/hooks/use-game-state';
 import { useSession } from '@app/hooks/use-session';
 import { GlobalUnityContext } from '@app/hooks/use-unity-instance';
@@ -77,9 +77,16 @@ export const NavPanel = ({
     const [zoneName, setZoneName] = useState(decodeString(zone?.name?.value ?? '') || '');
     const [zoneDescription, setZoneDescription] = useState(zone?.description?.value || '');
     const [zoneUrl, setZoneUrl] = useState(zone?.url?.value || '');
+    const [ensName, setEnsName] = useState('');
 
     const hasConnection = player || wallet;
     const address = player?.addr || wallet?.address || '';
+
+    useEffect(() => {
+        if (address) {
+            lookupENSName(address).then(setEnsName).catch(console.error);
+        }
+    }, [address]);
 
     const isZoneOwner = address === zone?.owner?.addr;
 
@@ -190,9 +197,7 @@ export const NavPanel = ({
                 <Dialog onClose={closeAccountDialog} width="304px" height="">
                     <div style={{ padding: 0 }}>
                         <h3>SETTINGS</h3>
-                        <p>
-                            {address.slice(0, 9)}...{address.slice(-9)}
-                        </p>
+                        <p>{ensName || `${address.slice(0, 9)}...${address.slice(-9)}`}</p>
                         <br />
 
                         {isZoneOwner && (

--- a/frontend/src/components/panels/nav-panel.tsx
+++ b/frontend/src/components/panels/nav-panel.tsx
@@ -77,16 +77,25 @@ export const NavPanel = ({
     const [zoneName, setZoneName] = useState(decodeString(zone?.name?.value ?? '') || '');
     const [zoneDescription, setZoneDescription] = useState(zone?.description?.value || '');
     const [zoneUrl, setZoneUrl] = useState(zone?.url?.value || '');
-    const [ensName, setEnsName] = useState('');
+    const [ensNames, setEnsNames] = useState<{ [key: string]: string | null }>({});
 
     const hasConnection = player || wallet;
     const address = player?.addr || wallet?.address || '';
 
     useEffect(() => {
-        if (address) {
-            lookupENSName(address).then(setEnsName).catch(console.error);
+        if (showAccountDialog) {
+            if (address) {
+                lookupENSName(address)
+                    .then((n) =>
+                        setEnsNames((prevNames) => ({
+                            ...prevNames,
+                            [address]: n,
+                        }))
+                    )
+                    .catch(console.error);
+            }
         }
-    }, [address]);
+    }, [address, showAccountDialog]);
 
     const isZoneOwner = address === zone?.owner?.addr;
 
@@ -197,7 +206,7 @@ export const NavPanel = ({
                 <Dialog onClose={closeAccountDialog} width="304px" height="">
                     <div style={{ padding: 0 }}>
                         <h3>SETTINGS</h3>
-                        <p>{ensName || `${address.slice(0, 9)}...${address.slice(-9)}`}</p>
+                        <p>{ensNames[address] || `${address.slice(0, 9)}...${address.slice(-9)}`}</p>
                         <br />
 
                         {isZoneOwner && (

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -39,14 +39,34 @@ export const decodeString = (value: string): string => {
     }
 };
 
-export async function lookupENSName(address: string) {
+const ensCache: { [address: string]: string | null } = {};
+let ensActiveChecks = 0;
+
+export async function lookupENSName(address: string): Promise<string | null> {
+    // Check if the address is already in the ensCache
+    if (ensCache.hasOwnProperty(address)) {
+        return ensCache[address];
+    }
+
+    // Lookup max 5 addresses at a time
+    if (ensActiveChecks >= 5) {
+        return null;
+    }
+
     const ensProvider = ethers.getDefaultProvider('mainnet');
     try {
+        ensActiveChecks++;
+        ensCache[address] = null;
         const name = await ensProvider.lookupAddress(address);
-        return name || address;
+        // Cache the result, even if it's null
+        ensCache[address] = name;
+        return name;
     } catch (error) {
         console.error('ENS lookup failed', error);
-        return address;
+        ensCache[address] = null;
+        return null;
+    } finally {
+        ensActiveChecks--;
     }
 }
 

--- a/frontend/src/helpers/index.ts
+++ b/frontend/src/helpers/index.ts
@@ -39,6 +39,17 @@ export const decodeString = (value: string): string => {
     }
 };
 
+export async function lookupENSName(address: string) {
+    const ensProvider = ethers.getDefaultProvider('mainnet');
+    try {
+        const name = await ensProvider.lookupAddress(address);
+        return name || address;
+    } catch (error) {
+        console.error('ENS lookup failed', error);
+        return address;
+    }
+}
+
 export const getItemStructure = (itemId: string) => {
     return [...itemId]
         .slice(2)

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -211,7 +211,7 @@ const ZoneList = ({
             });
             observer.current?.disconnect();
         };
-    }, [ensNames, zones]);
+    }, [ensNames]);
 
     return (
         <div>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import { lookupENSName } from '@app/helpers';
 import {
     DownstreamLogo,
     EmbossedBottomPanel,
@@ -162,6 +163,20 @@ const ZoneList = ({
     unitZoneLimit: number;
     onClickEnter: (id: number) => void;
 }) => {
+    const [ensNames, setEnsNames] = useState({});
+
+    useEffect(() => {
+        zones.forEach(async (zone) => {
+            if (zone.owner?.addr) {
+                const ensName = await lookupENSName(zone.owner.addr);
+                setEnsNames((prevNames) => ({
+                    ...prevNames,
+                    [zone.owner?.addr]: ensName,
+                }));
+            }
+        });
+    }, [zones]);
+
     return (
         <div>
             {zones.map((zone) => (
@@ -174,7 +189,7 @@ const ZoneList = ({
                     maxUnits={zone.maxUnits}
                     imageURL={zone.url?.value ? zone.url.value : 'https://assets.downstream.game/tile.png'}
                     onClickEnter={onClickEnter}
-                    ownerAddress={zone.owner?.addr || '0x0'}
+                    ownerAddress={ensNames[zone.owner?.addr] || zone.owner?.addr || '0x0'}
                 />
             ))}
         </div>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -165,21 +165,21 @@ const ZoneList = ({
 }) => {
     const [ensNames, setEnsNames] = useState<{ [key: string]: string | null }>({});
 
-    const handleVisibilityChange = async (ownerAddress: string) => {
-        // console.log('a zone is on screen');
-        if (ownerAddress && !ensNames[ownerAddress]) {
-            const ensName = await lookupENSName(ownerAddress);
-            setEnsNames((prevNames) => ({
-                ...prevNames,
-                [ownerAddress]: ensName,
-            }));
-        }
-    };
-
     const zoneRefs = useRef<(HTMLDivElement | null)[]>([]);
     const observer = useRef<IntersectionObserver | null>(null);
 
     useEffect(() => {
+        const handleVisibilityChange = async (ownerAddress: string) => {
+            //console.log('a zone is on screen');
+            if (ownerAddress && !ensNames[ownerAddress]) {
+                const ensName = await lookupENSName(ownerAddress);
+                setEnsNames((prevNames) => ({
+                    ...prevNames,
+                    [ownerAddress]: ensName,
+                }));
+            }
+        };
+
         observer.current = new IntersectionObserver(
             (entries) => {
                 entries.forEach((entry) => {
@@ -196,21 +196,22 @@ const ZoneList = ({
             { threshold: 0.1 }
         );
 
-        zoneRefs.current.forEach((ref) => {
+        const currentRefs = zoneRefs.current;
+        currentRefs.forEach((ref) => {
             if (ref) {
                 observer.current?.observe(ref);
             }
         });
 
         return () => {
-            zoneRefs.current.forEach((ref) => {
+            currentRefs.forEach((ref) => {
                 if (ref) {
                     observer.current?.unobserve(ref);
                 }
             });
             observer.current?.disconnect();
         };
-    }, [zones]);
+    }, [ensNames, zones]);
 
     return (
         <div>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -23,7 +23,7 @@ import { GameStateProvider, useCogClient, useGlobal, usePlayer, useWallet } from
 import { SessionProvider } from '@app/hooks/use-session';
 import { WalletProviderProvider, useWalletProvider } from '@app/hooks/use-wallet-provider';
 import Image from 'next/image';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { useRouter } from 'next/router';
 import iconUnit from '@app/assets/icon-unit.svg';
 import { pipe, subscribe } from 'wonka';
@@ -163,34 +163,74 @@ const ZoneList = ({
     unitZoneLimit: number;
     onClickEnter: (id: number) => void;
 }) => {
-    const [ensNames, setEnsNames] = useState({});
+    const [ensNames, setEnsNames] = useState<{ [key: string]: string | null }>({});
+
+    const handleVisibilityChange = async (ownerAddress: string) => {
+        // console.log('a zone is on screen');
+        if (ownerAddress && !ensNames[ownerAddress]) {
+            const ensName = await lookupENSName(ownerAddress);
+            setEnsNames((prevNames) => ({
+                ...prevNames,
+                [ownerAddress]: ensName,
+            }));
+        }
+    };
+
+    const zoneRefs = useRef<(HTMLDivElement | null)[]>([]);
+    const observer = useRef<IntersectionObserver | null>(null);
 
     useEffect(() => {
-        zones.forEach(async (zone) => {
-            if (zone.owner?.addr) {
-                const ensName = await lookupENSName(zone.owner.addr);
-                setEnsNames((prevNames) => ({
-                    ...prevNames,
-                    [zone.owner?.addr]: ensName,
-                }));
+        observer.current = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        const ownerAddress = entry.target.getAttribute('data-owner-address');
+                        if (ownerAddress) {
+                            handleVisibilityChange(ownerAddress)
+                                .then(() => {})
+                                .catch((err) => console.error(err));
+                        }
+                    }
+                });
+            },
+            { threshold: 0.1 }
+        );
+
+        zoneRefs.current.forEach((ref) => {
+            if (ref) {
+                observer.current?.observe(ref);
             }
         });
+
+        return () => {
+            zoneRefs.current.forEach((ref) => {
+                if (ref) {
+                    observer.current?.unobserve(ref);
+                }
+            });
+            observer.current?.disconnect();
+        };
     }, [zones]);
 
     return (
         <div>
-            {zones.map((zone) => (
-                <ZoneRow
-                    key={zone.key}
-                    id={zone.id}
-                    name={zone.name}
-                    description={zone.description?.value || `Unknown zone #${zone.id}`}
-                    activeUnits={zone.activeUnits.length}
-                    maxUnits={zone.maxUnits}
-                    imageURL={zone.url?.value ? zone.url.value : 'https://assets.downstream.game/tile.png'}
-                    onClickEnter={onClickEnter}
-                    ownerAddress={ensNames[zone.owner?.addr] || zone.owner?.addr || '0x0'}
-                />
+            {zones.map((zone, index) => (
+                <div
+                    key={zone.id}
+                    ref={(el) => (zoneRefs.current[index] = el)}
+                    data-owner-address={zone.owner?.addr || '0x0'}
+                >
+                    <ZoneRow
+                        id={zone.id}
+                        name={zone.name}
+                        description={zone.description?.value || `Unknown zone #${zone.id}`}
+                        activeUnits={zone.activeUnits.length}
+                        maxUnits={zone.maxUnits}
+                        imageURL={zone.url?.value ? zone.url.value : 'https://assets.downstream.game/tile.png'}
+                        onClickEnter={onClickEnter}
+                        ownerAddress={ensNames[zone.owner?.addr] || zone.owner?.addr || '0x0'}
+                    />
+                </div>
             ))}
         </div>
     );


### PR DESCRIPTION
## What
Uses ENS name if it can be found instead of the wallet address:
### Zones Page
![image](https://github.com/playmint/ds/assets/27741109/c96cbe12-c745-4b4f-9597-f5cf941463dd)

### Account Panel
![image](https://github.com/playmint/ds/assets/27741109/2e23ad0f-359d-4655-916f-b952b5e0f14b)

## Notes
- I've tested to see that it's working on the account panel
- ~I don't know 100% if it's working on the zone page until it's in main because I can't mint a zone on my MetaMask account locally (I think?)~
  - However, I can get it to log my ENS on the zones page, so it is working.