### PR TITLE
Fix ducks and building rotation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,4 @@
 /contracts/node_modules/
 /contracts/lib/cog/services/
 !/contracts/lib/cog/services/schema/
+/map/ProjectSettings/ScriptableBuildPipeline.json

--- a/frontend/src/components/map/Buildings.tsx
+++ b/frontend/src/components/map/Buildings.tsx
@@ -75,7 +75,8 @@ export const Buildings = memo(
                     const coords = getCoords(b.location.tile);
                     const height = getTileHeightFromCoords(coords);
                     const selected = selectedElementID === b.id ? 'outline' : 'none';
-                    const rotation = b.facingDirection == FacingDirectionKind.RIGHT ? -30 : 30;
+                    console.log(b);
+                    const rotation = b.facingDirection && b.facingDirection == FacingDirectionKind.LEFT ? 30 : -30;
                     const tile = tiles.find(({ id }) => id === b.location?.tile.id);
                     const overrideModel = (pluginBuildingProperties || [])
                         .find((prop) => prop.id == b.id && prop.key == 'model')

--- a/frontend/src/components/map/Buildings.tsx
+++ b/frontend/src/components/map/Buildings.tsx
@@ -75,7 +75,6 @@ export const Buildings = memo(
                     const coords = getCoords(b.location.tile);
                     const height = getTileHeightFromCoords(coords);
                     const selected = selectedElementID === b.id ? 'outline' : 'none';
-                    console.log(b);
                     const rotation = b.facingDirection && b.facingDirection == FacingDirectionKind.LEFT ? 30 : -30;
                     const tile = tiles.find(({ id }) => id === b.location?.tile.id);
                     const overrideModel = (pluginBuildingProperties || [])

--- a/map/Assets/Addressables/DisplayBuilding/DisplayBuildingMapElement.prefab
+++ b/map/Assets/Addressables/DisplayBuilding/DisplayBuildingMapElement.prefab
@@ -449,7 +449,7 @@ PrefabInstance:
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.038
+      value: 0.0043643117
       objectReference: {fileID: 0}
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
@@ -459,27 +459,27 @@ PrefabInstance:
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 0.05016914
       objectReference: {fileID: 0}
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 0.70710576
       objectReference: {fileID: 0}
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 1
+      value: 0.70710784
       objectReference: {fileID: 0}
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
@@ -489,7 +489,7 @@ PrefabInstance:
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 2481613906286960452, guid: 249851de4fb29b548ae1f53ad9c8dcb7,
         type: 3}

--- a/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/Roof_04.prefab
+++ b/map/Assets/Addressables/FactoryBuilding/FactoryBuilding_2.0/Roof_04.prefab
@@ -135,22 +135,22 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
@@ -160,7 +160,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
@@ -241,22 +241,22 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
@@ -266,7 +266,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 39ef6f0947a150742b03acab7789bd28,
         type: 3}

--- a/map/ProjectSettings/ScriptableBuildPipeline.json
+++ b/map/ProjectSettings/ScriptableBuildPipeline.json
@@ -1,0 +1,13 @@
+{
+    "useBuildCacheServer": false,
+    "cacheServerHost": "",
+    "cacheServerPort": 8126,
+    "threadedArchiving": true,
+    "logCacheMiss": false,
+    "slimWriteResults": true,
+    "maximumCacheSize": 20,
+    "useDetailedBuildLog": false,
+    "useV2Hasher": true,
+    "fileIDHashSeed": 0,
+    "prefabPackedHeaderSize": 2
+}


### PR DESCRIPTION
This PR rotates the duck roofs on both the factory buildings and the duck counter buildings so that the face the same direction as the building itself.

It also adjusts how dynamically placed buildings are rotated so that they show off both of their detailed sides